### PR TITLE
chore!: drop Node 20/22 support, target Node 24 LTS only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,6 @@ jobs:
           - os: macos-latest
             node-version: 24
           - os: ubuntu-latest
-            node-version: 20
-          - os: ubuntu-latest
-            node-version: 22
-          - os: ubuntu-latest
             node-version: 24
           - os: windows-latest
             node-version: 24

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chrome"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "bin": {
     "tabctl": "dist/cli/tabctl.js"

--- a/src/cli/lib/client.ts
+++ b/src/cli/lib/client.ts
@@ -1,4 +1,4 @@
-import net from "net";
+import net from "node:net";
 import { resolveConfig } from "./constants";
 import type { ProgressCallback } from "./types";
 

--- a/src/cli/lib/commands/meta.ts
+++ b/src/cli/lib/commands/meta.ts
@@ -4,9 +4,9 @@
  * Setup command is in ./setup.ts.
  */
 
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { VERSION, BASE_VERSION, GIT_SHA, DIRTY, SKILL_NAME, SKILL_REPO } from "../constants";

--- a/src/cli/lib/commands/params.ts
+++ b/src/cli/lib/commands/params.ts
@@ -3,7 +3,7 @@
  * These functions extract and validate command parameters from CLI options.
  */
 
-import fs from "fs";
+import fs from "node:fs";
 import { errorOut } from "../output";
 import { normalizeGroupColor } from "../args";
 import type { Options } from "../types";

--- a/src/cli/lib/commands/setup.ts
+++ b/src/cli/lib/commands/setup.ts
@@ -3,9 +3,9 @@
  * Extracted from meta.ts for modularity.
  */
 
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { HOST_NAME, HOST_DESCRIPTION, EXTENSION_ID_PATTERN, resolveConfig } from "../constants";
 import { printJson, errorOut } from "../output";

--- a/src/cli/lib/policy.ts
+++ b/src/cli/lib/policy.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 
 import { resolveConfig } from "../../shared/config";
 

