### PR TITLE
fix(cli): fix version comparison and ping output for pre-release versions

### DIFF
--- a/rust/crates/host/src/host_impl.rs
+++ b/rust/crates/host/src/host_impl.rs
@@ -13,7 +13,7 @@ pub fn run() {
 use orchestrate::{OrchStep, Orchestration};
 #[cfg(test)]
 use protocol::{
-    create_id, host_version, now_ms, read_native_message, write_native_message,
+    add_ping_metadata, create_id, host_version, now_ms, read_native_message, write_native_message,
     MAX_NATIVE_MESSAGE_BYTES,
 };
 #[cfg(test)]
@@ -981,5 +981,50 @@ mod tests {
         );
         // Error response must carry the original client request_id, not the internal orch-* id
         assert_eq!(payload.request_id.as_deref(), Some("req-abort"));
+    }
+
+    #[test]
+    fn versions_in_sync_uses_dev_stripped_version() {
+        let host_ver = host_version();
+
+        // Extension version with -dev suffix matching host base version
+        let mut data = Map::new();
+        data.insert(
+            "version".to_string(),
+            Value::String(format!("{host_ver}-dev.abc123")),
+        );
+        data.insert(
+            "baseVersion".to_string(),
+            Value::String("0.6.0".to_string()),
+        );
+        let result = add_ping_metadata(data);
+        assert_eq!(
+            result.get("versionsInSync").and_then(|v| v.as_bool()),
+            Some(true),
+            "dev-stripped version should match host base version"
+        );
+
+        // Extension version without dev suffix matching host
+        let mut data2 = Map::new();
+        data2.insert("version".to_string(), Value::String(host_ver.to_string()));
+        let result2 = add_ping_metadata(data2);
+        assert_eq!(
+            result2.get("versionsInSync").and_then(|v| v.as_bool()),
+            Some(true),
+            "exact version match should be in sync"
+        );
+
+        // Extension version that does NOT match host
+        let mut data3 = Map::new();
+        data3.insert(
+            "version".to_string(),
+            Value::String("99.99.99-dev.xyz".to_string()),
+        );
+        let result3 = add_ping_metadata(data3);
+        assert_eq!(
+            result3.get("versionsInSync").and_then(|v| v.as_bool()),
+            Some(false),
+            "mismatched versions should not be in sync"
+        );
     }
 }

--- a/rust/crates/host/src/host_impl/protocol.rs
+++ b/rust/crates/host/src/host_impl/protocol.rs
@@ -139,10 +139,6 @@ pub(super) fn value_object(input: Option<Value>) -> Map<String, Value> {
 }
 
 pub(super) fn add_ping_metadata(mut data: Map<String, Value>) -> Map<String, Value> {
-    let extension_base_version = data
-        .get("baseVersion")
-        .and_then(|v| v.as_str())
-        .map(str::to_string);
     let extension_version = data
         .get("version")
         .and_then(|v| v.as_str())
@@ -160,11 +156,18 @@ pub(super) fn add_ping_metadata(mut data: Map<String, Value>) -> Map<String, Val
         Value::String(git_sha().to_string()),
     );
     data.insert("hostDirty".to_string(), Value::Bool(is_dirty()));
-    let versions_in_sync = extension_base_version
+    let versions_in_sync = extension_version
         .as_deref()
-        .map(|v| v == base_version())
-        .or_else(|| extension_version.as_deref().map(|v| v == host_version()))
+        .map(|v| strip_dev_suffix(v) == base_version())
         .unwrap_or(false);
     data.insert("versionsInSync".to_string(), Value::Bool(versions_in_sync));
     data
+}
+
+fn strip_dev_suffix(version: &str) -> &str {
+    if let Some(idx) = version.find("-dev.") {
+        &version[..idx]
+    } else {
+        version
+    }
 }

--- a/rust/crates/tabctl/src/cli/api.rs
+++ b/rust/crates/tabctl/src/cli/api.rs
@@ -52,9 +52,18 @@ where
         routed.profile.as_deref(),
         routed.progress,
     )?;
-    let rendered = render_response(&response, routed.json, routed.pretty);
+    let rendered = if routed.action == "ping" && !routed.json {
+        render_ping_human(&response)
+    } else {
+        render_response(&response, routed.json, routed.pretty)
+    };
     if rendered.is_ok() {
-        maybe_runtime_extension_auto_sync(&routed.action, routed.profile.as_deref());
+        let prefetched = if routed.action == "ping" {
+            Some(&response)
+        } else {
+            None
+        };
+        maybe_runtime_extension_auto_sync(&routed.action, routed.profile.as_deref(), prefetched);
     }
     rendered
 }

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -783,11 +783,13 @@ mod tests {
     }
 
     #[test]
