### PR TITLE
fix(cli): release integration tests + skill and help --json fixes

### DIFF
--- a/rust/crates/tabctl/src/cli/local.rs
+++ b/rust/crates/tabctl/src/cli/local.rs
@@ -37,11 +37,48 @@ pub(super) fn run_help(matches: &ArgMatches, sub: &ArgMatches) -> Result<(), Str
 
 fn structured_help(cli: &Command) -> serde_json::Value {
     let version = env!("CARGO_PKG_VERSION");
+
+    let format_opt = |a: &clap::Arg| -> Option<String> {
+        if let Some(long) = a.get_long() {
+            let vn = a.get_value_names().map(|v| {
+                v.iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join("|")
+            });
+            Some(match vn {
+                Some(ref v) if !v.is_empty() => format!("--{long} <{v}>"),
+                _ => format!("--{long}"),
+            })
+        } else if let Some(idx) = a.get_index() {
+            let id = a.get_id().as_str();
+            Some(format!("<{id}> (positional {idx})"))
+        } else {
+            None
+        }
+    };
+
+    let global_ids: std::collections::HashSet<&str> = cli
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .map(|a| a.get_id().as_str())
+        .collect();
+
     let global_opts: Vec<String> = cli
         .get_arguments()
         .filter(|a| a.get_id() != "help" && a.get_id() != "version")
-        .filter_map(|a| a.get_long().map(|l| format!("--{l}")))
+        .filter_map(&format_opt)
         .collect();
+
+    // Derive usage from clap
+    let mut usage_buf = Vec::new();
+    let _ = cli.clone().write_help(&mut usage_buf);
+    let usage_text = String::from_utf8_lossy(&usage_buf);
+    let usage = usage_text
+        .lines()
+        .find(|l| l.starts_with("Usage:"))
+        .map(|l| l.trim_start_matches("Usage:").trim().to_string())
+        .unwrap_or_else(|| "tabctl [OPTIONS] [COMMAND]".to_string());
 
     let commands: Vec<serde_json::Value> = cli
         .get_subcommands()
@@ -59,26 +96,8 @@ fn structured_help(cli: &Command) -> serde_json::Value {
             let opts: Vec<String> = c
                 .get_arguments()
                 .filter(|a| a.get_id() != "help" && a.get_id() != "version")
-                .filter(|a| !global_opts.contains(&format!("--{}", a.get_long().unwrap_or(""))))
-                .filter_map(|a| {
-                    if let Some(long) = a.get_long() {
-                        let vn = a.get_value_names().map(|v| {
-                            v.iter()
-                                .map(|s| s.to_string())
-                                .collect::<Vec<_>>()
-                                .join("|")
-                        });
-                        Some(match vn {
-                            Some(ref v) if !v.is_empty() => format!("--{long} <{v}>"),
-                            _ => format!("--{long}"),
-                        })
-                    } else if let Some(idx) = a.get_index() {
-                        let id = a.get_id().as_str();
-                        Some(format!("<{id}> (positional {idx})"))
-                    } else {
-                        None
-                    }
-                })
+                .filter(|a| !global_ids.contains(a.get_id().as_str()))
+                .filter_map(&format_opt)
                 .collect();
             if !opts.is_empty() {
                 entry.insert("options".into(), json!(opts));
@@ -90,7 +109,7 @@ fn structured_help(cli: &Command) -> serde_json::Value {
 
     json!({
         "version": version,
-        "usage": "tabctl [OPTIONS] [COMMAND]",
+        "usage": usage,
         "commands": commands,
         "globalOptions": global_opts
     })

--- a/scripts/test-mise-release.sh
+++ b/scripts/test-mise-release.sh
@@ -44,7 +44,7 @@ run_tabctl() {
   local channel="$1"; shift
   case "$channel" in
     npm)  npx -y "tabctl@${NPM_VERSION}" "$@" 2>/dev/null ;;
-    mise) mise x "github:ekroon/tabctl@${MISE_VERSION}" -- tabctl "$@" 2>&1 ;;
+    mise) mise x "github:ekroon/tabctl@${MISE_VERSION}" -- tabctl "$@" 2>/dev/null ;;
   esac
 }
 
@@ -260,15 +260,19 @@ _run_with_timeout() {
   return $rc
 }
 
+# Run a tabctl command with timeout via the appropriate channel.
+_run_skill_tabctl() {
+  local channel="$1"; shift
+  case "$channel" in
+    npm)  npx -y "tabctl@${NPM_VERSION}" "$@" 2>/dev/null ;;
+    mise) mise x "github:ekroon/tabctl@${MISE_VERSION}" -- tabctl "$@" 2>/dev/null ;;
+  esac
+}
+
 test_skill_json() {
   local ch="$1"
   local out
-  out=$(_run_with_timeout 10 bash -c "
-    case '$ch' in
-      npm)  npx -y 'tabctl@$NPM_VERSION' skill --json 2>/dev/null ;;
-      mise) mise x 'github:ekroon/tabctl@$MISE_VERSION' -- tabctl skill --json 2>/dev/null ;;
-    esac
-  " 2>/dev/null || true)
+  out=$(_run_with_timeout 10 _run_skill_tabctl "$ch" skill --json 2>/dev/null || true)
   if [ -z "$out" ]; then
     record FAIL "$ch" "skill --json" "timeout or no output (interactive?)"
     return
