### PR TITLE
test(host): avoid focus store temp path collisions

### DIFF
--- a/rust/crates/host/src/host_impl/focus_store.rs
+++ b/rust/crates/host/src/host_impl/focus_store.rs
@@ -157,16 +157,24 @@ pub(super) fn enrich_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_STORE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     struct TempStorePath(std::path::PathBuf);
 
     impl TempStorePath {
         fn new() -> Self {
+            let counter = TEMP_STORE_COUNTER.fetch_add(1, Ordering::Relaxed);
             let unique = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_nanos())
                 .unwrap_or(0);
-            Self(std::env::temp_dir().join(format!("tabctl-focus-store-{unique}.json")))
+            let pid = std::process::id();
+            Self(
+                std::env::temp_dir()
+                    .join(format!("tabctl-focus-store-{pid}-{unique}-{counter}.json")),
+            )
         }
 
         fn as_path(&self) -> &Path {


### PR DESCRIPTION
## Summary
- make focus_store test temp file paths unique per process and invocation
- avoid collisions when host tests run concurrently or rapidly reuse temp names
- keep the change scoped to test-only helper code in `focus_store.rs`

## Testing
- `cargo test --manifest-path rust/Cargo.toml -p tabctl-host enrich_snapshot_fills_missing_timestamps --lib`
- host test suite passed before commit creation on the clean branch