--- a/src/cli/lib/response.ts
+++ b/src/cli/lib/response.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { renderCsv, renderMarkdown } from "./report";
 import { evaluateTab, type Policy } from "./policy";
 import { printJson, errorOut } from "./output";

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import fs from "fs";
-import net from "net";
-import crypto from "crypto";
+import fs from "node:fs";
+import net from "node:net";
+import crypto from "node:crypto";
 import { resolveConfig } from "../shared/config";
 import {
   handleNativeMessage as _handleNativeMessage,

--- a/src/host/lib/handlers.ts
+++ b/src/host/lib/handlers.ts
@@ -1,4 +1,4 @@
-import net from "net";
+import net from "node:net";
 import { VERSION, BASE_VERSION, GIT_SHA, DIRTY } from "../../shared/version";
 import {
   appendUndoRecord,

--- a/src/host/lib/undo.ts
+++ b/src/host/lib/undo.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 const DEFAULT_RETENTION_DAYS = 30;
 

--- a/src/scripts/integration-test.ts
+++ b/src/scripts/integration-test.ts
@@ -8,10 +8,10 @@
  * Env:    CHROME_PATH – override Chrome binary location
  */
 
-import fs from "fs";
-import net from "net";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { execSync, spawnSync, type ChildProcess } from "node:child_process";
 import { resolveSocketPath } from "../shared/config";
 

--- a/src/scripts/lib/integration-cdp.ts
+++ b/src/scripts/lib/integration-cdp.ts
@@ -3,9 +3,9 @@
  * DevTools Protocol messaging over stdio pipes.
  */
 
-import fs from "fs";
-import net from "net";
-import path from "path";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { Writable, Readable } from "node:stream";
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,7 +1,7 @@
-import os from "os";
-import path from "path";
-import crypto from "crypto";
-import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import fs from "node:fs";
 
 function defaultConfigBase(): string {
   if (process.platform === "win32") {

--- a/src/shared/extension-sync.ts
+++ b/src/shared/extension-sync.ts
@@ -1,6 +1,6 @@
-import path from "path";
-import fs from "fs";
-import crypto from "crypto";
+import path from "node:path";
+import fs from "node:fs";
+import crypto from "node:crypto";
 import { resolveConfig } from "./config";
 
 export const EXTENSION_DIR_NAME = "extension";

--- a/src/shared/profiles.ts
+++ b/src/shared/profiles.ts
@@ -1,5 +1,5 @@
-import path from "path";
-import fs from "fs";
+import path from "node:path";
+import fs from "node:fs";
 import { resolveConfig } from "./config";
 
 export type ProfileEntry = {

--- a/src/tests/unit/cli-helpers.ts
+++ b/src/tests/unit/cli-helpers.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 

--- a/src/tests/unit/cli.close-analyze.test.ts
+++ b/src/tests/unit/cli.close-analyze.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { startMockSocket, stopMockSocket } from "./socket";
 import { runCli, parseOutput, mockResponse } from "./cli-helpers";

--- a/src/tests/unit/cli.groups.test.ts
+++ b/src/tests/unit/cli.groups.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { startMockSocket, stopMockSocket } from "./socket";
 import { runCli, parseOutput, mockResponse } from "./cli-helpers";

--- a/src/tests/unit/cli.help-version.test.ts
+++ b/src/tests/unit/cli.help-version.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { runCli, assertVersion, pkgVersion, parseOutput } from "./cli-helpers";
 

--- a/src/tests/unit/cli.list.test.ts
+++ b/src/tests/unit/cli.list.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import os from "os";
-import path from "path";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { startMockSocket, stopMockSocket } from "./socket";
 import { runCli, parseOutput, mockResponse } from "./cli-helpers";

--- a/src/tests/unit/cli.screenshot.test.ts
+++ b/src/tests/unit/cli.screenshot.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { startMockSocket, stopMockSocket } from "./socket";
 import { runCli, parseOutput, mockResponse } from "./cli-helpers";

--- a/src/tests/unit/cli.setup-profiles.test.ts
+++ b/src/tests/unit/cli.setup-profiles.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { runCli, runCliWithStdin, parseOutput } from "./cli-helpers";
 
@@ -551,7 +551,7 @@ test("setup auto-derived extension ID matches Chromium algorithm", async () => {
 
     // Verify the derived ID matches the Chromium SHA256-based algorithm
     const extensionDir = path.join(homeDir, ".local", "state", "tabctl", "extension");
-    const crypto = require("crypto");
+    const crypto = require("node:crypto");
     const hash = crypto.createHash("sha256").update(extensionDir).digest("hex").slice(0, 32);
     const expectedId = hash.split("").map((c: string) => String.fromCharCode("a".charCodeAt(0) + parseInt(c, 16))).join("");
     assert.equal(output.data.extensionId, expectedId);

--- a/src/tests/unit/config.test.ts
+++ b/src/tests/unit/config.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { resolveConfig, resetConfig, expandEnvVars, resolveSocketPath } from "../../shared/config";
 

--- a/src/tests/unit/extension-sync.test.ts
+++ b/src/tests/unit/extension-sync.test.ts
@@ -1,8 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import os from "os";
-import path from "path";
-import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
 import {
   readExtensionVersion,
   resolveInstalledExtensionDir,
@@ -228,7 +228,7 @@ test("synced host bundle is executable", () => {
     assert.equal(result.synced, true);
 
     // Verify the bundle actually runs (will exit when stdin closes)
-    const { spawnSync } = require("child_process");
+    const { spawnSync } = require("node:child_process");
     const proc = spawnSync(process.execPath, [result.hostPath], {
       input: "{}",
       encoding: "utf-8",

--- a/src/tests/unit/host.test.ts
+++ b/src/tests/unit/host.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import net from "net";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
 import { readUndoRecords } from "../../host/lib/undo";

--- a/src/tests/unit/policy.test.ts
+++ b/src/tests/unit/policy.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { evaluateTab, loadPolicy } from "../../cli/lib/policy";
 import { resetConfig } from "../../shared/config";

--- a/src/tests/unit/profile.test.ts
+++ b/src/tests/unit/profile.test.ts
@@ -1,8 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import os from "os";
-import path from "path";
-import fs from "fs";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
 import {
   loadProfiles,
   saveProfiles,

--- a/src/tests/unit/readme-links.test.ts
+++ b/src/tests/unit/readme-links.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 test("README test links reference existing tests", () => {
   // Collect all test names from source test files

--- a/src/tests/unit/socket.ts
+++ b/src/tests/unit/socket.ts
@@ -1,8 +1,8 @@
-import net from "net";
-import os from "os";
-import path from "path";
-import crypto from "crypto";
-import fs from "fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import fs from "node:fs";
 
 export function createSocketPath(): string {
   if (process.platform === "win32") {

--- a/src/tests/unit/undo.test.ts
+++ b/src/tests/unit/undo.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import fs from "fs";
-import os from "os";
-import path from "path";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { appendUndoRecord, readUndoRecords, filterByRetention, findUndoRecord, findLatestUndoRecord } from "../../host/lib/undo";
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2024",
     "module": "CommonJS",
     "moduleResolution": "Node",
     "rootDir": "src",
     "outDir": "dist",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2024", "DOM"],
     "types": ["node", "chrome"],
     "strict": false,
     "esModuleInterop": true,


### PR DESCRIPTION
- Bump engines.node from >=20 to >=24
- Remove Node 20 and 22 from CI test matrix
- Raise TypeScript target/lib from ES2020 to ES2024
- Normalize all bare built-in imports to node: prefix

BREAKING CHANGE: Node.js 24 or later is now required