@@ -293,12 +297,7 @@ test_skill_json() {
 test_skill_agent() {
   local ch="$1"
   local out
-  out=$(_run_with_timeout 10 bash -c "
-    case '$ch' in
-      npm)  npx -y 'tabctl@$NPM_VERSION' skill --agent github-copilot --json 2>/dev/null ;;
-      mise) mise x 'github:ekroon/tabctl@$MISE_VERSION' -- tabctl skill --agent github-copilot --json 2>/dev/null ;;
-    esac
-  " 2>/dev/null || true)
+  out=$(_run_with_timeout 10 _run_skill_tabctl "$ch" skill --agent github-copilot --json 2>/dev/null || true)
   if [ -z "$out" ]; then
     record FAIL "$ch" "skill --agent --json" "timeout or no output (interactive prompt?)"
     return


### PR DESCRIPTION
## What

Fix two CLI regressions found during release integration testing of v0.5.3 (npm) vs v0.6.0-alpha.9 (mise), and add an automated test script for cross-channel verification.

## Changes

### 1. Release integration test script (`scripts/test-mise-release.sh`)
Automated test that exercises both distribution channels:
- **npm** (`npx tabctl@<version>`) for stable releases
- **mise** (`mise x github:ekroon/tabctl@<version>`) for alpha releases

Tests 15+ commands (version, help, ping, list, group-list, analyze, profile-list, profile-show, policy, history, doctor, skill) plus open/close/undo mutations. Reports pass/fail with a summary.

### 2. Fix: `tabctl skill` non-interactive mode
`tabctl skill` was running `npx skills add` without `-y`/`--yes`, causing it to block on interactive prompts — broken for agent/automation use. Now passes `-y` to npx and `--yes` to the skills CLI.

### 3. Fix: `help --json` structured output
`help --json` was returning clap's plain text wrapped in `{command, text}` instead of the structured format agents expect. Now introspects the clap `Command` tree to produce `{version, usage, commands:[{name, aliases, options}], globalOptions}`. Single-command help (`help <command> --json`) still returns the text form.

## Related issues

- Closes behavior reported during integration testing
- Filed #44 (npm alpha.9 ships alpha.8 binary) 
- Filed #45 (doctor stale profile UX after mise upgrade)

## Testing

- All 78 unit tests pass
- All integration tests pass (browser_coverage, browser_integration, browser_primitives, local_commands)
- Cross-target checks pass (linux-x86_64, windows-x86_64, macos-x86_64)
- Manual verification of both fixes with dev build
- Release integration test script run with full pass (35/35 pass after fixes, 1 known failure for skill on current alpha release)
