### PR TITLE
chore: centralize version management and update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,45 @@ tabctl dedupe --window 123 --confirm # Execute after review
 - Keep the subject in present-tense, lowercase imperative form.
 - Do not add a trailing period.
 
+## Release workflow
+
+Direct pushes to `main` are blocked by a branch ruleset (requires PR + CI checks + Copilot review).
+
+**Version management:** All version files are synced by `scripts/bump-version.js` (exposed as `npm run bump:<kind>`). Never edit version fields manually.
+
+```bash
+npm run bump:alpha    # next alpha
+npm run bump:rc       # alpha → rc.1, or rc.N+1
+npm run bump:stable   # strip pre-release suffix
+npm run bump:patch    # patch bump
+npm run bump:minor    # minor bump
+npm run bump:major    # major bump
+```
+
+**Release flow:** See `skills/release/SKILL.md` for the full process. Summary:
+1. `npm run bump:alpha` (or other kind) on a `chore/release-v{NEW}` branch
+2. `npm test` + `npm run build`
+3. Commit, push, open PR
+4. `scripts/ci-wait-merge.sh <PR#> --tag v{NEW}` — waits for CI, merges (normal merge, not squash), tags, creates GitHub release
+5. The `release.yml` workflow builds binaries and publishes to npm
+
+**Merge strategy:** Always use normal merge for release PRs (not squash) to preserve commit identity.
+
+## Scripts
+
+- `scripts/bump-version.js` — syncs all version files (package.json, win32-x64, 3× Cargo.toml, lockfiles)
+- `scripts/ci-wait-merge.sh` — waits for CI, merges PR, tags, creates GitHub release
+- `scripts/test-mise-release.sh` — integration test comparing npm stable vs mise alpha channels
+- `scripts/gen-version.js` — generates extension manifest version at build time
+
+## Skills
+
+The `skills/` directory contains agent skills installable via `tabctl skill`:
+
+- `skills/tabctl/` — CLI usage guide for agents
+- `skills/release/` — Release automation (version bump → PR → merge → tag → release)
+- `skills/git-commit/` — Conventional commit message generation
+
 ## Principles (read first)
 - Only mutate tabs that the test itself created.
 - Never run `archive --all` or `close --apply` in a normal browsing session.

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -3,6 +3,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("node:child_process");
 
 const root = path.resolve(__dirname, "..");
 const pkgPath = path.join(root, "package.json");
@@ -119,4 +120,15 @@ syncJsonPackageVersion(winPkgPath, pkg.version);
 for (const cargoPath of cargoPackagePaths) {
   syncCargoPackageVersion(cargoPath, pkg.version);
 }
+
+// Sync lockfiles
+execSync("npm install --package-lock-only --ignore-scripts", {
+  cwd: root,
+  stdio: "ignore",
+});
+execSync("cargo generate-lockfile --manifest-path rust/Cargo.toml", {
+  cwd: root,
+  stdio: "ignore",
+});
+
 process.stdout.write(`${pkg.version}\n`);

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -13,14 +13,17 @@ Direct pushes to `main` are blocked by a branch ruleset. All releases go through
 
 ## Version files
 
-All five version files must stay in sync. The release workflow (`release.yml`) validates this:
+All version files must stay in sync. The `scripts/bump-version.js` script (exposed via `npm run bump:*`) updates all of them in one command. The release workflow (`release.yml`) validates they match:
 
-1. `package.json` — root package version
-2. `package-lock.json` — lockfile (updated automatically by `npm version`)
+1. `package.json` — root package version (single source of truth)
+2. `package-lock.json` — lockfile
 3. `packages/win32-x64/package.json` — Windows platform package
 4. `rust/crates/tabctl/Cargo.toml` — main Rust binary
 5. `rust/crates/host/Cargo.toml` — host crate
 6. `rust/crates/shared/Cargo.toml` — shared crate
+7. `rust/Cargo.lock` — Rust lockfile
+
+Never edit these version fields manually. Always use `npm run bump:<kind>`.
 
 ## Prerequisites
 
@@ -117,33 +120,24 @@ git checkout -b "chore/release-v${NEW}"
 
 ### Step 5: Update all version files
 
-**package.json + package-lock.json:**
+Use the bump script which updates all version files (package.json, package-lock.json, packages/win32-x64/package.json, 3× Cargo.toml, Cargo.lock) in one command:
+
 ```bash
-npm version "${NEW}" --no-git-tag-version
+# For the recommended bump type:
+npm run bump:alpha    # 0.6.0-alpha.9 → 0.6.0-alpha.10
+npm run bump:rc       # 0.6.0-alpha.10 → 0.6.0-rc.1
+npm run bump:stable   # 0.6.0-rc.1 → 0.6.0
+npm run bump:patch    # 0.6.0 → 0.6.1
+npm run bump:minor    # 0.6.1 → 0.7.0
+npm run bump:major    # 0.7.0 → 1.0.0
 ```
 
-**packages/win32-x64/package.json:**
+If the user chose a custom version that doesn't match a standard bump, update manually:
 ```bash
-node -e "
-  const fs = require('fs');
-  const p = './packages/win32-x64/package.json';
-  const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-  pkg.version = '${NEW}';
-  fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
-"
+node scripts/bump-version.js <kind>
 ```
 
-**Rust Cargo.toml files (all three):**
-```bash
-for f in rust/crates/tabctl/Cargo.toml rust/crates/host/Cargo.toml rust/crates/shared/Cargo.toml; do
-  sed -i '' "s/^version = \".*\"/version = \"${NEW}\"/" "$f"
-done
-```
-
-After updating Cargo.toml files, update the lockfile:
-```bash
-cargo generate-lockfile --manifest-path rust/Cargo.toml
-```
+Verify the output matches the expected version.
 
 ### Step 6: Run tests
 
@@ -169,6 +163,8 @@ git add package.json package-lock.json packages/win32-x64/package.json \
        rust/crates/shared/Cargo.toml rust/Cargo.lock
 git commit -m "chore(release): v${NEW}"
 ```
+
+All these files are updated by `scripts/bump-version.js` in Step 5.
 
 ### Step 9: Push branch and open PR
 


### PR DESCRIPTION
Three improvements:

1. **bump-version.js** now syncs lockfiles too (package-lock.json + Cargo.lock), so `npm run bump:alpha` updates all 7 files in one command.

2. **Release skill** updated to use `npm run bump:<kind>` instead of manual `npm version` + `sed` + `cargo generate-lockfile`.

3. **AGENTS.md** gains missing sections: release workflow (PR-based, normal merge), version management (`npm run bump:*`), helper scripts, and skills directory.