### PR TITLE
chore(release): v0.6.0-alpha.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-alpha.8",
+  "version": "0.6.0-alpha.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-alpha.8",
+      "version": "0.6.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-alpha.9",
+  "version": "0.6.0-alpha.10",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-alpha.9",
+  "version": "0.6.0-alpha.10",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -68,12 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,18 +90,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -293,11 +287,10 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
@@ -432,9 +425,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -443,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-alpha.9"
+version = "0.6.0-alpha.10"
 dependencies = [
  "clap",
  "dirs",
@@ -458,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-alpha.9"
+version = "0.6.0-alpha.10"
 dependencies = [
  "getrandom",
  "serde_json",
@@ -469,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-alpha.9"
+version = "0.6.0-alpha.10"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/crates/host/Cargo.toml
+++ b/rust/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabctl-host"
-version = "0.6.0-alpha.9"
+version = "0.6.0-alpha.10"
 edition = "2021"
 
 [lib]

--- a/rust/crates/shared/Cargo.toml
+++ b/rust/crates/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabctl-shared"
-version = "0.6.0-alpha.9"
+version = "0.6.0-alpha.10"
 edition = "2021"
 
 [lib]

--- a/rust/crates/tabctl/Cargo.toml
+++ b/rust/crates/tabctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabctl"
-version = "0.6.0-alpha.9"
+version = "0.6.0-alpha.10"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bump all version files to 0.6.0-alpha.10.

Changes since v0.6.0-alpha.9:
- fix(cli): release integration tests + skill and help --json fixes (#46)
- docs(release): update skill for PR workflow and Cargo.toml bumps (#47)

After merge, tag `v0.6.0-alpha.10` and create release.