-    fn compare_base_versions_ignores_prerelease_metadata() {
+    fn compare_base_versions_handles_prerelease_ordering() {
+        // pre-release < release with same triplet
         assert_eq!(
             compare_base_versions("0.6.0-alpha.5", "0.6.0"),
-            Some(std::cmp::Ordering::Equal)
+            Some(std::cmp::Ordering::Less)
         );
+        // higher triplet wins regardless of pre-release
         assert_eq!(
             compare_base_versions("0.6.1-rc.1", "0.6.0"),
             Some(std::cmp::Ordering::Greater)
@@ -796,6 +798,40 @@ mod tests {
             compare_base_versions("0.5.2", "0.6.0-alpha.1"),
             Some(std::cmp::Ordering::Less)
         );
+        // pre-release numeric ordering
+        assert_eq!(
+            compare_base_versions("0.6.0-alpha.10", "0.6.0-alpha.9"),
+            Some(std::cmp::Ordering::Greater)
+        );
+        assert_eq!(
+            compare_base_versions("0.6.0-alpha.9", "0.6.0-alpha.10"),
+            Some(std::cmp::Ordering::Less)
+        );
+        // same pre-release
+        assert_eq!(
+            compare_base_versions("0.6.0-alpha.10", "0.6.0-alpha.10"),
+            Some(std::cmp::Ordering::Equal)
+        );
+        // rc > alpha (lexicographic)
+        assert_eq!(
+            compare_base_versions("0.6.0-rc.1", "0.6.0-alpha.10"),
+            Some(std::cmp::Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn strip_dev_suffix_preserves_prerelease_tags() {
+        assert_eq!(
+            strip_dev_suffix("0.6.0-alpha.10-dev.f4ad4314"),
+            "0.6.0-alpha.10"
+        );
+        assert_eq!(
+            strip_dev_suffix("0.6.0-alpha.10-dev.f4ad4314.dirty"),
+            "0.6.0-alpha.10"
+        );
+        assert_eq!(strip_dev_suffix("0.6.0-alpha.10"), "0.6.0-alpha.10");
+        assert_eq!(strip_dev_suffix("0.6.0"), "0.6.0");
+        assert_eq!(strip_dev_suffix("1.0.0-rc.1-dev.abc123"), "1.0.0-rc.1");
     }
 
     #[test]
@@ -825,8 +861,8 @@ mod tests {
     }
 
     #[test]
-    fn should_runtime_auto_sync_skips_ping_and_reload() {
-        assert!(!should_runtime_auto_sync("ping"));
+    fn should_runtime_auto_sync_skips_reload() {
+        assert!(should_runtime_auto_sync("ping"));
         assert!(!should_runtime_auto_sync("reload"));
         assert!(should_runtime_auto_sync("list"));
     }

--- a/rust/crates/tabctl/src/cli/output.rs
+++ b/rust/crates/tabctl/src/cli/output.rs
@@ -34,6 +34,80 @@ pub(super) fn render_local_command(
     Ok(())
 }
 
+pub(super) fn render_ping_human(response: &ResponseEnvelope) -> Result<(), String> {
+    if !response.ok {
+        if let Some(error) = &response.error {
+            eprintln!("error: {}", error.message);
+            if let Some(hint) = &error.hint {
+                eprintln!("hint: {hint}");
+            }
+        } else {
+            eprintln!("error: ping failed");
+        }
+        return Err("request failed".to_string());
+    }
+
+    let data = response
+        .data
+        .as_ref()
+        .and_then(Value::as_object)
+        .ok_or("missing ping data")?;
+
+    let ext_sha = data
+        .get("gitSha")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let host_sha = data
+        .get("hostGitSha")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let in_sync = data
+        .get("versionsInSync")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let host_version = data
+        .get("hostBaseVersion")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let ext_version = data
+        .get("version")
+        .and_then(Value::as_str)
+        .map(strip_dev_suffix)
+        .unwrap_or("unknown");
+    let ext_dirty = data.get("dirty").and_then(Value::as_bool).unwrap_or(false);
+    let host_dirty = data
+        .get("hostDirty")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let dirty_marker = |d: bool| if d { "+dirty" } else { "" };
+
+    if in_sync {
+        println!(
+            "\u{2705} tabctl {} (ext {}{}, host {}{}, in sync)",
+            host_version,
+            ext_sha,
+            dirty_marker(ext_dirty),
+            host_sha,
+            dirty_marker(host_dirty),
+        );
+    } else {
+        println!(
+            "\u{26a0}\u{fe0f} tabctl \u{2014} out of sync (ext {}, host {})",
+            ext_version, host_version,
+        );
+    }
+    Ok(())
+}
+
+fn strip_dev_suffix(version: &str) -> &str {
+    if let Some(idx) = version.find("-dev.") {
+        &version[..idx]
+    } else {
+        version
+    }
+}
+
 pub(super) fn render_response(
     response: &ResponseEnvelope,
     json_mode: bool,

--- a/rust/crates/tabctl/src/cli/setup.rs
+++ b/rust/crates/tabctl/src/cli/setup.rs
@@ -107,6 +107,19 @@ pub(super) fn normalize_base_version(version: &str) -> &str {
         .unwrap_or(version)
 }
 
+/// Strips `-dev.{sha}[.dirty]` build suffix but preserves pre-release tags.
+/// e.g. "0.6.0-alpha.10-dev.f4ad4314" → "0.6.0-alpha.10"
+///      "0.6.0-alpha.10-dev.f4ad4314.dirty" → "0.6.0-alpha.10"
+///      "0.6.0-alpha.10" → "0.6.0-alpha.10"
+///      "0.6.0" → "0.6.0"
+pub(super) fn strip_dev_suffix(version: &str) -> &str {
+    if let Some(idx) = version.find("-dev.") {
+        &version[..idx]
+    } else {
+        version
+    }
+}
+
 pub(super) fn parse_base_triplet(version: &str) -> Option<(u64, u64, u64)> {
     let mut parts = normalize_base_version(version)
         .split('.')
@@ -117,7 +130,46 @@ pub(super) fn parse_base_triplet(version: &str) -> Option<(u64, u64, u64)> {
 pub(super) fn compare_base_versions(a: &str, b: &str) -> Option<std::cmp::Ordering> {
     let a_parts = parse_base_triplet(a)?;
     let b_parts = parse_base_triplet(b)?;
-    Some(a_parts.cmp(&b_parts))
+    let triplet_ord = a_parts.cmp(&b_parts);
+    if triplet_ord != std::cmp::Ordering::Equal {
+        return Some(triplet_ord);
+    }
+    // Triplets equal — compare pre-release segments (semver: no pre-release > has pre-release)
+    let a_pre = extract_prerelease(a);
+    let b_pre = extract_prerelease(b);
+    Some(compare_prerelease(a_pre, b_pre))
+}
+
+fn extract_prerelease(version: &str) -> Option<&str> {
+    let after_triplet = version.split_once('-').map(|(_, rest)| rest)?;
+    // strip build metadata (+...)
+    Some(
+        after_triplet
+            .split_once('+')
+            .map_or(after_triplet, |(pre, _)| pre),
+    )
+}
+
+fn compare_prerelease(a: Option<&str>, b: Option<&str>) -> std::cmp::Ordering {
+    match (a, b) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Greater, // no pre-release > has pre-release
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (Some(a), Some(b)) => {
+            let a_parts = a.split('.');
+            let b_parts = b.split('.');
+            for (ap, bp) in a_parts.zip(b_parts) {
+                let ord = match (ap.parse::<u64>(), bp.parse::<u64>()) {
+                    (Ok(an), Ok(bn)) => an.cmp(&bn),
+                    _ => ap.cmp(bp),
+                };
+                if ord != std::cmp::Ordering::Equal {
+                    return ord;
+                }
+            }
+            a.len().cmp(&b.len())
+        }
+    }
 }
 
 pub(super) fn chromium_extension_id_from_digest(digest: &[u8]) -> String {
@@ -552,7 +604,7 @@ pub(super) fn sync_extension_unpacked_dir(
 }
 
 pub(super) fn should_runtime_auto_sync(action: &str) -> bool {
-    !matches!(action, "ping" | "reload")
+    !matches!(action, "reload")
 }
 
 pub(super) fn effective_auto_sync_mode() -> AutoSyncMode {
@@ -568,7 +620,11 @@ pub(super) fn effective_auto_sync_mode() -> AutoSyncMode {
     }
 }
 
-pub(super) fn maybe_runtime_extension_auto_sync(action: &str, profile: Option<&str>) {
+pub(super) fn maybe_runtime_extension_auto_sync(
+    action: &str,
+    profile: Option<&str>,
+    prefetched_ping: Option<&ResponseEnvelope>,
+) {
     if !should_runtime_auto_sync(action) {
         return;
     }
@@ -589,9 +645,15 @@ pub(super) fn maybe_runtime_extension_auto_sync(action: &str, profile: Option<&s
         }
     }
 
-    let ping = match send_request("ping", Value::Object(Map::new()), profile, false) {
-        Ok(response) if response.ok => response,
-        _ => return,
+    let owned_ping;
+    let ping = if let Some(pre) = prefetched_ping {
+        pre
+    } else {
+        owned_ping = match send_request("ping", Value::Object(Map::new()), profile, false) {
+            Ok(response) if response.ok => response,
+            _ => return,
+        };
+        &owned_ping
     };
 
     let Some(data) = ping.data.as_ref().and_then(Value::as_object) else {
@@ -599,19 +661,22 @@ pub(super) fn maybe_runtime_extension_auto_sync(action: &str, profile: Option<&s
     };
 
     let host_base = data.get("hostBaseVersion").and_then(Value::as_str);
-    let extension_base = data.get("baseVersion").and_then(Value::as_str);
-    let (Some(host_base), Some(extension_base)) = (host_base, extension_base) else {
+    let extension_version = data
+        .get("version")
+        .and_then(Value::as_str)
+        .map(strip_dev_suffix);
+    let (Some(host_base), Some(ext_release)) = (host_base, extension_version) else {
         return;
     };
 
-    if normalize_base_version(host_base) == normalize_base_version(extension_base) {
+    if ext_release == host_base {
         return;
     }
 
-    if compare_base_versions(extension_base, host_base) == Some(std::cmp::Ordering::Greater) {
+    if compare_base_versions(ext_release, host_base) == Some(std::cmp::Ordering::Greater) {
         eprintln!(
             "[tabctl] extension auto-sync skipped (installed extension {} is newer than tabctl {})",
-            extension_base, host_base
+            ext_release, host_base
         );
         return;
     }
@@ -619,28 +684,31 @@ pub(super) fn maybe_runtime_extension_auto_sync(action: &str, profile: Option<&s
     let source = match resolve_extension_release_source(Some(host_base), None, None, None) {
         Ok(source) => source,
         Err(error) => {
-            eprintln!("[tabctl] extension auto-sync failed: {error}");
+            eprintln!(
+                "\u{26a0}\u{fe0f} auto-sync failed: {error}. Run 'tabctl setup' to sync manually."
+            );
             return;
         }
     };
 
+    eprint!("\u{2699}\u{fe0f} auto-syncing extension to {host_base}...");
     let sync = match sync_extension_release(&source, true) {
         Ok(sync) => sync,
         Err(error) => {
-            eprintln!("[tabctl] extension auto-sync failed: {error}");
+            eprintln!(
+                " failed\n\u{26a0}\u{fe0f} auto-sync failed: {error}. Run 'tabctl setup' to sync manually."
+            );
             return;
         }
     };
 
     if !sync.updated {
+        eprintln!(" already up to date");
         return;
     }
 
     let _ = send_request("reload", Value::Object(Map::new()), profile, false);
-    eprintln!(
-        "[tabctl] extension auto-synced to {} at {}",
-        sync.target_version, sync.active_path
-    );
+    eprintln!(" done");
 }
 
 pub(super) fn run_setup(matches: &ArgMatches, sub: &ArgMatches) -> Result<(), String> {


### PR DESCRIPTION
## Summary

Fix auto-sync silently failing for pre-release versions and simplify ping output.

### Root cause
`normalize_base_version()` stripped pre-release tags, making `0.6.0-alpha.9` and `0.6.0-alpha.10` appear identical. Auto-sync skipped upgrades between pre-release versions. Additionally, `versionsInSync` always reported `false` for pre-releases.

### Changes
- Add `strip_dev_suffix()` preserving pre-release tags (only strips `-dev.{sha}`)
- Fix auto-sync to compare extension version (dev-stripped) vs hostBaseVersion
- Fix `versionsInSync` in host protocol to use same comparison
- Add proper semver-aware `compare_base_versions()` with pre-release ordering
- Enable ping to trigger auto-sync (pass pre-fetched response to avoid recursion)
- Add compact human-readable ping output (JSON still available with `--json`)
- Improve auto-sync status messages with progress indicators