### PR TITLE
feat(ci): automate release preparation flow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,213 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type
+        required: true
+        type: choice
+        default: auto
+        options:
+          - auto
+          - alpha
+          - rc
+          - stable
+          - patch
+          - minor
+          - major
+      base_branch:
+        description: Branch to prepare the release from
+        required: true
+        type: string
+        default: main
+      dry_run:
+        description: Show the release plan without creating a branch or PR
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Determine release plan
+        id: plan
+        env:
+          REQUESTED_BUMP: ${{ inputs.bump }}
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const { execSync } = require("node:child_process");
+          const { bump, formatVersion, parseVersion, recommendReleaseBump } = require("./scripts/versioning");
+
+          const currentVersion = require("./package.json").version;
+          const requestedBump = process.env.REQUESTED_BUMP;
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+          const run = (command) => execSync(command, {
+            encoding: "utf8",
+            shell: "/bin/bash",
+            stdio: ["ignore", "pipe", "pipe"],
+          }).trim();
+
+          const latestTag = run("git tag --sort=-version:refname | head -n 1 || true");
+          const commitRange = latestTag ? `${latestTag}..HEAD` : "";
+          const commitList = run(commitRange
+            ? `git log ${commitRange} --oneline --no-decorate`
+            : "git log --oneline --no-decorate");
+          const commitBodies = run(commitRange
+            ? `git log ${commitRange} --pretty=format:%s%n%b%n==END==`
+            : "git log --pretty=format:%s%n%b%n==END==");
+
+          const recommendation = recommendReleaseBump(currentVersion, commitBodies);
+          const selectedBump = requestedBump === "auto" ? recommendation.bump : requestedBump;
+          const nextVersion = formatVersion(bump(parseVersion(currentVersion), selectedBump));
+          const branchName = `chore/release-v${nextVersion}`;
+          const prTitle = `chore(release): v${nextVersion}`;
+          const commitCount = commitList ? commitList.split("\n").length : 0;
+
+          const outputs = {
+            current_version: currentVersion,
+            latest_tag: latestTag,
+            selected_bump: selectedBump,
+            next_version: nextVersion,
+            branch_name: branchName,
+            pr_title: prTitle,
+            recommendation_reason: recommendation.reason,
+            commit_count: String(commitCount),
+          };
+
+          fs.appendFileSync(outputPath, `${Object.entries(outputs).map(([key, value]) => `${key}=${value}`).join("\n")}\n`);
+          fs.appendFileSync(summaryPath, [
+            "### Release preparation plan",
+            "",
+            "| Field | Value |",
+            "|---|---|",
+            `| Current version | \`${currentVersion}\` |`,
+            `| Last tag | \`${latestTag || "none"}\` |`,
+            `| Requested bump | \`${requestedBump}\` |`,
+            `| Selected bump | \`${selectedBump}\` |`,
+            `| Next version | \`${nextVersion}\` |`,
+            `| Recommendation | ${recommendation.reason} |`,
+            `| Commit count | ${commitCount} |`,
+            "",
+            "#### Commits since last tag",
+            "",
+            "```text",
+            commitList || "(no commits found)",
+            "```",
+            "",
+          ].join("\n"));
+          NODE
+
+      - name: Ensure release branch does not already exist
+        if: inputs.dry_run == false
+        env:
+          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+        shell: bash
+        run: |
+          if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+            echo "Local branch ${BRANCH_NAME} already exists." >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            echo "Remote branch ${BRANCH_NAME} already exists." >&2
+            exit 1
+          fi
+
+      - name: Create release branch and bump version
+        if: inputs.dry_run == false
+        env:
+          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+          SELECTED_BUMP: ${{ steps.plan.outputs.selected_bump }}
+          NEXT_VERSION: ${{ steps.plan.outputs.next_version }}
+        shell: bash
+        run: |
+          git checkout -b "${BRANCH_NAME}"
+          npm run "bump:${SELECTED_BUMP}"
+          actual_version="$(node -p "require('./package.json').version")"
+          if [ "${actual_version}" != "${NEXT_VERSION}" ]; then
+            echo "Expected version ${NEXT_VERSION}, got ${actual_version}" >&2
+            exit 1
+          fi
+
+      - name: Commit and push release branch
+        if: inputs.dry_run == false
+        env:
+          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+          PR_TITLE: ${{ steps.plan.outputs.pr_title }}
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json packages/win32-x64/package.json \
+            rust/crates/shared/Cargo.toml rust/crates/host/Cargo.toml \
+            rust/crates/graphql/Cargo.toml rust/crates/tabctl/Cargo.toml rust/Cargo.lock
+          git commit -m "${PR_TITLE}"
+          git push -u origin "${BRANCH_NAME}"
+
+      - name: Create release pull request
+        if: inputs.dry_run == false
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+          CURRENT_VERSION: ${{ steps.plan.outputs.current_version }}
+          NEXT_VERSION: ${{ steps.plan.outputs.next_version }}
+          SELECTED_BUMP: ${{ steps.plan.outputs.selected_bump }}
+          PR_TITLE: ${{ steps.plan.outputs.pr_title }}
+          RECOMMENDATION_REASON: ${{ steps.plan.outputs.recommendation_reason }}
+        shell: bash
+        run: |
+          body="$(cat <<EOF
+          ## Release preparation
+
+          - Current version: \`${CURRENT_VERSION}\`
+          - Next version: \`${NEXT_VERSION}\`
+          - Bump type: \`${SELECTED_BUMP}\`
+          - Recommendation: ${RECOMMENDATION_REASON}
+
+          This PR was created automatically by the **Prepare Release** workflow.
+          After it merges, the **Tag Release** workflow will create \`v${NEXT_VERSION}\` and dispatch the **Release** workflow.
+          EOF
+          )"
+          pr_url="$(GH_PAGER="" gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${BRANCH_NAME}" \
+            --title "${PR_TITLE}" \
+            --body "${body}")"
+          echo "url=${pr_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: inputs.dry_run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        shell: bash
+        run: GH_PAGER="" gh pr merge "${PR_URL}" --auto --merge
+
+      - name: Summarize PR
+        if: inputs.dry_run == false
+        run: |
+          echo "#### Release PR" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.pr.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,56 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to release (for example v0.6.0)
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
 
 jobs:
-  # ── Validate release tag against package.json version ──────────────
+  resolve-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve release tag
+        id: resolve
+        shell: bash
+        run: |
+          tag='${{ inputs.tag || github.ref_name }}'
+          if [ -z "$tag" ]; then
+            echo "Release tag is required." >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
   validate:
+    needs: resolve-tag
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.check.outputs.version }}
       dist_tag: ${{ steps.check.outputs.dist_tag }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
       - name: Validate tag and resolve channel
         id: check
         shell: bash
         run: |
-          tag='${{ github.event.release.tag_name }}'
+          tag='${{ needs.resolve-tag.outputs.tag }}'
           version="$(node -p "require('./package.json').version")"
           expected_tag="v${version}"
           if [ "$tag" != "$expected_tag" ]; then
@@ -32,11 +61,14 @@ jobs:
           const fs = require("fs");
           const path = require("path");
           const root = process.cwd();
-          const packageVersion = require(path.join(root, "package.json")).version;
+          const packageJson = require(path.join(root, "package.json"));
+          const packageVersion = packageJson.version;
           const winPackageVersion = require(path.join(root, "packages", "win32-x64", "package.json")).version;
+          const winOptionalDependencyVersion = packageJson.optionalDependencies?.["tabctl-win32-x64"];
           const cargoFiles = [
             "rust/crates/shared/Cargo.toml",
             "rust/crates/host/Cargo.toml",
+            "rust/crates/graphql/Cargo.toml",
             "rust/crates/tabctl/Cargo.toml",
           ];
           const mismatches = [];
@@ -52,6 +84,10 @@ jobs:
 
           if (winPackageVersion !== packageVersion) {
             mismatches.push(`packages/win32-x64/package.json=${winPackageVersion} (expected ${packageVersion})`);
+          }
+
+          if (winOptionalDependencyVersion !== packageVersion) {
+            mismatches.push(`package.json optionalDependencies.tabctl-win32-x64=${winOptionalDependencyVersion} (expected ${packageVersion})`);
           }
 
           for (const file of cargoFiles) {
@@ -70,26 +106,22 @@ jobs:
           }
           NODE
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          if [ '${{ github.event.release.prerelease }}' = 'true' ]; then
-            if [[ "$version" == *-alpha.* ]]; then
-              echo "dist_tag=alpha" >> "$GITHUB_OUTPUT"
-            elif [[ "$version" == *-rc.* ]]; then
-              echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
-            else
-              echo "Prerelease must use an -alpha.N or -rc.N version." >&2
-              exit 1
-            fi
+          if [[ "$version" == *-alpha.* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=alpha" >> "$GITHUB_OUTPUT"
+          elif [[ "$version" == *-rc.* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
+          elif [[ "$version" == *-* ]]; then
+            echo "Only -alpha.N and -rc.N prerelease versions are supported." >&2
+            exit 1
           else
-            if [[ "$version" == *-* ]]; then
-              echo "Stable releases must not publish prerelease versions." >&2
-              exit 1
-            fi
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
             echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-  # ── Build cross-platform Rust binaries ─────────────────────────────
   build:
-    needs: validate
+    needs: [resolve-tag, validate]
     strategy:
       matrix:
         include:
@@ -116,6 +148,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -136,25 +170,27 @@ jobs:
         if: matrix.archive == 'tar.gz'
         run: |
           cd rust/target/${{ matrix.target }}/release
-          tar czf "$GITHUB_WORKSPACE/tabctl-${{ github.event.release.tag_name }}-${{ matrix.asset_suffix }}.tar.gz" tabctl
+          tar czf "$GITHUB_WORKSPACE/tabctl-${{ needs.resolve-tag.outputs.tag }}-${{ matrix.asset_suffix }}.tar.gz" tabctl
 
       - name: Package (zip)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Compress-Archive -Path "rust/target/${{ matrix.target }}/release/tabctl.exe" -DestinationPath "tabctl-${{ github.event.release.tag_name }}-${{ matrix.asset_suffix }}.zip"
+          Compress-Archive -Path "rust/target/${{ matrix.target }}/release/tabctl.exe" -DestinationPath "tabctl-${{ needs.resolve-tag.outputs.tag }}-${{ matrix.asset_suffix }}.zip"
 
-      - name: Upload release asset
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload '${{ github.event.release.tag_name }}' tabctl-${{ github.event.release.tag_name }}-${{ matrix.asset_suffix }}.* --clobber
+      - name: Upload packaged binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: tabctl-${{ matrix.asset_suffix }}
+          path: tabctl-${{ needs.resolve-tag.outputs.tag }}-${{ matrix.asset_suffix }}.*
 
-  # ── Build and upload browser extension ─────────────────────────────
   extension:
-    needs: validate
+    needs: [resolve-tag, validate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -166,19 +202,22 @@ jobs:
           mkdir -p artifacts
           (cd dist && zip -qr ../artifacts/tabctl-extension.zip extension)
           shasum -a 256 artifacts/tabctl-extension.zip > artifacts/tabctl-extension.zip.sha256
-      - name: Upload extension assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload '${{ github.event.release.tag_name }}' artifacts/tabctl-extension.zip artifacts/tabctl-extension.zip.sha256 --clobber
+      - name: Upload extension artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tabctl-extension
+          path: |
+            artifacts/tabctl-extension.zip
+            artifacts/tabctl-extension.zip.sha256
 
-  # ── Publish to npm (secondary distribution channel) ────────────────
-  npm-publish:
-    needs: [validate, build, extension]
+  npm_publish:
+    needs: [resolve-tag, validate, build, extension]
     runs-on: ubuntu-latest
-    # Set to false to skip npm publish; useful during Rust migration
     if: ${{ vars.PUBLISH_NPM != 'false' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
@@ -208,18 +247,40 @@ jobs:
         env:
           TABCTL_VERSION_MODE: release
 
-      - name: Sync platform package version
-        run: |
-          node -e "
-            const pkg = require('./package.json');
-            const win = require('./packages/win32-x64/package.json');
-            win.version = pkg.version;
-            require('fs').writeFileSync('./packages/win32-x64/package.json', JSON.stringify(win, null, 2) + '\n');
-          "
-
       - name: Publish tabctl-win32-x64
         run: npm publish --provenance --access public --tag '${{ needs.validate.outputs.dist_tag }}'
         working-directory: packages/win32-x64
 
       - name: Publish tabctl
         run: npm publish --provenance --access public --tag '${{ needs.validate.outputs.dist_tag }}'
+
+  create-release:
+    needs: [resolve-tag, validate, build, extension, npm_publish]
+    if: ${{ always() && needs.validate.result == 'success' && needs.build.result == 'success' && needs.extension.result == 'success' && (needs.npm_publish.result == 'success' || needs.npm_publish.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ needs.resolve-tag.outputs.tag }}
+          IS_PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+        shell: bash
+        run: |
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            gh release upload "${TAG_NAME}" artifacts/* --clobber
+            exit 0
+          fi
+          prerelease_flag=()
+          if [ "${IS_PRERELEASE}" = "true" ]; then
+            prerelease_flag+=(--prerelease)
+          fi
+          gh release create "${TAG_NAME}" \
+            --title "${TAG_NAME}" \
+            --generate-notes \
+            "${prerelease_flag[@]}" \
+            artifacts/*

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,70 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/release-v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Fetch tags
+        run: git fetch --force --tags origin
+
+      - name: Resolve release tag
+        id: resolve
+        shell: bash
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          tag="v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag if needed
+        id: tag
+        env:
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        shell: bash
+        run: |
+          if git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG_NAME}" -m "Release ${TAG_NAME}"
+          git push origin "${TAG_NAME}"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.resolve.outputs.tag }}
+        shell: bash
+        run: GH_PAGER="" gh workflow run release.yml --ref main -f tag="${TAG_NAME}"
+
+      - name: Summarize
+        run: |
+          echo "### Tag release" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| PR | #${{ github.event.pull_request.number }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`${{ steps.resolve.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tag | \`${{ steps.resolve.outputs.tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tag created in this run | ${{ steps.tag.outputs.created }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -369,8 +369,14 @@ Pre-release staging flow:
 - `bump:rc` promotes alpha to `x.y.z-rc.1` (or increments RC)
 - `bump:stable` drops the prerelease suffix for final stable publish
 
-Release publishing (`.github/workflows/publish.yml`) enforces:
+Release automation:
+- Run the **Prepare Release** workflow to choose or auto-detect the next version and open a release PR.
+- When that PR merges, **Tag Release** creates `v<version>` and dispatches **Release**.
+- The root `package.json` version and `optionalDependencies.tabctl-win32-x64` are kept in sync by `scripts/bump-version.js`.
+
+Release publishing (`.github/workflows/release.yml`) supports both tag pushes and explicit workflow dispatch, and enforces:
 - Git tag must match `package.json` version (`v<version>`)
+- `package.json.optionalDependencies["tabctl-win32-x64"]` must match `package.json` version
 - prerelease tags publish to `alpha`/`rc`; stable publishes to `latest`
 - `npm run build` and `npm test` must pass before publish
 - release assets include `tabctl-extension.zip` plus `tabctl-extension.zip.sha256`

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -4,10 +4,12 @@
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("node:child_process");
+const { bump, formatVersion, parseVersion } = require("./versioning");
 
 const root = path.resolve(__dirname, "..");
 const pkgPath = path.join(root, "package.json");
 const winPkgPath = path.join(root, "packages", "win32-x64", "package.json");
+const winPackageName = "tabctl-win32-x64";
 const cargoPackagePaths = [
   path.join(root, "rust", "crates", "shared", "Cargo.toml"),
   path.join(root, "rust", "crates", "host", "Cargo.toml"),
@@ -22,6 +24,11 @@ function readPackage() {
 
 function writePackage(pkg) {
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf8");
+}
+
+function syncOptionalDependencyVersion(pkg, dependencyName, version) {
+  pkg.optionalDependencies = pkg.optionalDependencies || {};
+  pkg.optionalDependencies[dependencyName] = version;
 }
 
 function syncJsonPackageVersion(filePath, version) {
@@ -43,79 +50,12 @@ function syncCargoPackageVersion(filePath, version) {
   fs.writeFileSync(filePath, next, "utf8");
 }
 
-function parseVersion(version) {
-  const match = String(version).trim().match(/^(\d+)\.(\d+)\.(\d+)(?:-(alpha|rc)\.(\d+))?(?:\+.*)?$/);
-  if (!match) {
-    throw new Error(`Invalid version: ${version}`);
-  }
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-    prereleaseTag: match[4] || null,
-    prereleaseNumber: match[5] ? Number(match[5]) : null,
-  };
-}
-
-function formatVersion(parts) {
-  const base = `${parts.major}.${parts.minor}.${parts.patch}`;
-  if (!parts.prereleaseTag) return base;
-  const num = Number.isInteger(parts.prereleaseNumber) ? parts.prereleaseNumber : 1;
-  return `${base}-${parts.prereleaseTag}.${num}`;
-}
-
-function bump(current, kind) {
-  const next = { ...current };
-  if (kind === "major") {
-    next.major += 1;
-    next.minor = 0;
-    next.patch = 0;
-    next.prereleaseTag = null;
-    next.prereleaseNumber = null;
-  } else if (kind === "minor") {
-    next.minor += 1;
-    next.patch = 0;
-    next.prereleaseTag = null;
-    next.prereleaseNumber = null;
-  } else if (kind === "patch") {
-    next.patch += 1;
-    next.prereleaseTag = null;
-    next.prereleaseNumber = null;
-  } else if (kind === "alpha") {
-    if (next.prereleaseTag === "alpha") {
-      next.prereleaseNumber += 1;
-    } else if (next.prereleaseTag === "rc") {
-      throw new Error("Cannot bump alpha from an rc prerelease");
-    } else {
-      next.patch += 1;
-      next.prereleaseTag = "alpha";
-      next.prereleaseNumber = 1;
-    }
-  } else if (kind === "rc") {
-    if (next.prereleaseTag === "rc") {
-      next.prereleaseNumber += 1;
-    } else if (next.prereleaseTag === "alpha") {
-      next.prereleaseTag = "rc";
-      next.prereleaseNumber = 1;
-    } else {
-      next.patch += 1;
-      next.prereleaseTag = "rc";
-      next.prereleaseNumber = 1;
-    }
-  } else if (kind === "stable") {
-    next.prereleaseTag = null;
-    next.prereleaseNumber = null;
-  } else {
-    throw new Error(`Unknown bump kind: ${kind}`);
-  }
-  return next;
-}
-
 const kind = process.argv[2] || "patch";
 const pkg = readPackage();
 const current = parseVersion(pkg.version || "0.0.0");
 const next = bump(current, kind);
 pkg.version = formatVersion(next);
+syncOptionalDependencyVersion(pkg, winPackageName, pkg.version);
 writePackage(pkg);
 syncJsonPackageVersion(winPkgPath, pkg.version);
 for (const cargoPath of cargoPackagePaths) {

--- a/scripts/versioning.js
+++ b/scripts/versioning.js
@@ -1,0 +1,100 @@
+"use strict";
+
+function parseVersion(version) {
+  const match = String(version).trim().match(/^(\d+)\.(\d+)\.(\d+)(?:-(alpha|rc)\.(\d+))?(?:\+.*)?$/);
+  if (!match) {
+    throw new Error(`Invalid version: ${version}`);
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prereleaseTag: match[4] || null,
+    prereleaseNumber: match[5] ? Number(match[5]) : null,
+  };
+}
+
+function formatVersion(parts) {
+  const base = `${parts.major}.${parts.minor}.${parts.patch}`;
+  if (!parts.prereleaseTag) return base;
+  const num = Number.isInteger(parts.prereleaseNumber) ? parts.prereleaseNumber : 1;
+  return `${base}-${parts.prereleaseTag}.${num}`;
+}
+
+function bump(current, kind) {
+  const next = { ...current };
+  if (kind === "major") {
+    next.major += 1;
+    next.minor = 0;
+    next.patch = 0;
+    next.prereleaseTag = null;
+    next.prereleaseNumber = null;
+  } else if (kind === "minor") {
+    next.minor += 1;
+    next.patch = 0;
+    next.prereleaseTag = null;
+    next.prereleaseNumber = null;
+  } else if (kind === "patch") {
+    next.patch += 1;
+    next.prereleaseTag = null;
+    next.prereleaseNumber = null;
+  } else if (kind === "alpha") {
+    if (next.prereleaseTag === "alpha") {
+      next.prereleaseNumber += 1;
+    } else if (next.prereleaseTag === "rc") {
+      throw new Error("Cannot bump alpha from an rc prerelease");
+    } else {
+      next.patch += 1;
+      next.prereleaseTag = "alpha";
+      next.prereleaseNumber = 1;
+    }
+  } else if (kind === "rc") {
+    if (next.prereleaseTag === "rc") {
+      next.prereleaseNumber += 1;
+    } else if (next.prereleaseTag === "alpha") {
+      next.prereleaseTag = "rc";
+      next.prereleaseNumber = 1;
+    } else {
+      next.patch += 1;
+      next.prereleaseTag = "rc";
+      next.prereleaseNumber = 1;
+    }
+  } else if (kind === "stable") {
+    next.prereleaseTag = null;
+    next.prereleaseNumber = null;
+  } else {
+    throw new Error(`Unknown bump kind: ${kind}`);
+  }
+  return next;
+}
+
+function detectConventionalCommitBump(commitsText) {
+  const text = String(commitsText || "");
+  if (/(^|\n)[a-z]+(?:\([^)]+\))?!:/m.test(text) || /BREAKING CHANGE:/m.test(text)) {
+    return "major";
+  }
+  if (/(^|\n)feat(?:\([^)]+\))?:/m.test(text)) {
+    return "minor";
+  }
+  return "patch";
+}
+
+function recommendReleaseBump(currentVersion, commitsText) {
+  const current = typeof currentVersion === "string" ? parseVersion(currentVersion) : currentVersion;
+  if (current.prereleaseTag === "alpha") {
+    return { bump: "rc", reason: "current version is an alpha prerelease" };
+  }
+  if (current.prereleaseTag === "rc") {
+    return { bump: "stable", reason: "current version is a release candidate" };
+  }
+  const detected = detectConventionalCommitBump(commitsText);
+  return { bump: detected, reason: `detected ${detected} bump from conventional commits` };
+}
+
+module.exports = {
+  bump,
+  detectConventionalCommitBump,
+  formatVersion,
+  parseVersion,
+  recommendReleaseBump,
+};

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -11,11 +11,23 @@ Automate the full release cycle: version bump → test → build → commit → 
 
 Direct pushes to `main` are blocked by a branch ruleset. All releases go through a PR.
 
+## Preferred GitHub Actions flow
+
+The default release path is now GitHub Actions-driven:
+
+1. Run the **Prepare Release** workflow (`.github/workflows/prepare-release.yml`)
+2. Review/approve the generated release PR
+3. Let GitHub auto-merge the PR after checks pass
+4. The **Tag Release** workflow (`.github/workflows/tag-release.yml`) tags the merge commit
+5. The **Release** workflow (`.github/workflows/release.yml`) runs for that tag and publishes the artifacts
+
+The manual flow below remains the fallback/operator path when you need to release outside GitHub Actions.
+
 ## Version files
 
 All version files must stay in sync. The `scripts/bump-version.js` script (exposed via `npm run bump:*`) updates all of them in one command. The release workflow (`release.yml`) validates they match:
 
-1. `package.json` — root package version (single source of truth)
+1. `package.json` — root package version (single source of truth) and `optionalDependencies.tabctl-win32-x64`
 2. `package-lock.json` — lockfile
 3. `packages/win32-x64/package.json` — Windows platform package
 4. `rust/crates/tabctl/Cargo.toml` — main Rust binary


### PR DESCRIPTION
## What
- add a `Prepare Release` workflow that recommends or accepts a bump, creates a release branch, opens a PR, and enables auto-merge
- add a `Tag Release` workflow and refactor `Release` so merged release PRs tag the version and explicitly dispatch the publish workflow
- keep release manifests aligned by syncing `optionalDependencies.tabctl-win32-x64` and validating it alongside all versioned manifests
- update release docs to describe the new GitHub Actions flow

## Why
- automate the release path end-to-end in GitHub Actions instead of relying on manual bump, PR, tag, and release steps
- use an explicit workflow dispatch handoff after tagging, matching the proven `copilot-token-cost` pattern

## Testing
- `npm test`
- `npm run test:integration`
- YAML parse checks for `.github/workflows/prepare-release.yml`, `.github/workflows/tag-release.yml`, and `.github/workflows/release.yml`
- versioning helper smoke checks plus a live tabctl smoke test (`profile-show`, `ping`, open test window, screenshot capture, verify grouped tabs, close test tabs)
