### PR TITLE
chore(release): v0.6.0-alpha.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-alpha.10",
+  "version": "0.6.0-alpha.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-alpha.10",
+      "version": "0.6.0-alpha.11",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-alpha.10",
+  "version": "0.6.0-alpha.11",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-alpha.10",
+  "version": "0.6.0-alpha.11",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.11"
 dependencies = [
  "clap",
  "dirs",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.11"
 dependencies = [
  "getrandom",
  "serde_json",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.11"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/crates/host/Cargo.toml
+++ b/rust/crates/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabctl-host"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.11"
 edition = "2021"
 
 [lib]

--- a/rust/crates/shared/Cargo.toml
+++ b/rust/crates/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabctl-shared"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.11"
 edition = "2021"
 
 [lib]

--- a/rust/crates/tabctl/Cargo.toml
+++ b/rust/crates/tabctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tabctl"
-version = "0.6.0-alpha.10"
+version = "0.6.0-alpha.11"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bump all version files to 0.6.0-alpha.11. After merge, tag and create release.