### PR TITLE
fix(windows): normalize native host pipe identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,19 @@ npm test                          # unit tests
 Rust-only validation:
 ```bash
 npm run rust:verify
+npm run check:targets  # local cross-target cfg/type check
 ```
+
+On macOS, `npm run check:targets` and the pre-push hook can use Zig for the C
+cross-compiler needed by `libsqlite3-sys`:
+
+```bash
+brew install zig
+```
+
+The script auto-detects Zig outside CI and wires the Linux/Windows C compiler
+environment for the check. If Windows cross-checks still report a missing
+`llvm-lib`, install or relink Homebrew `llvm@21`.
 
 Browser-backed integration harness (requires built dist artifacts and Chrome):
 ```bash

--- a/README.md
+++ b/README.md
@@ -234,21 +234,24 @@ See [CLI.md](CLI.md#configuration) for full details.
 - Undo log: `<dataDir>/undo.jsonl` (default: `~/.local/state/tabctl/undo.jsonl`)
 - Browser-state history DB: `<dataDir>/state.db` (default: `~/.local/state/tabctl/state.db`)
 - Profile registry: `<configDir>/profiles.json`
-- WSL TCP port file: `<dataDir>/tcp-port` (written by the Windows host)
+- Windows pipe endpoint file: `<dataDir>/pipe-endpoint`
 
 ## Windows + WSL transport
 
-On Windows, the host exposes a dual endpoint model:
+On Windows, the host exposes a named-pipe endpoint model:
 - Windows native clients use a named pipe endpoint (`\\.\pipe\tabctl-<hash>`).
-- WSL/Linux clients use `tcp://127.0.0.1:<port>`, with the host writing `<dataDir>/tcp-port`.
+- WSL/Linux clients use a Windows named-pipe bridge; the Windows host publishes `<dataDir>/pipe-endpoint`, and the WSL CLI relays through `powershell.exe`.
 
 WSL endpoint discovery (CLI):
-1. `TABCTL_SOCKET` (explicit endpoint); if this is a pipe endpoint in WSL, CLI still prefers discovered TCP.
-2. `TABCTL_TCP_PORT` (forces `127.0.0.1:<port>`).
-3. `tcp-port` file discovery from resolved data dir (and equivalent `/mnt/c/Users/*/.../tabctl/.../tcp-port` locations).
-4. Fallback: `tcp://127.0.0.1:38000`.
+1. `TABCTL_SOCKET` (explicit endpoint).
+2. `pipe-endpoint` file discovery from resolved data dir (and equivalent `/mnt/c/Users/*/.../tabctl/.../pipe-endpoint` locations).
 
-Relevant knobs: `TABCTL_SOCKET`, `TABCTL_TCP_PORT`, `TABCTL_PROFILE`, `TABCTL_DATA_DIR`, `TABCTL_STATE_DIR`, `TABCTL_CONFIG_DIR`.
+WSL named-pipe mode:
+- This is the default WSL transport now.
+- The CLI discovers the pipe endpoint from `<dataDir>/pipe-endpoint` (including the mirrored `/mnt/c/Users/*/...` candidate paths used for other WSL bridge files).
+- TCP is disabled for the WSL transport path.
+
+Relevant knobs: `TABCTL_SOCKET`, `TABCTL_PROFILE`, `TABCTL_DATA_DIR`, `TABCTL_STATE_DIR`, `TABCTL_CONFIG_DIR`.
 
 ## Troubleshooting (setup/ping on Windows + WSL)
 
@@ -260,7 +263,7 @@ Relevant knobs: `TABCTL_SOCKET`, `TABCTL_TCP_PORT`, `TABCTL_PROFILE`, `TABCTL_DA
 - Disable runtime sync entirely with `TABCTL_AUTO_SYNC_MODE=off`.
 - `tabctl ping --json` is the canonical runtime version check (`versionsInSync`, `hostBaseVersion`, `baseVersion`).
 - Version metadata is intentionally health-only: regular GraphQL payloads do not include version fields unless you explicitly query health surfaces.
-- `tabctl ping` returns connect errors (`ENOENT`, `ECONNREFUSED`, timeout): ensure extension is loaded and active, rerun `tabctl setup`, and in WSL verify `TABCTL_TCP_PORT` or `<dataDir>/tcp-port` matches a listening localhost port.
+- `tabctl ping` returns connect errors (`ENOENT`, `ECONNREFUSED`, timeout): ensure extension is loaded and active, rerun `tabctl setup`, and in WSL verify the profile data dir contains a current `pipe-endpoint` file.
 - `tabctl doctor --fix --json` includes per-profile connectivity diagnostics in `data.profiles[].connectivity`; if ping remains unhealthy after local repairs, follow `manualSteps`.
 
 Local release-like sync test recipe:
@@ -323,8 +326,7 @@ Policy is shared across all profiles.
 ## Security
 - The native host is locked to your extension ID.
 - All data stays local; no external API keys are used.
-- TCP connections (used for WSL ↔ Windows communication) are secured with a per-session auth token. The host generates a random token on startup; the CLI reads it automatically. See [CLI.md](CLI.md) for details.
-- TCP transport is available on all platforms via `TABCTL_HOST_TCP=1` (host) and `TABCTL_TRANSPORT=tcp` (CLI). All TCP connections are authenticated. See [CLI.md](CLI.md) for details.
+- WSL ↔ Windows communication uses a local named-pipe bridge via `powershell.exe`; no TCP fallback is used on that path.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ Relevant knobs: `TABCTL_SOCKET`, `TABCTL_PROFILE`, `TABCTL_DATA_DIR`, `TABCTL_ST
 - Runtime command runs can auto-sync extension files when host/extension versions drift; rerun `tabctl query 'mutation { reloadExtension { reloading } }'` if the browser does not pick up changes immediately.
 - For local release-like testing while developing, force runtime sync behavior with `TABCTL_AUTO_SYNC_MODE=release-like`.
 - Disable runtime sync entirely with `TABCTL_AUTO_SYNC_MODE=off`.
-- `tabctl ping --json` is the canonical runtime version check (`versionsInSync`, `hostBaseVersion`, `baseVersion`).
-- Version metadata is intentionally health-only: regular GraphQL payloads do not include version fields unless you explicitly query health surfaces.
+- `tabctl ping --json` is a host connectivity/health check; use it to confirm the native host is reachable and healthy.
+- Version metadata is intentionally health-only: regular GraphQL payloads do not include version fields unless you explicitly query health surfaces, which may expose fields such as `versionsInSync`, `hostBaseVersion`, and `baseVersion`.
 - `tabctl ping` returns connect errors (`ENOENT`, `ECONNREFUSED`, timeout): ensure extension is loaded and active, rerun `tabctl setup`, and in WSL verify the profile data dir contains a current `pipe-endpoint` file.
 - `tabctl doctor --fix --json` includes per-profile connectivity diagnostics in `data.profiles[].connectivity`; if ping remains unhealthy after local repairs, follow `manualSteps`.
 
@@ -274,7 +274,7 @@ tabctl setup --browser edge --extension-id <extension-id> --release-tag v0.5.2
 # 2) Run the current binary with forced release-like auto-sync
 TABCTL_AUTO_SYNC_MODE=release-like cargo run --manifest-path rust/Cargo.toml -p tabctl -- query '{ tabs { total } }'
 
-# 3) Verify host/extension base versions are back in sync
+# 3) Verify host connectivity/health after auto-sync
 tabctl ping --json
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.3",
+  "version": "0.6.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.3",
+      "version": "0.6.0-rc.4",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"
@@ -24,7 +24,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.3"
+        "tabctl-win32-x64": "0.6.0-rc.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -569,17 +569,7 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "version": "0.6.0-rc.3",
-      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.3.tgz",
-      "integrity": "sha512-mrcMMT6bH1Y00gvTYYtfA4BOgFVNTwh8DBlNSNSK7RAHGqFP2/kZtmiyYX47bacuwxGOzk6TwjL1BP9OZjPk1A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.3",
+  "version": "0.6.0-rc.4",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -52,7 +52,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.3"
+    "tabctl-win32-x64": "0.6.0-rc.4"
   },
   "dependencies": {
     "normalize-url": "^8.1.1"

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.3",
+  "version": "0.6.0-rc.4",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -924,6 +924,7 @@ version = "0.6.0-rc.3"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
  "url-normalize",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -25,15 +25,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -92,15 +92,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -125,9 +125,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -141,18 +141,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -162,15 +162,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -459,12 +459,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -472,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -485,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -499,15 +500,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -519,15 +520,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -551,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -561,12 +562,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -579,9 +580,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "juniper"
@@ -616,15 +617,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -642,15 +643,15 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -694,15 +695,15 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -782,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -812,9 +813,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -881,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "clap",
  "dirs",
@@ -897,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "indexmap",
  "juniper",
@@ -906,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "getrandom",
  "rusqlite",
@@ -920,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -970,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -980,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1213,15 +1214,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1230,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1242,18 +1243,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1263,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1274,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1285,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.4"

--- a/rust/crates/graphql/src/schema.rs
+++ b/rust/crates/graphql/src/schema.rs
@@ -96,10 +96,10 @@ impl Query {
                 });
             }
             TabOrderBy::TitleAsc => {
-                tabs.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
+                tabs.sort_by_key(|tab| tab.title.to_lowercase());
             }
             TabOrderBy::TitleDesc => {
-                tabs.sort_by(|a, b| b.title.to_lowercase().cmp(&a.title.to_lowercase()));
+                tabs.sort_by_key(|tab| std::cmp::Reverse(tab.title.to_lowercase()));
             }
             TabOrderBy::IndexAsc => {} // default order from snapshot
         }

--- a/rust/crates/host/src/host_impl.rs
+++ b/rust/crates/host/src/host_impl.rs
@@ -19,9 +19,10 @@ use protocol::{
     MAX_NATIVE_MESSAGE_BYTES,
 };
 #[cfg(test)]
+use runtime::resolve_config;
+#[cfg(all(test, not(windows)))]
 use runtime::{
-    generate_and_write_auth_token, resolve_config, AUTH_TOKEN_FILENAME, AUTH_TOKEN_LENGTH,
-    TCP_PORT_FILENAME,
+    generate_and_write_auth_token, AUTH_TOKEN_FILENAME, AUTH_TOKEN_LENGTH, TCP_PORT_FILENAME,
 };
 #[cfg(test)]
 use serde_json::{Map, Value};
@@ -35,8 +36,10 @@ use std::io;
 use std::path::PathBuf;
 #[cfg(test)]
 use std::sync::Arc;
+#[cfg(all(test, not(windows)))]
+use tabctl_shared::ResponseEnvelope;
 #[cfg(test)]
-use tabctl_shared::{NativeMessage, ProtocolError, RequestEnvelope, ResponseEnvelope};
+use tabctl_shared::{NativeMessage, ProtocolError, RequestEnvelope};
 #[cfg(test)]
 use undo::{append_undo_record, read_undo_records};
 #[cfg(test)]
@@ -495,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn ping_response_preserves_runtime_extension_id() {
+    fn ping_is_served_locally_with_native_channel_flag() {
         let mut state = HostState::new(temp_undo_path(), temp_focus_db_path(), None);
         let effects = state.handle_cli_request(
             5,
@@ -506,37 +509,8 @@ mod tests {
                 auth_token: None,
             },
         );
-        let HostEffect::SendNative(native_req) = &effects[0] else {
-            panic!("expected ping forward");
-        };
-        assert_eq!(native_req.id, "req-ping");
-
-        let native_resp = NativeMessage {
-            id: native_req.id.clone(),
-            action: None,
-            ok: Some(true),
-            progress: None,
-            params: Some(Value::Object(Map::new())),
-            data: Some(Value::Object(Map::from_iter([
-                (
-                    "runtimeId".to_string(),
-                    Value::String("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string()),
-                ),
-                ("version".to_string(), Value::String("1.2.3".to_string())),
-                (
-                    "baseVersion".to_string(),
-                    Value::String("1.2.3".to_string()),
-                ),
-                (
-                    "component".to_string(),
-                    Value::String("extension".to_string()),
-                ),
-            ]))),
-            error: None,
-        };
-        let effects = state.handle_native_message(native_resp);
         let HostEffect::Respond { payload, .. } = &effects[0] else {
-            panic!("expected ping response");
+            panic!("expected local ping response");
         };
         assert_eq!(payload.request_id.as_deref(), Some("req-ping"));
         assert_eq!(payload.component.as_deref(), Some("host"));
@@ -546,26 +520,21 @@ mod tests {
             .as_ref()
             .and_then(|v| v.as_object())
             .expect("response data");
-        assert_eq!(
-            data.get("runtimeId").and_then(|v| v.as_str()),
-            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-        );
-        assert_eq!(data.get("version").and_then(|v| v.as_str()), Some("1.2.3"));
-        assert_eq!(
-            data.get("component").and_then(|v| v.as_str()),
-            Some("extension")
-        );
+        assert_eq!(data.get("component").and_then(|v| v.as_str()), Some("host"));
         assert_eq!(
             data.get("hostVersion").and_then(|v| v.as_str()),
             Some(host_version())
         );
-        assert!(data.get("hostBaseVersion").is_some());
+        assert_eq!(
+            data.get("nativeChannelAvailable").and_then(|v| v.as_bool()),
+            Some(true)
+        );
         assert_eq!(
             data.get("versionsInSync").and_then(|v| v.as_bool()),
             Some(false)
         );
-        assert!(data.get("extensionVersion").is_none());
-        assert!(data.get("extensionComponent").is_none());
+        assert!(data.get("runtimeId").is_none());
+        assert!(data.get("version").is_none());
         assert!(payload.ok);
     }
 
@@ -669,10 +638,9 @@ mod tests {
         );
     }
 
-    // TCP bridge tests — run on all platforms to validate bridge fundamentals
-    // without requiring WSL. The host TCP listener (Windows) and the CLI TCP
-    // discovery path (WSL) both rely on a simple port file + loopback socket.
+    // TCP bridge tests remain relevant for the Unix opt-in TCP path.
 
+    #[cfg(not(windows))]
     #[test]
     fn tcp_port_file_format_roundtrip() {
         let tmp = std::env::temp_dir().join(format!("tabctl-host-tcp-{}", now_ms()));
@@ -685,6 +653,7 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn tcp_listener_binds_loopback_and_accepts_connection() {
         use std::io::{Read, Write};
@@ -706,6 +675,7 @@ mod tests {
         assert_eq!(buf, b"ping");
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_auth_token_file_generation() {
         let tmp = std::env::temp_dir().join(format!("tabctl-host-auth-{}", now_ms()));
@@ -731,6 +701,7 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn tcp_auth_token_rejects_wrong_token() {
         let undo_path = temp_undo_path();
@@ -781,6 +752,7 @@ mod tests {
         let _ = std::fs::remove_file(undo_path);
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn tcp_auth_token_accepts_correct_token() {
         let undo_path = temp_undo_path();
@@ -798,14 +770,16 @@ mod tests {
         let provided = request.auth_token.as_deref().unwrap_or("");
         assert_eq!(provided, expected_token.as_str());
 
-        // With correct token, request should be forwarded normally
+        // With correct token, request should be served normally
         let effects = state.handle_cli_request(101, request);
-        let HostEffect::SendNative(native) = &effects[0] else {
-            panic!("expected ping to be forwarded to extension");
+        let HostEffect::Respond { payload, .. } = &effects[0] else {
+            panic!("expected local ping response");
         };
-        assert_eq!(native.id, "req-good-auth");
+        assert!(payload.ok);
+        assert_eq!(payload.request_id.as_deref(), Some("req-good-auth"));
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn tcp_auth_token_missing_token_rejected() {
         let expected_token = Arc::new("correct-token-abc123".to_string());
@@ -839,10 +813,11 @@ mod tests {
         assert!(expected_auth_token.is_none());
 
         let effects = state.handle_cli_request(102, request);
-        let HostEffect::SendNative(native) = &effects[0] else {
-            panic!("expected ping forward without auth check");
+        let HostEffect::Respond { payload, .. } = &effects[0] else {
+            panic!("expected local ping without auth check");
         };
-        assert_eq!(native.id, "req-no-tcp");
+        assert!(payload.ok);
+        assert_eq!(payload.request_id.as_deref(), Some("req-no-tcp"));
     }
 
     #[test]

--- a/rust/crates/host/src/host_impl/dispatch.rs
+++ b/rust/crates/host/src/host_impl/dispatch.rs
@@ -3,16 +3,18 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 use tabctl_shared::{ProtocolError, RequestEnvelope, ResponseEnvelope};
 
 use super::protocol::{
-    base_response, host_version, log_line, read_native_message, write_native_message,
+    base_response, host_version, log_line, read_native_message, trace_line, write_native_message,
 };
 use super::state::{HostEffect, HostState};
 
 const MAX_RESPONSE_BYTES: usize = 20 * 1024 * 1024;
 
 pub(super) type ClientWriter = Arc<Mutex<Box<dyn Write + Send>>>;
+pub(super) type NativeWriter = Arc<Mutex<Box<dyn Write + Send>>>;
 pub(super) type Clients = Arc<Mutex<HashMap<u64, ClientWriter>>>;
 
 fn send_response(stream: &ClientWriter, payload: &ResponseEnvelope) {
@@ -37,42 +39,111 @@ fn send_response(stream: &ClientWriter, payload: &ResponseEnvelope) {
     }
 
     if let Ok(mut guard) = stream.lock() {
-        let _ = writeln!(guard, "{serialized}");
-        let _ = guard.flush();
+        if let Err(err) = writeln!(guard, "{serialized}") {
+            log_line(&format!("client write failed: {err}"));
+            return;
+        }
+        if let Err(err) = guard.flush() {
+            log_line(&format!("client flush failed: {err}"));
+        }
     }
 }
 
-fn dispatch_effect(effect: HostEffect, clients: &Clients, native_out: &Arc<Mutex<io::Stdout>>) {
+fn dispatch_effect(
+    effect: HostEffect,
+    state: &Arc<Mutex<HostState>>,
+    clients: &Clients,
+    native_out: &NativeWriter,
+) {
     match effect {
         HostEffect::SendNative(message) => {
+            trace_line(&format!(
+                "send native: id={} action={}",
+                message.id,
+                message.action.as_deref().unwrap_or("<none>")
+            ));
             if let Ok(mut out) = native_out.lock() {
                 if let Err(err) = write_native_message(&mut *out, &message) {
                     log_line(&format!("native write failed: {err}"));
+                    let follow_up = {
+                        let Ok(mut guard) = state.lock() else {
+                            return;
+                        };
+                        guard.fail_pending_request(
+                            &message.id,
+                            "Failed to write to native browser channel".to_string(),
+                            Some(err.to_string()),
+                        )
+                    };
+                    if let Some(effect) = follow_up {
+                        dispatch_effect(effect, state, clients, native_out);
+                    }
                 }
             }
         }
         HostEffect::Respond { client_id, payload } => {
+            trace_line(&format!(
+                "respond client: client_id={} request_id={} action={} ok={} progress={}",
+                client_id,
+                payload.request_id.as_deref().unwrap_or("<none>"),
+                payload.action.as_deref().unwrap_or("<none>"),
+                payload.ok,
+                payload.progress.unwrap_or(false)
+            ));
+            let is_final = !payload.progress.unwrap_or(false);
             let stream = clients
                 .lock()
                 .ok()
                 .and_then(|map| map.get(&client_id).cloned());
             if let Some(stream) = stream {
                 send_response(&stream, &payload);
+                if is_final {
+                    let _ = clients.lock().map(|mut map| map.remove(&client_id));
+                }
             }
         }
     }
 }
 
-pub(super) fn start_native_reader(
+pub(super) fn start_request_timeout_reaper(
     state: Arc<Mutex<HostState>>,
     clients: Clients,
-    native_out: Arc<Mutex<io::Stdout>>,
+    native_out: NativeWriter,
 ) {
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_millis(250));
+        let effects = {
+            let Ok(mut guard) = state.lock() else {
+                continue;
+            };
+            guard.collect_timed_out_requests()
+        };
+        for effect in effects {
+            dispatch_effect(effect, &state, &clients, &native_out);
+        }
+    });
+}
+
+fn start_native_reader_with<R>(
+    mut reader: R,
+    state: Arc<Mutex<HostState>>,
+    clients: Clients,
+    native_out: NativeWriter,
+    exit_on_eof: bool,
+) where
+    R: Read + Send + 'static,
+{
     thread::spawn(move || {
-        let mut stdin = io::stdin().lock();
         loop {
-            match read_native_message(&mut stdin) {
+            match read_native_message(&mut reader) {
                 Ok(Some(message)) => {
+                    trace_line(&format!(
+                        "recv native: id={} ok={} progress={} action={}",
+                        message.id,
+                        message.ok.unwrap_or(false),
+                        message.progress.unwrap_or(false),
+                        message.action.as_deref().unwrap_or("<none>")
+                    ));
                     let effects = {
                         let Ok(mut guard) = state.lock() else {
                             continue;
@@ -80,7 +151,7 @@ pub(super) fn start_native_reader(
                         guard.handle_native_message(message)
                     };
                     for effect in effects {
-                        dispatch_effect(effect, &clients, &native_out);
+                        dispatch_effect(effect, &state, &clients, &native_out);
                     }
                 }
                 Ok(None) => break,
@@ -90,8 +161,18 @@ pub(super) fn start_native_reader(
                 }
             }
         }
-        process::exit(0);
+        if exit_on_eof {
+            process::exit(0);
+        }
     });
+}
+
+pub(super) fn start_native_reader(
+    state: Arc<Mutex<HostState>>,
+    clients: Clients,
+    native_out: NativeWriter,
+) {
+    start_native_reader_with(io::stdin(), state, clients, native_out, true);
 }
 
 pub(super) fn handle_client(
@@ -99,15 +180,24 @@ pub(super) fn handle_client(
     reader: Box<dyn Read + Send>,
     state: Arc<Mutex<HostState>>,
     clients: Clients,
-    native_out: Arc<Mutex<io::Stdout>>,
+    native_out: NativeWriter,
     expected_auth_token: Option<Arc<String>>,
+    close_after_first_request: bool,
 ) {
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
+    let mut saw_request = false;
 
     loop {
         line.clear();
-        let read = reader.read_line(&mut line).unwrap_or(0);
+        let read = match reader.read_line(&mut line) {
+            Ok(read) => read,
+            Err(err) => {
+                log_line(&format!("client read error: {err}"));
+                0
+            }
+        };
+        trace_line(&format!("client read: client_id={client_id} bytes={read}"));
         if read == 0 {
             break;
         }
@@ -116,6 +206,10 @@ pub(super) fn handle_client(
             continue;
         }
 
+        trace_line(&format!(
+            "client request: client_id={client_id} line={trimmed}"
+        ));
+        saw_request = true;
         let request = serde_json::from_str::<RequestEnvelope>(trimmed);
         let effects = match request {
             Ok(request) => {
@@ -175,9 +269,333 @@ pub(super) fn handle_client(
         };
 
         for effect in effects {
-            dispatch_effect(effect, &clients, &native_out);
+            dispatch_effect(effect, &state, &clients, &native_out);
+        }
+
+        if close_after_first_request {
+            break;
         }
     }
 
-    let _ = clients.lock().map(|mut map| map.remove(&client_id));
+    if !saw_request {
+        let _ = clients.lock().map(|mut map| map.remove(&client_id));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host_impl::protocol::read_native_message;
+    use std::io::{Cursor, Result as IoResult};
+    use std::net::{TcpListener, TcpStream};
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+    use tabctl_shared::{NativeMessage, ResponseEnvelope};
+
+    struct SharedBufferWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBufferWriter {
+        fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+            if let Ok(mut inner) = self.0.lock() {
+                inner.extend_from_slice(buf);
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    fn test_state(native_channel_available: bool) -> Arc<Mutex<HostState>> {
+        Arc::new(Mutex::new(HostState::new_with_native_channel(
+            PathBuf::from("dispatch-test-undo.jsonl"),
+            PathBuf::from("dispatch-test-focus.json"),
+            None,
+            native_channel_available,
+        )))
+    }
+
+    fn native_sink() -> (NativeWriter, Arc<Mutex<Vec<u8>>>) {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let writer: NativeWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(sink.clone()))));
+        (writer, sink)
+    }
+
+    #[test]
+    fn handle_client_keeps_writer_registered_after_request_eof_for_async_response() {
+        let state = test_state(true);
+        let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let writer: ClientWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(sink))));
+        let client_id = 42;
+        clients.lock().unwrap().insert(client_id, writer);
+
+        let request = r#"{"id":"req-1","action":"snapshot","params":{}}"#;
+        let (native_out, _native_sink) = native_sink();
+        handle_client(
+            client_id,
+            Box::new(Cursor::new(format!("{request}\n").into_bytes())),
+            state,
+            clients.clone(),
+            native_out,
+            None,
+            false,
+        );
+
+        assert!(
+            clients.lock().unwrap().contains_key(&client_id),
+            "client writer should remain registered for async response delivery"
+        );
+    }
+
+    #[test]
+    fn handle_client_stops_after_first_request_when_requested() {
+        let state = test_state(true);
+        let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let writer: ClientWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(sink))));
+        let client_id = 43;
+        clients.lock().unwrap().insert(client_id, writer);
+
+        let first = r#"{"id":"req-43","action":"snapshot","params":{}}"#;
+        let second = r#"{"id":"req-44","action":"snapshot","params":{}}"#;
+        let (native_out, native_sink) = native_sink();
+        handle_client(
+            client_id,
+            Box::new(Cursor::new(format!("{first}\n{second}\n").into_bytes())),
+            state,
+            clients.clone(),
+            native_out,
+            None,
+            true,
+        );
+
+        let mut cursor = Cursor::new(native_sink.lock().unwrap().clone());
+        let native_request = read_native_message(&mut cursor)
+            .expect("decode first native request")
+            .expect("first native request exists");
+        assert_eq!(native_request.action.as_deref(), Some("p:snapshot"));
+        assert!(
+            read_native_message(&mut cursor)
+                .expect("decode remaining native requests")
+                .is_none(),
+            "close-after-first-request should stop before reading another request"
+        );
+        assert!(
+            clients.lock().unwrap().contains_key(&client_id),
+            "client writer should remain registered for async response delivery"
+        );
+    }
+
+    #[test]
+    fn handle_client_removes_writer_when_no_request_was_read() {
+        let state = test_state(true);
+        let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let writer: ClientWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(sink))));
+        let client_id = 7;
+        clients.lock().unwrap().insert(client_id, writer);
+
+        let (native_out, _native_sink) = native_sink();
+        handle_client(
+            client_id,
+            Box::new(Cursor::new(Vec::<u8>::new())),
+            state,
+            clients.clone(),
+            native_out,
+            None,
+            false,
+        );
+
+        assert!(
+            !clients.lock().unwrap().contains_key(&client_id),
+            "idle client without a request should be cleaned up"
+        );
+    }
+
+    #[test]
+    fn final_response_removes_client_after_write() {
+        let state = test_state(true);
+        let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let writer: ClientWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(sink.clone()))));
+        let client_id = 9;
+        clients.lock().unwrap().insert(client_id, writer);
+
+        let (native_out, _native_sink) = native_sink();
+        dispatch_effect(
+            HostEffect::Respond {
+                client_id,
+                payload: ResponseEnvelope {
+                    ok: true,
+                    action: Some("snapshot".to_string()),
+                    request_id: Some("req-9".to_string()),
+                    component: None,
+                    version: None,
+                    progress: None,
+                    data: Some(serde_json::json!({"ok": true})),
+                    error: None,
+                },
+            },
+            &state,
+            &clients,
+            &native_out,
+        );
+
+        assert!(!clients.lock().unwrap().contains_key(&client_id));
+        let output = String::from_utf8(sink.lock().unwrap().clone()).unwrap();
+        assert!(output.contains("\"requestId\":\"req-9\""));
+    }
+
+    #[test]
+    fn end_to_end_async_native_response_is_returned_to_client() {
+        let state = test_state(true);
+        let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let client_sink = Arc::new(Mutex::new(Vec::new()));
+        let client_writer: ClientWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(
+            client_sink.clone(),
+        ))));
+        let client_id = 15;
+        clients.lock().unwrap().insert(client_id, client_writer);
+
+        let (native_out, native_sink) = native_sink();
+        let request = r#"{"id":"req-15","action":"snapshot","params":{}}"#;
+        handle_client(
+            client_id,
+            Box::new(Cursor::new(format!("{request}\n").into_bytes())),
+            state.clone(),
+            clients.clone(),
+            native_out.clone(),
+            None,
+            false,
+        );
+
+        let native_bytes = native_sink.lock().unwrap().clone();
+        let native_request = read_native_message(&mut Cursor::new(native_bytes))
+            .expect("decode native request")
+            .expect("native request exists");
+        assert_eq!(native_request.action.as_deref(), Some("p:snapshot"));
+
+        let effects = state.lock().unwrap().handle_native_message(NativeMessage {
+            id: native_request.id,
+            action: Some("p:snapshot".to_string()),
+            ok: Some(true),
+            progress: None,
+            params: None,
+            data: Some(serde_json::json!({
+                "windows": [],
+                "generatedAt": 1700000000000_u64
+            })),
+            error: None,
+        });
+        for effect in effects {
+            dispatch_effect(effect, &state, &clients, &native_out);
+        }
+
+        let output = String::from_utf8(client_sink.lock().unwrap().clone()).unwrap();
+        assert!(
+            output.contains("\"ok\":true"),
+            "missing success response: {output}"
+        );
+        assert!(
+            output.contains("\"requestId\":\"req-15\""),
+            "missing request id in response: {output}"
+        );
+        assert!(
+            output.contains("\"action\":\"snapshot\""),
+            "missing action in response: {output}"
+        );
+        assert!(
+            !clients.lock().unwrap().contains_key(&client_id),
+            "client should be removed after final async response"
+        );
+    }
+
+    #[test]
+    fn native_reader_thread_returns_async_response_to_client_end_to_end() {
+        let state = test_state(true);
+        let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let client_sink = Arc::new(Mutex::new(Vec::new()));
+        let client_writer: ClientWriter = Arc::new(Mutex::new(Box::new(SharedBufferWriter(
+            client_sink.clone(),
+        ))));
+        let client_id = 21;
+        clients.lock().unwrap().insert(client_id, client_writer);
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind fake native listener");
+        let addr = listener.local_addr().expect("fake native addr");
+        let extension_side = TcpStream::connect(addr).expect("connect fake native client");
+        let (host_side, _) = listener.accept().expect("accept fake native host side");
+        let host_reader = host_side.try_clone().expect("clone fake native host side");
+        let native_out: NativeWriter = Arc::new(Mutex::new(Box::new(host_side)));
+
+        start_native_reader_with(
+            host_reader,
+            state.clone(),
+            clients.clone(),
+            native_out.clone(),
+            false,
+        );
+
+        let request = r#"{"id":"req-21","action":"snapshot","params":{}}"#;
+        handle_client(
+            client_id,
+            Box::new(Cursor::new(format!("{request}\n").into_bytes())),
+            state,
+            clients.clone(),
+            native_out,
+            None,
+            false,
+        );
+
+        let mut extension_reader = extension_side.try_clone().expect("clone extension stream");
+        let native_request = read_native_message(&mut extension_reader)
+            .expect("read native request")
+            .expect("native request exists");
+        assert_eq!(native_request.action.as_deref(), Some("p:snapshot"));
+
+        let mut extension_writer = extension_side;
+        write_native_message(
+            &mut extension_writer,
+            &NativeMessage {
+                id: native_request.id,
+                action: Some("p:snapshot".to_string()),
+                ok: Some(true),
+                progress: None,
+                params: None,
+                data: Some(serde_json::json!({
+                    "windows": [],
+                    "generatedAt": 1700000001234_u64
+                })),
+                error: None,
+            },
+        )
+        .expect("write native response");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let output = String::from_utf8(client_sink.lock().unwrap().clone()).unwrap();
+            if output.contains("\"requestId\":\"req-21\"") {
+                assert!(
+                    output.contains("\"ok\":true"),
+                    "missing success response: {output}"
+                );
+                assert!(
+                    output.contains("\"action\":\"snapshot\""),
+                    "missing action: {output}"
+                );
+                assert!(
+                    output.contains("\"generatedAt\":1700000001234"),
+                    "missing data: {output}"
+                );
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for client response"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
 }

--- a/rust/crates/host/src/host_impl/orchestrate/graphql_contracts.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/graphql_contracts.rs
@@ -161,8 +161,16 @@ fn contract_open_tabs() {
         json!({"groupId": 30}),
         // p:group-update
         json!({"id": 30}),
-        // p:tab-query (verification)
-        json!([{"id": 50, "groupId": 30}, {"id": 51, "groupId": 30}]),
+        // p:snapshot (verification)
+        json!({
+            "windows": [{
+                "windowId": 100,
+                "tabs": [
+                    {"tabId": 50, "windowId": 100, "index": 0, "url": "https://x.com", "title": "X", "groupId": 30, "groupTitle": "Test"},
+                    {"tabId": 51, "windowId": 100, "index": 1, "url": "https://y.com", "title": "Y", "groupId": 30, "groupTitle": "Test"}
+                ]
+            }]
+        }),
     ];
 
     let (mut response, undo) = drive_to_completion(&mut orch, &mock_responses);

--- a/rust/crates/host/src/host_impl/orchestrate/mod.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/mod.rs
@@ -41,6 +41,8 @@ pub(super) trait Orchestration: Send + std::fmt::Debug {
 pub(super) enum OrchStep {
     /// Send a `p:`-prefixed primitive action to the extension.
     SendPrimitive { action: String, params: Value },
+    /// Wait before continuing the orchestration.
+    Delay { duration_ms: u64 },
     /// Orchestration succeeded — respond to CLI client.
     Complete {
         response: Value,
@@ -149,6 +151,9 @@ fn drive_to_completion(
                 idx += 1;
             }
             OrchStep::Progress { .. } => {
+                step = orch.step(Value::Null);
+            }
+            OrchStep::Delay { .. } => {
                 step = orch.step(Value::Null);
             }
         }

--- a/rust/crates/host/src/host_impl/orchestrate/open.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/open.rs
@@ -4,13 +4,16 @@ use tabctl_shared::normalize_url;
 use super::resolve::resolve_window_id;
 use super::OrchStep;
 
+const VERIFY_DELAY_MS: u64 = 100;
+const VERIFY_MAX_ATTEMPTS: usize = 30;
+
 /// Orchestration for the `open` command.
 ///
 /// Two main paths:
 /// 1. `--new-window`: p:window-create → p:tab-create×N → p:tab-remove(seed)
-///    → p:tab-group + p:group-update
+///    → p:tab-group + p:group-update → p:snapshot → verify
 /// 2. Existing window: p:snapshot → resolve window + dedup URLs →
-///    p:tab-create×N → p:tab-group + p:group-update → p:tab-query → verify
+///    p:tab-create×N → p:tab-group + p:group-update → p:snapshot → verify
 #[derive(Debug)]
 pub(crate) struct OpenOrchestration {
     params: Value,
@@ -33,6 +36,7 @@ struct OpenState {
     new_group_id: Option<i64>,
     need_group_update: bool,
     insert_index: Option<i64>,
+    verify_attempts: usize,
 }
 
 #[derive(Debug)]
@@ -43,6 +47,7 @@ enum OpenPhase {
     RemoveSeedTab,
     GroupTabs,
     UpdateGroup,
+    Verify,
 }
 
 impl OpenOrchestration {
@@ -130,6 +135,7 @@ impl super::Orchestration for OpenOrchestration {
             OpenPhase::RemoveSeedTab => self.handle_seed_removed(),
             OpenPhase::GroupTabs => self.handle_grouped(response),
             OpenPhase::UpdateGroup => self.handle_group_updated(),
+            OpenPhase::Verify => self.handle_verify(response),
         }
     }
 }
@@ -485,7 +491,108 @@ impl OpenOrchestration {
     }
 
     fn try_verify_grouping(&mut self) -> OrchStep {
-        self.complete()
+        if self.state.created.is_empty() {
+            return self.complete();
+        }
+
+        self.phase = OpenPhase::Verify;
+        self.state.verify_attempts = 0;
+        self.request_verify_snapshot()
+    }
+
+    fn request_verify_snapshot(&self) -> OrchStep {
+        OrchStep::SendPrimitive {
+            action: "p:snapshot".to_string(),
+            params: Value::Object(Map::new()),
+        }
+    }
+
+    fn handle_verify(&mut self, response: Value) -> OrchStep {
+        if response.is_null() {
+            return self.request_verify_snapshot();
+        }
+
+        if self.created_state_is_visible(&response) {
+            return self.complete();
+        }
+
+        self.state.verify_attempts += 1;
+        if self.state.verify_attempts >= VERIFY_MAX_ATTEMPTS {
+            return OrchStep::Error {
+                message: "Timed out waiting for opened tabs to appear in browser state".to_string(),
+                hint: Some(
+                    "The browser accepted the open request, but a follow-up snapshot did not reflect the created tabs before the command timeout.".to_string(),
+                ),
+            };
+        }
+
+        OrchStep::Delay {
+            duration_ms: VERIFY_DELAY_MS,
+        }
+    }
+
+    fn created_state_is_visible(&mut self, snapshot: &Value) -> bool {
+        let Some(window_id) = self.state.window_id else {
+            return false;
+        };
+        let Some(window) = snapshot
+            .get("windows")
+            .and_then(Value::as_array)
+            .and_then(|windows| {
+                windows.iter().find(|window| {
+                    window.get("windowId").and_then(Value::as_i64) == Some(window_id)
+                })
+            })
+        else {
+            return false;
+        };
+
+        let Some(tabs) = window.get("tabs").and_then(Value::as_array) else {
+            return false;
+        };
+
+        for idx in 0..self.state.created.len() {
+            let Some(tab_id) = self.state.created[idx].get("tabId").and_then(Value::as_i64) else {
+                return false;
+            };
+            let Some(tab) = tabs
+                .iter()
+                .find(|tab| tab.get("tabId").and_then(Value::as_i64) == Some(tab_id))
+            else {
+                return false;
+            };
+
+            if let Some(expected_url) = self.state.urls.get(idx) {
+                let actual_url = tab.get("url").and_then(Value::as_str).unwrap_or("");
+                if actual_url.trim().is_empty()
+                    || normalize_url(actual_url) != normalize_url(expected_url)
+                {
+                    return false;
+                }
+            }
+
+            if self.state.group_title.is_some() {
+                let group_id = self.state.new_group_id.or(self.state.existing_group_id);
+                if group_id.is_some() && tab.get("groupId").and_then(Value::as_i64) != group_id {
+                    return false;
+                }
+                if let Some(title) = &self.state.group_title {
+                    if tab.get("groupTitle").and_then(Value::as_str) != Some(title.as_str()) {
+                        return false;
+                    }
+                }
+            }
+
+            if let Some(created) = self.state.created[idx].as_object_mut() {
+                for field in ["windowId", "index", "url", "title", "groupId", "groupTitle"] {
+                    if let Some(value) = tab.get(field) {
+                        created.insert(field.to_string(), value.clone());
+                    }
+                }
+            }
+        }
+
+        true
     }
 
     fn complete(&self) -> OrchStep {
@@ -564,14 +671,27 @@ mod tests {
         assert!(matches!(&step, OrchStep::SendPrimitive { action, params }
                 if action == "p:group-update" && params["title"] == "Test"));
 
-        // updated → complete
+        // updated → verify snapshot before completing
         let step = orch.step(serde_json::json!({"id": 50}));
+        assert!(matches!(&step, OrchStep::SendPrimitive { action, .. } if action == "p:snapshot"));
+
+        let step = orch.step(serde_json::json!({
+            "windows": [{
+                "windowId": 100,
+                "tabs": [
+                    {"tabId": 1, "windowId": 100, "index": 0, "url": "https://a.com/", "title": "A", "groupId": 50, "groupTitle": "Test"},
+                    {"tabId": 2, "windowId": 100, "index": 1, "url": "https://b.com/", "title": "B", "groupId": 50, "groupTitle": "Test"}
+                ]
+            }]
+        }));
         let OrchStep::Complete { response, .. } = step else {
             panic!("expected Complete");
         };
         assert_eq!(response["windowId"], 100);
         assert_eq!(response["summary"]["createdTabs"], 2);
         assert_eq!(response["summary"]["grouped"], true);
+        assert_eq!(response["created"][0]["url"], "https://a.com/");
+        assert_eq!(response["created"][0]["groupTitle"], "Test");
     }
 
     #[test]
@@ -642,5 +762,47 @@ mod tests {
         };
         assert_eq!(response["windowId"], 100);
         assert_eq!(response["summary"]["createdTabs"], 0);
+    }
+
+    #[test]
+    fn open_waits_until_created_tabs_are_visible() {
+        let params = serde_json::json!({
+            "urls": ["https://a.com"],
+            "newWindow": true
+        });
+        let mut orch = OpenOrchestration::new(&params);
+
+        assert!(matches!(orch.start(), OrchStep::SendPrimitive { .. }));
+        assert!(matches!(
+            orch.step(serde_json::json!({"id": 100, "tabs": [{"id": 999}]})),
+            OrchStep::SendPrimitive { .. }
+        ));
+        assert!(matches!(
+            orch.step(serde_json::json!({"id": 1, "windowId": 100, "index": 0})),
+            OrchStep::SendPrimitive { action, .. } if action == "p:tab-remove"
+        ));
+        let step = orch.step(serde_json::json!({"removed": true}));
+        assert!(matches!(&step, OrchStep::SendPrimitive { action, .. } if action == "p:snapshot"));
+
+        let step = orch.step(serde_json::json!({
+            "windows": [{
+                "windowId": 100,
+                "tabs": []
+            }]
+        }));
+        assert!(matches!(step, OrchStep::Delay { duration_ms } if duration_ms == VERIFY_DELAY_MS));
+
+        let step = orch.step(Value::Null);
+        assert!(matches!(&step, OrchStep::SendPrimitive { action, .. } if action == "p:snapshot"));
+
+        let step = orch.step(serde_json::json!({
+            "windows": [{
+                "windowId": 100,
+                "tabs": [
+                    {"tabId": 1, "windowId": 100, "index": 0, "url": "https://a.com/"}
+                ]
+            }]
+        }));
+        assert!(matches!(step, OrchStep::Complete { .. }));
     }
 }

--- a/rust/crates/host/src/host_impl/orchestrate/open.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/open.rs
@@ -43,8 +43,6 @@ enum OpenPhase {
     RemoveSeedTab,
     GroupTabs,
     UpdateGroup,
-    VerifyQuery,
-    VerifyGroup,
 }
 
 impl OpenOrchestration {
@@ -132,8 +130,6 @@ impl super::Orchestration for OpenOrchestration {
             OpenPhase::RemoveSeedTab => self.handle_seed_removed(),
             OpenPhase::GroupTabs => self.handle_grouped(response),
             OpenPhase::UpdateGroup => self.handle_group_updated(),
-            OpenPhase::VerifyQuery => self.handle_verify_query(response),
-            OpenPhase::VerifyGroup => self.complete(),
         }
     }
 }
@@ -489,53 +485,6 @@ impl OpenOrchestration {
     }
 
     fn try_verify_grouping(&mut self) -> OrchStep {
-        let target_group_id = self.state.new_group_id.or(self.state.existing_group_id);
-        if target_group_id.is_none() || self.state.created.is_empty() {
-            return self.complete();
-        }
-
-        // Query tabs to verify grouping
-        let window_id = self.state.window_id.unwrap();
-        self.phase = OpenPhase::VerifyQuery;
-        OrchStep::SendPrimitive {
-            action: "p:tab-query".to_string(),
-            params: serde_json::json!({"query": {"windowId": window_id}}),
-        }
-    }
-
-    fn handle_verify_query(&mut self, response: Value) -> OrchStep {
-        let target_group_id = self.state.new_group_id.or(self.state.existing_group_id);
-        let Some(target_gid) = target_group_id else {
-            return self.complete();
-        };
-
-        let created_ids: std::collections::HashSet<i64> = self
-            .state
-            .created
-            .iter()
-            .filter_map(|c| c.get("tabId").and_then(Value::as_i64))
-            .collect();
-
-        // Find tabs that should be grouped but aren't
-        let tabs = response.as_array().unwrap_or(&Vec::new()).clone();
-        let straggler_ids: Vec<i64> = tabs
-            .iter()
-            .filter(|tab| {
-                let tid = tab.get("id").and_then(Value::as_i64).unwrap_or(0);
-                let gid = tab.get("groupId").and_then(Value::as_i64).unwrap_or(-1);
-                created_ids.contains(&tid) && gid != target_gid
-            })
-            .filter_map(|tab| tab.get("id").and_then(Value::as_i64))
-            .collect();
-
-        if !straggler_ids.is_empty() {
-            self.phase = OpenPhase::VerifyGroup;
-            return OrchStep::SendPrimitive {
-                action: "p:tab-group".to_string(),
-                params: serde_json::json!({"groupId": target_gid, "tabIds": straggler_ids}),
-            };
-        }
-
         self.complete()
     }
 
@@ -615,15 +564,8 @@ mod tests {
         assert!(matches!(&step, OrchStep::SendPrimitive { action, params }
                 if action == "p:group-update" && params["title"] == "Test"));
 
-        // updated → verify query
+        // updated → complete
         let step = orch.step(serde_json::json!({"id": 50}));
-        assert!(matches!(&step, OrchStep::SendPrimitive { action, .. } if action == "p:tab-query"));
-
-        // all grouped → complete
-        let step = orch.step(serde_json::json!([
-            {"id": 1, "groupId": 50},
-            {"id": 2, "groupId": 50}
-        ]));
         let OrchStep::Complete { response, .. } = step else {
             panic!("expected Complete");
         };

--- a/rust/crates/host/src/host_impl/protocol.rs
+++ b/rust/crates/host/src/host_impl/protocol.rs
@@ -107,6 +107,18 @@ pub(super) fn log_line(message: &str) {
     eprintln!("[tabctl-host-rust] {message}");
 }
 
+pub(super) fn trace_enabled() -> bool {
+    std::env::var("TABCTL_TRACE_IO")
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+pub(super) fn trace_line(message: &str) {
+    if trace_enabled() {
+        log_line(message);
+    }
+}
+
 pub(super) fn version_info_value() -> Value {
     let info = VersionInfo {
         version: host_version().to_string(),
@@ -144,6 +156,31 @@ pub(super) fn value_object(input: Option<Value>) -> Map<String, Value> {
     input
         .and_then(|v| v.as_object().cloned())
         .unwrap_or_default()
+}
+
+pub(super) fn host_ping_data(native_channel_available: bool) -> Map<String, Value> {
+    let mut data = Map::new();
+    data.insert("now".to_string(), Value::Number(now_ms().into()));
+    data.insert("component".to_string(), Value::String("host".to_string()));
+    data.insert(
+        "hostVersion".to_string(),
+        Value::String(host_version().to_string()),
+    );
+    data.insert(
+        "hostBaseVersion".to_string(),
+        Value::String(base_version().to_string()),
+    );
+    data.insert(
+        "hostGitSha".to_string(),
+        Value::String(git_sha().to_string()),
+    );
+    data.insert("hostDirty".to_string(), Value::Bool(is_dirty()));
+    data.insert(
+        "nativeChannelAvailable".to_string(),
+        Value::Bool(native_channel_available),
+    );
+    data.insert("versionsInSync".to_string(), Value::Bool(false));
+    data
 }
 
 pub(super) fn add_ping_metadata(mut data: Map<String, Value>) -> Map<String, Value> {

--- a/rust/crates/host/src/host_impl/runtime.rs
+++ b/rust/crates/host/src/host_impl/runtime.rs
@@ -16,7 +16,12 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use tabctl_shared::{ProfileRegistry, SocketEndpoint, TabctlConfig};
+#[cfg(windows)]
+use tabctl_shared::windows_pipe_path;
+use tabctl_shared::{
+    normalize_path_for_current_platform, path_to_platform_string, ProfileRegistry, SocketEndpoint,
+    TabctlConfig,
+};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::{CloseHandle, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE};
 #[cfg(windows)]
@@ -79,30 +84,23 @@ fn default_state_base() -> PathBuf {
 fn resolve_socket_path(data_dir: &Path) -> String {
     #[cfg(windows)]
     {
-        let mut hasher = Sha256::new();
-        hasher.update(data_dir.to_string_lossy().as_bytes());
-        let digest = hasher.finalize();
-        let hash = digest[..6]
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<String>();
-        format!(r"\\.\pipe\tabctl-{hash}")
+        windows_pipe_path(&path_to_platform_string(data_dir))
     }
     #[cfg(not(windows))]
     {
-        data_dir.join("tabctl.sock").to_string_lossy().to_string()
+        path_to_platform_string(&data_dir.join("tabctl.sock"))
     }
 }
 
 fn resolve_base_data_dir() -> PathBuf {
     if let Ok(path) = std::env::var("TABCTL_DATA_DIR") {
         if !path.trim().is_empty() {
-            return PathBuf::from(path);
+            return PathBuf::from(normalize_path_for_current_platform(&path));
         }
     }
     if let Ok(path) = std::env::var("TABCTL_STATE_DIR") {
         if !path.trim().is_empty() {
-            return PathBuf::from(path);
+            return PathBuf::from(normalize_path_for_current_platform(&path));
         }
     }
     if let Ok(state_home) = std::env::var("XDG_STATE_HOME") {
@@ -125,15 +123,15 @@ fn resolve_profile_data_dir(config_dir: &Path, profile_name: &str) -> Option<Pat
     registry
         .profiles
         .get(profile_name)
-        .map(|entry| PathBuf::from(&entry.data_dir))
+        .map(|entry| PathBuf::from(normalize_path_for_current_platform(&entry.data_dir)))
 }
 
 pub(super) fn resolve_config() -> TabctlConfig {
     let config_dir = std::env::var("TABCTL_CONFIG_DIR")
-        .map(PathBuf::from)
+        .map(|path| PathBuf::from(normalize_path_for_current_platform(&path)))
         .unwrap_or_else(|_| {
             std::env::var("XDG_CONFIG_HOME")
-                .map(PathBuf::from)
+                .map(|path| PathBuf::from(normalize_path_for_current_platform(&path)))
                 .unwrap_or_else(|_| default_config_base())
                 .join("tabctl")
         });
@@ -149,13 +147,13 @@ pub(super) fn resolve_config() -> TabctlConfig {
         std::env::var("TABCTL_SOCKET").unwrap_or_else(|_| resolve_socket_path(&data_dir));
 
     TabctlConfig {
-        config_dir: config_dir.to_string_lossy().to_string(),
-        data_dir: data_dir.to_string_lossy().to_string(),
-        base_data_dir: base_data_dir.to_string_lossy().to_string(),
+        config_dir: path_to_platform_string(&config_dir),
+        data_dir: path_to_platform_string(&data_dir),
+        base_data_dir: path_to_platform_string(&base_data_dir),
         socket_path,
-        undo_log: data_dir.join("undo.jsonl").to_string_lossy().to_string(),
-        wrapper_dir: data_dir.to_string_lossy().to_string(),
-        policy_path: config_dir.join("policy.json").to_string_lossy().to_string(),
+        undo_log: path_to_platform_string(&data_dir.join("undo.jsonl")),
+        wrapper_dir: path_to_platform_string(&data_dir),
+        policy_path: path_to_platform_string(&config_dir.join("policy.json")),
         active_profile_name,
     }
 }
@@ -303,7 +301,7 @@ fn connect_named_pipe_instance(path: &str) -> io::Result<File> {
 
 fn deterministic_tcp_start_port(data_dir: &Path) -> u16 {
     let mut hasher = Sha256::new();
-    hasher.update(data_dir.to_string_lossy().as_bytes());
+    hasher.update(path_to_platform_string(data_dir).as_bytes());
     let digest = hasher.finalize();
     let seed = u16::from_be_bytes([digest[6], digest[7]]);
     TCP_PORT_BASE + (seed % TCP_PORT_SPAN)

--- a/rust/crates/host/src/host_impl/runtime.rs
+++ b/rust/crates/host/src/host_impl/runtime.rs
@@ -262,7 +262,7 @@ fn run_unix() -> io::Result<()> {
                         clients_clone,
                         native_out_clone,
                         None,
-                        false,
+                        true,
                     )
                 });
             }
@@ -436,7 +436,7 @@ fn spawn_tcp_accept_loop(
                             clients_clone,
                             native_out_clone,
                             token_clone,
-                            false,
+                            true,
                         )
                     });
                 }

--- a/rust/crates/host/src/host_impl/runtime.rs
+++ b/rust/crates/host/src/host_impl/runtime.rs
@@ -565,6 +565,7 @@ const _: () = assert!(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
     use super::*;
 
     #[cfg(windows)]

--- a/rust/crates/host/src/host_impl/runtime.rs
+++ b/rust/crates/host/src/host_impl/runtime.rs
@@ -1,8 +1,11 @@
+#[cfg(not(windows))]
 use sha2::{Digest, Sha256};
 use std::fs;
 #[cfg(windows)]
 use std::fs::File;
 use std::io;
+use std::io::IsTerminal;
+#[cfg(not(windows))]
 use std::net::TcpListener;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -23,7 +26,9 @@ use tabctl_shared::{
     TabctlConfig,
 };
 #[cfg(windows)]
-use windows_sys::Win32::Foundation::{CloseHandle, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_ACCESS_DENIED, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE,
+};
 #[cfg(windows)]
 use windows_sys::Win32::Storage::FileSystem::{FILE_FLAG_FIRST_PIPE_INSTANCE, PIPE_ACCESS_DUPLEX};
 #[cfg(windows)]
@@ -32,15 +37,26 @@ use windows_sys::Win32::System::Pipes::{
     PIPE_UNLIMITED_INSTANCES, PIPE_WAIT,
 };
 
-use super::dispatch::{handle_client, start_native_reader, ClientWriter, Clients};
+use super::dispatch::{
+    handle_client, start_native_reader, start_request_timeout_reaper, ClientWriter, Clients,
+    NativeWriter,
+};
 use super::protocol::{log_line, next_counter};
 use super::state::HostState;
 
+#[cfg(not(windows))]
 pub(super) const TCP_PORT_FILENAME: &str = "tcp-port";
+#[cfg(not(windows))]
 pub(super) const AUTH_TOKEN_FILENAME: &str = "auth-token";
+#[cfg(windows)]
+pub(super) const PIPE_ENDPOINT_FILENAME: &str = "pipe-endpoint";
+#[cfg(not(windows))]
 pub(super) const AUTH_TOKEN_LENGTH: usize = 32; // 32 hex chars = 128 bits
+#[cfg(not(windows))]
 const TCP_PORT_BASE: u16 = 38_000;
+#[cfg(not(windows))]
 const TCP_PORT_SPAN: u16 = 1_000;
+#[cfg(not(windows))]
 const TCP_PORT_ATTEMPTS: u16 = 128;
 
 fn default_config_base() -> PathBuf {
@@ -188,15 +204,18 @@ fn run_unix() -> io::Result<()> {
     let listener = UnixListener::bind(&socket_path)?;
     let _ = fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600));
 
-    let state = Arc::new(Mutex::new(HostState::new(
+    let native_channel_available = !io::stdin().is_terminal() && !io::stdout().is_terminal();
+    let state = Arc::new(Mutex::new(HostState::new_with_native_channel(
         PathBuf::from(&config.undo_log),
         PathBuf::from(&config.base_data_dir).join("focus.db"),
         config.active_profile_name.clone(),
+        native_channel_available,
     )));
     let clients: Clients = Arc::new(Mutex::new(std::collections::HashMap::new()));
-    let native_out = Arc::new(Mutex::new(io::stdout()));
+    let native_out: NativeWriter = Arc::new(Mutex::new(Box::new(io::stdout())));
 
     start_native_reader(state.clone(), clients.clone(), native_out.clone());
+    start_request_timeout_reaper(state.clone(), clients.clone(), native_out.clone());
 
     // Optional TCP listener (opt-in via TABCTL_HOST_TCP=1)
     let tcp_enabled = std::env::var("TABCTL_HOST_TCP")
@@ -243,6 +262,7 @@ fn run_unix() -> io::Result<()> {
                         clients_clone,
                         native_out_clone,
                         None,
+                        false,
                     )
                 });
             }
@@ -259,6 +279,12 @@ fn to_wide(value: &str) -> Vec<u16> {
         .encode_wide()
         .chain(std::iter::once(0))
         .collect()
+}
+
+#[cfg(windows)]
+fn should_retry_without_first_pipe_instance(open_mode: u32, err: &io::Error) -> bool {
+    open_mode & FILE_FLAG_FIRST_PIPE_INSTANCE != 0
+        && err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32)
 }
 
 #[cfg(windows)]
@@ -279,7 +305,12 @@ fn connect_named_pipe_instance(path: &str) -> io::Result<File> {
             )
         };
         if handle == INVALID_HANDLE_VALUE {
-            return Err(io::Error::last_os_error());
+            let err = io::Error::last_os_error();
+            if should_retry_without_first_pipe_instance(open_mode, &err) {
+                open_mode = PIPE_ACCESS_DUPLEX;
+                continue;
+            }
+            return Err(err);
         }
         let connected = unsafe { ConnectNamedPipe(handle, std::ptr::null_mut()) };
         if connected == 0 {
@@ -288,10 +319,6 @@ fn connect_named_pipe_instance(path: &str) -> io::Result<File> {
                 unsafe {
                     CloseHandle(handle);
                 }
-                if open_mode & FILE_FLAG_FIRST_PIPE_INSTANCE != 0 {
-                    open_mode = PIPE_ACCESS_DUPLEX;
-                    continue;
-                }
                 return Err(err);
             }
         }
@@ -299,6 +326,7 @@ fn connect_named_pipe_instance(path: &str) -> io::Result<File> {
     }
 }
 
+#[cfg(not(windows))]
 fn deterministic_tcp_start_port(data_dir: &Path) -> u16 {
     let mut hasher = Sha256::new();
     hasher.update(path_to_platform_string(data_dir).as_bytes());
@@ -307,6 +335,7 @@ fn deterministic_tcp_start_port(data_dir: &Path) -> u16 {
     TCP_PORT_BASE + (seed % TCP_PORT_SPAN)
 }
 
+#[cfg(not(windows))]
 fn bind_tcp_listener(data_dir: &Path) -> io::Result<(TcpListener, u16)> {
     if let Ok(port) = std::env::var("TABCTL_TCP_PORT") {
         let parsed = port
@@ -332,12 +361,21 @@ fn bind_tcp_listener(data_dir: &Path) -> io::Result<(TcpListener, u16)> {
     ))
 }
 
+#[cfg(not(windows))]
 fn write_tcp_port_file(data_dir: &Path, port: u16) -> io::Result<PathBuf> {
     let path = data_dir.join(TCP_PORT_FILENAME);
     fs::write(&path, format!("{port}\n"))?;
     Ok(path)
 }
 
+#[cfg(windows)]
+fn write_pipe_endpoint_file(data_dir: &Path, pipe_path: &str) -> io::Result<PathBuf> {
+    let path = data_dir.join(PIPE_ENDPOINT_FILENAME);
+    fs::write(&path, format!("{pipe_path}\n"))?;
+    Ok(path)
+}
+
+#[cfg(not(windows))]
 pub(super) fn generate_and_write_auth_token(data_dir: &Path) -> io::Result<String> {
     let mut bytes = [0u8; 16]; // 16 bytes = 128 bits → 32 hex chars
     getrandom::getrandom(&mut bytes).map_err(|e| io::Error::other(e.to_string()))?;
@@ -348,6 +386,7 @@ pub(super) fn generate_and_write_auth_token(data_dir: &Path) -> io::Result<Strin
     Ok(token)
 }
 
+#[cfg(not(windows))]
 fn setup_tcp_listener(data_dir: &Path) -> io::Result<(TcpListener, u16, Arc<String>)> {
     let (listener, port) = bind_tcp_listener(data_dir)?;
     let port_file = write_tcp_port_file(data_dir, port)?;
@@ -361,11 +400,12 @@ fn setup_tcp_listener(data_dir: &Path) -> io::Result<(TcpListener, u16, Arc<Stri
     Ok((listener, port, auth_token))
 }
 
+#[cfg(not(windows))]
 fn spawn_tcp_accept_loop(
     listener: TcpListener,
     state: Arc<Mutex<HostState>>,
     clients: Clients,
-    native_out: Arc<Mutex<io::Stdout>>,
+    native_out: NativeWriter,
     auth_token: Arc<String>,
 ) {
     thread::spawn(move || {
@@ -396,6 +436,7 @@ fn spawn_tcp_accept_loop(
                             clients_clone,
                             native_out_clone,
                             token_clone,
+                            false,
                         )
                     });
                 }
@@ -428,25 +469,24 @@ fn run_windows() -> io::Result<()> {
 
     let data_dir = PathBuf::from(&config.data_dir);
     fs::create_dir_all(&data_dir)?;
-    let (tcp_listener, _tcp_port, auth_token) = setup_tcp_listener(&data_dir)?;
+    let pipe_file = write_pipe_endpoint_file(&data_dir, &pipe_path)?;
 
-    let state = Arc::new(Mutex::new(HostState::new(
+    let native_channel_available = !io::stdin().is_terminal() && !io::stdout().is_terminal();
+    let state = Arc::new(Mutex::new(HostState::new_with_native_channel(
         PathBuf::from(&config.undo_log),
         PathBuf::from(&config.base_data_dir).join("focus.db"),
         config.active_profile_name.clone(),
+        native_channel_available,
     )));
     let clients: Clients = Arc::new(Mutex::new(std::collections::HashMap::new()));
-    let native_out = Arc::new(Mutex::new(io::stdout()));
+    let native_out: NativeWriter = Arc::new(Mutex::new(Box::new(io::stdout())));
     start_native_reader(state.clone(), clients.clone(), native_out.clone());
+    start_request_timeout_reaper(state.clone(), clients.clone(), native_out.clone());
 
-    spawn_tcp_accept_loop(
-        tcp_listener,
-        state.clone(),
-        clients.clone(),
-        native_out.clone(),
-        auth_token,
-    );
-
+    log_line(&format!(
+        "published pipe endpoint file {}",
+        pipe_file.display()
+    ));
     log_line(&format!("listening on {pipe_path}"));
 
     loop {
@@ -475,6 +515,7 @@ fn run_windows() -> io::Result<()> {
                         clients_clone,
                         native_out_clone,
                         None,
+                        true,
                     )
                 });
             }
@@ -509,12 +550,107 @@ pub(super) fn run() {
 }
 
 // Compile-time invariants for the TCP port range constants shared by host and CLI.
+#[cfg(not(windows))]
 const _: () = assert!(
     TCP_PORT_BASE >= 1024,
     "port base must be an unprivileged port"
 );
+#[cfg(not(windows))]
 const _: () = assert!(TCP_PORT_SPAN > 0, "port span must be non-zero");
+#[cfg(not(windows))]
 const _: () = assert!(
     (TCP_PORT_BASE as u32) + (TCP_PORT_SPAN as u32) <= 65535,
     "port range must fit in a u16"
 );
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(windows)]
+    fn test_pipe_path(name: &str) -> String {
+        format!(r"\\.\pipe\tabctl-{name}-{}", next_counter())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn retries_without_first_pipe_instance_on_access_denied() {
+        let err = io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32);
+        assert!(should_retry_without_first_pipe_instance(
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            &err,
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn does_not_retry_without_first_pipe_instance_for_other_errors() {
+        let err = io::Error::from_raw_os_error(ERROR_PIPE_CONNECTED as i32);
+        assert!(!should_retry_without_first_pipe_instance(
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_FIRST_PIPE_INSTANCE,
+            &err,
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn does_not_retry_when_first_pipe_instance_flag_is_not_set() {
+        let err = io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32);
+        assert!(!should_retry_without_first_pipe_instance(
+            PIPE_ACCESS_DUPLEX,
+            &err
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn named_pipe_roundtrip_survives_server_reader_drop_after_request() {
+        use std::fs::OpenOptions;
+        use std::io::{BufRead, BufReader, Write};
+        use std::thread;
+        use std::time::Duration;
+
+        let pipe_path = test_pipe_path("roundtrip");
+        let server_path = pipe_path.clone();
+        let server = thread::spawn(move || {
+            let mut writer = connect_named_pipe_instance(&server_path).expect("create server pipe");
+            let reader = writer.try_clone().expect("clone server pipe for reader");
+            let mut buf = String::new();
+            let mut reader = BufReader::new(reader);
+            reader.read_line(&mut buf).expect("read client request");
+            assert!(buf.contains("\"action\":\"snapshot\""));
+            drop(reader);
+            thread::sleep(Duration::from_millis(50));
+            writeln!(writer, "{{\"ok\":true,\"action\":\"snapshot\",\"requestId\":\"req-1\",\"data\":{{\"windows\":[]}}}}")
+                .expect("write server response");
+            writer.flush().expect("flush server response");
+        });
+
+        let mut client = loop {
+            match OpenOptions::new().read(true).write(true).open(&pipe_path) {
+                Ok(client) => break client,
+                Err(err) if err.raw_os_error() == Some(2) || err.raw_os_error() == Some(231) => {
+                    thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Err(err) => panic!("connect client to named pipe: {err}"),
+            }
+        };
+        let mut client_reader = BufReader::new(client.try_clone().expect("clone client pipe"));
+        writeln!(
+            client,
+            "{{\"id\":\"req-1\",\"action\":\"snapshot\",\"params\":{{}}}}"
+        )
+        .expect("write client request");
+        client.flush().expect("flush client request");
+
+        let mut response = String::new();
+        client_reader
+            .read_line(&mut response)
+            .expect("read server response");
+        assert!(response.contains("\"ok\":true"));
+        assert!(response.contains("\"requestId\":\"req-1\""));
+
+        server.join().expect("join server thread");
+    }
+}

--- a/rust/crates/host/src/host_impl/state.rs
+++ b/rust/crates/host/src/host_impl/state.rs
@@ -1,6 +1,7 @@
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 use tabctl_shared::{ClientInfo, NativeMessage, ProtocolError, RequestEnvelope, ResponseEnvelope};
 
 use super::browser_state;
@@ -800,6 +801,11 @@ impl HostState {
                     data: None,
                     error: None,
                 })]
+            }
+            OrchStep::Delay { duration_ms } => {
+                std::thread::sleep(Duration::from_millis(duration_ms));
+                let next_step = orch.step(Value::Null);
+                self.process_orch_step(client_id, action, request_id, txid, next_step, orch)
             }
             OrchStep::Complete { response, undo } => {
                 if let Some(ref undo_data) = undo {

--- a/rust/crates/host/src/host_impl/state.rs
+++ b/rust/crates/host/src/host_impl/state.rs
@@ -73,6 +73,19 @@ impl HostState {
         Self::error_effect(pending, message_id, "Request timed out".to_string(), None)
     }
 
+    fn ingest_snapshot_response(&self, snapshot: &Value) {
+        let payload = serde_json::json!({
+            "reason": "snapshot",
+            "recordedAt": now_ms(),
+            "snapshot": snapshot,
+        });
+        if let Err(err) =
+            browser_state::ingest_sync(&self.state_db_path, self.profile_name.as_deref(), &payload)
+        {
+            log_line(&format!("browser-state snapshot ingest failed: {err}"));
+        }
+    }
+
     #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn new(
         undo_log: PathBuf,
@@ -634,6 +647,7 @@ impl HostState {
                     &mut response_data,
                     self.profile_name.as_deref(),
                 );
+                self.ingest_snapshot_response(&response_data);
             }
             let step = orch.step(response_data);
             return self.process_orch_step(
@@ -647,6 +661,23 @@ impl HostState {
         }
 
         // Legacy path — no orchestration
+        let legacy_response_data = if pending.action == "snapshot" {
+            let mut response_data = message
+                .data
+                .clone()
+                .unwrap_or(Value::Object(message_data.clone()));
+            if response_data.get("windows").is_some() {
+                let _ = focus_store::enrich_snapshot(
+                    &self.focus_db_path,
+                    &mut response_data,
+                    self.profile_name.as_deref(),
+                );
+                self.ingest_snapshot_response(&response_data);
+            }
+            Some(response_data)
+        } else {
+            None
+        };
 
         if pending.action == "ping" {
             let data = add_ping_metadata(message_data);
@@ -718,7 +749,10 @@ impl HostState {
 
         let mut resp = base_response(true, Some(pending.action), Some(message_id));
         // Preserve original data shape (arrays, objects, etc.)
-        resp.data = Some(message.data.unwrap_or(Value::Object(message_data)));
+        resp.data = Some(
+            legacy_response_data
+                .unwrap_or_else(|| message.data.unwrap_or(Value::Object(message_data))),
+        );
         vec![HostEffect::Respond {
             client_id: pending.client_id,
             payload: resp,

--- a/rust/crates/host/src/host_impl/state.rs
+++ b/rust/crates/host/src/host_impl/state.rs
@@ -7,8 +7,9 @@ use super::browser_state;
 use super::focus_store;
 use super::orchestrate::{orchestration_for, OrchStep, Orchestration};
 use super::protocol::{
-    add_host_metadata, add_ping_metadata, base_response, create_id, host_version, local_actions,
-    log_line, now_ms, undo_actions, value_object, version_info_value, REQUEST_TIMEOUT_MS,
+    add_host_metadata, add_ping_metadata, base_response, create_id, host_ping_data, host_version,
+    local_actions, log_line, now_ms, trace_line, undo_actions, value_object, version_info_value,
+    REQUEST_TIMEOUT_MS,
 };
 use super::undo::{
     append_undo_record, filter_by_retention, find_latest_undo_record, find_undo_record,
@@ -40,6 +41,7 @@ pub(super) struct HostState {
     state_db_path: PathBuf,
     focus_db_path: PathBuf,
     profile_name: Option<String>,
+    native_channel_available: bool,
 }
 
 #[derive(Debug)]
@@ -52,10 +54,39 @@ pub(super) enum HostEffect {
 }
 
 impl HostState {
+    fn error_effect(
+        pending: PendingRequest,
+        message_id: String,
+        message: String,
+        hint: Option<String>,
+    ) -> HostEffect {
+        let resp_id = pending.request_id.clone().unwrap_or(message_id);
+        let mut resp = base_response(false, Some(pending.action), Some(resp_id));
+        resp.error = Some(ProtocolError { message, hint });
+        HostEffect::Respond {
+            client_id: pending.client_id,
+            payload: resp,
+        }
+    }
+
+    fn timeout_effect(pending: PendingRequest, message_id: String) -> HostEffect {
+        Self::error_effect(pending, message_id, "Request timed out".to_string(), None)
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn new(
         undo_log: PathBuf,
         focus_db_path: PathBuf,
         profile_name: Option<String>,
+    ) -> Self {
+        Self::new_with_native_channel(undo_log, focus_db_path, profile_name, true)
+    }
+
+    pub(super) fn new_with_native_channel(
+        undo_log: PathBuf,
+        focus_db_path: PathBuf,
+        profile_name: Option<String>,
+        native_channel_available: bool,
     ) -> Self {
         let state_db_path = undo_log
             .parent()
@@ -68,6 +99,7 @@ impl HostState {
             state_db_path,
             focus_db_path,
             profile_name,
+            native_channel_available,
         }
     }
 
@@ -78,6 +110,35 @@ impl HostState {
         txid: Option<String>,
     ) -> Vec<HostEffect> {
         self.forward_to_extension_with_orch(client_id, request, txid, None)
+    }
+
+    pub(super) fn collect_timed_out_requests(&mut self) -> Vec<HostEffect> {
+        let expired: Vec<String> = self
+            .pending
+            .iter()
+            .filter(|(_, pending)| now_ms().saturating_sub(pending.created_at) > REQUEST_TIMEOUT_MS)
+            .map(|(message_id, _)| message_id.clone())
+            .collect();
+
+        expired
+            .into_iter()
+            .filter_map(|message_id| {
+                self.pending
+                    .remove(&message_id)
+                    .map(|pending| Self::timeout_effect(pending, message_id))
+            })
+            .collect()
+    }
+
+    pub(super) fn fail_pending_request(
+        &mut self,
+        message_id: &str,
+        message: String,
+        hint: Option<String>,
+    ) -> Option<HostEffect> {
+        self.pending
+            .remove(message_id)
+            .map(|pending| Self::error_effect(pending, message_id.to_string(), message, hint))
     }
 
     fn forward_to_extension_with_orch(
@@ -116,6 +177,10 @@ impl HostState {
                 orchestration,
             },
         );
+        trace_line(&format!(
+            "pending insert: client_id={} request_id={} action={}",
+            client_id, request_id, request.action
+        ));
 
         vec![HostEffect::SendNative(NativeMessage {
             id: request_id,
@@ -146,6 +211,30 @@ impl HostState {
         }
 
         let action = request.action.clone();
+
+        if action == "ping" {
+            let mut resp = base_response(true, Some(action), request.id);
+            add_host_metadata(&mut resp);
+            resp.data = Some(Value::Object(host_ping_data(self.native_channel_available)));
+            return vec![HostEffect::Respond {
+                client_id,
+                payload: resp,
+            }];
+        }
+
+        if !self.native_channel_available && !local_actions().contains(action.as_str()) {
+            let mut resp = base_response(false, Some(action), request.id);
+            resp.error = Some(ProtocolError {
+                message: "Native browser channel unavailable".to_string(),
+                hint: Some(
+                    "The host is running without an attached browser native messaging channel, so browser-backed actions cannot complete.".to_string(),
+                ),
+            });
+            return vec![HostEffect::Respond {
+                client_id,
+                payload: resp,
+            }];
+        }
 
         if action == "version" {
             let mut resp = base_response(true, Some(action), request.id);
@@ -487,17 +576,12 @@ impl HostState {
         // Timeout check
         if let Some(pending) = self.pending.get(&message_id) {
             if now_ms().saturating_sub(pending.created_at) > REQUEST_TIMEOUT_MS {
+                trace_line(&format!(
+                    "pending timeout: request_id={} action={}",
+                    message_id, pending.action
+                ));
                 let timed_out = self.pending.remove(&message_id).expect("pending exists");
-                let resp_id = timed_out.request_id.clone().unwrap_or(message_id);
-                let mut resp = base_response(false, Some(timed_out.action), Some(resp_id));
-                resp.error = Some(ProtocolError {
-                    message: "Request timed out".to_string(),
-                    hint: None,
-                });
-                return vec![HostEffect::Respond {
-                    client_id: timed_out.client_id,
-                    payload: resp,
-                }];
+                return vec![Self::timeout_effect(timed_out, message_id)];
             }
         }
 
@@ -669,6 +753,10 @@ impl HostState {
                         orchestration: Some(orch),
                     },
                 );
+                trace_line(&format!(
+                    "pending orch step: client_id={} request_id={} action={} native_action={}",
+                    client_id, new_id, action, prim_action
+                ));
                 vec![HostEffect::SendNative(NativeMessage {
                     id: new_id,
                     action: Some(prim_action),
@@ -739,5 +827,84 @@ impl HostState {
                 effects
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Map, Value};
+
+    fn test_state() -> HostState {
+        HostState::new(
+            std::env::temp_dir().join("tabctl-host-state-test-undo.jsonl"),
+            std::env::temp_dir().join("tabctl-host-state-test-focus.db"),
+            None,
+        )
+    }
+
+    #[test]
+    fn non_ping_browser_actions_fail_fast_without_native_channel() {
+        let mut state = HostState::new_with_native_channel(
+            std::env::temp_dir().join("tabctl-host-state-test-undo.jsonl"),
+            std::env::temp_dir().join("tabctl-host-state-test-focus.db"),
+            None,
+            false,
+        );
+        let effects = state.handle_cli_request(
+            7,
+            RequestEnvelope {
+                id: Some("req-list".to_string()),
+                action: "list".to_string(),
+                params: Value::Object(Map::new()),
+                auth_token: None,
+            },
+        );
+        let HostEffect::Respond { client_id, payload } = &effects[0] else {
+            panic!("expected immediate error response");
+        };
+        assert_eq!(*client_id, 7);
+        assert!(!payload.ok);
+        assert_eq!(payload.action.as_deref(), Some("list"));
+        assert_eq!(payload.request_id.as_deref(), Some("req-list"));
+        assert_eq!(
+            payload.error.as_ref().map(|err| err.message.as_str()),
+            Some("Native browser channel unavailable")
+        );
+    }
+
+    #[test]
+    fn collect_timed_out_requests_returns_error_without_native_message() {
+        let mut state = test_state();
+        let request = RequestEnvelope {
+            id: Some("req-1".to_string()),
+            action: "analyze".to_string(),
+            params: Value::Object(Map::new()),
+            auth_token: None,
+        };
+
+        let effects = state.handle_cli_request(7, request);
+        let HostEffect::SendNative(native) = &effects[0] else {
+            panic!("expected native forward");
+        };
+        let pending = state
+            .pending
+            .get_mut(&native.id)
+            .expect("pending request should exist");
+        pending.created_at = now_ms().saturating_sub(REQUEST_TIMEOUT_MS + 1);
+
+        let effects = state.collect_timed_out_requests();
+        assert_eq!(effects.len(), 1);
+        let HostEffect::Respond { client_id, payload } = &effects[0] else {
+            panic!("expected timeout response");
+        };
+        assert_eq!(*client_id, 7);
+        assert!(!payload.ok);
+        assert_eq!(payload.action.as_deref(), Some("analyze"));
+        assert_eq!(payload.request_id.as_deref(), Some("req-1"));
+        assert_eq!(
+            payload.error.as_ref().map(|err| err.message.as_str()),
+            Some("Request timed out")
+        );
     }
 }

--- a/rust/crates/shared/Cargo.toml
+++ b/rust/crates/shared/Cargo.toml
@@ -9,4 +9,5 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 url-normalize = "0.1"

--- a/rust/crates/shared/src/lib.rs
+++ b/rust/crates/shared/src/lib.rs
@@ -1,11 +1,92 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::Path;
 use url_normalize::Options as NormalizeOptions;
 
 pub fn workspace_marker() -> &'static str {
     "tabctl-rust-workspace"
+}
+
+pub fn normalize_windows_path_string(path: &str) -> String {
+    if path.is_empty() {
+        return String::new();
+    }
+
+    let replaced = path.replace('/', "\\");
+    let (prefix, rest) = if let Some(rest) = replaced.strip_prefix(r"\\?\UNC\") {
+        (r"\\?\UNC\", rest)
+    } else if let Some(rest) = replaced.strip_prefix(r"\\?\") {
+        (r"\\?\", rest)
+    } else if let Some(rest) = replaced.strip_prefix(r"\\.\") {
+        (r"\\.\", rest)
+    } else if let Some(rest) = replaced.strip_prefix(r"\\") {
+        (r"\\", rest)
+    } else if let Some(rest) = replaced.strip_prefix('\\') {
+        (r"\", rest)
+    } else {
+        ("", replaced.as_str())
+    };
+
+    let had_drive_root = prefix.is_empty()
+        && replaced.len() >= 3
+        && replaced.as_bytes()[1] == b':'
+        && replaced[2..].chars().all(|ch| ch == '\\');
+
+    let mut segments = rest.split('\\').filter(|segment| !segment.is_empty());
+    let Some(first_segment) = segments.next() else {
+        return replaced;
+    };
+
+    let mut normalized = String::from(prefix);
+    if first_segment.len() == 2 && first_segment.as_bytes()[1] == b':' {
+        let drive = first_segment.as_bytes()[0] as char;
+        normalized.push(drive.to_ascii_uppercase());
+        normalized.push(':');
+    } else {
+        normalized.push_str(first_segment);
+    }
+
+    for segment in segments {
+        if !normalized.ends_with('\\') {
+            normalized.push('\\');
+        }
+        normalized.push_str(segment);
+    }
+
+    if had_drive_root && normalized.len() == 2 && normalized.as_bytes()[1] == b':' {
+        normalized.push('\\');
+    }
+
+    normalized
+}
+
+pub fn normalize_path_for_current_platform(path: &str) -> String {
+    #[cfg(windows)]
+    {
+        normalize_windows_path_string(path)
+    }
+    #[cfg(not(windows))]
+    {
+        path.to_string()
+    }
+}
+
+pub fn path_to_platform_string(path: &Path) -> String {
+    normalize_path_for_current_platform(&path.to_string_lossy())
+}
+
+pub fn windows_pipe_path(data_dir: &str) -> String {
+    let normalized = normalize_windows_path_string(data_dir);
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    let hash = digest[..6]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!(r"\\.\pipe\tabctl-{hash}")
 }
 
 /// Normalize a URL for deduplication and storage.
@@ -396,5 +477,29 @@ mod tests {
         assert!(SocketEndpoint::parse("unix://").is_err());
         assert!(SocketEndpoint::parse("udp://127.0.0.1:8008").is_err());
         assert!(SocketEndpoint::parse("relative.sock").is_err());
+    }
+
+    #[test]
+    fn normalize_windows_path_string_unifies_mixed_separators() {
+        let normalized =
+            normalize_windows_path_string(r"C:/Users/tester/AppData\\Local/tabctl/profiles/edge/");
+        assert_eq!(
+            normalized,
+            r"C:\Users\tester\AppData\Local\tabctl\profiles\edge"
+        );
+    }
+
+    #[test]
+    fn normalize_windows_path_string_preserves_unc_prefix() {
+        let normalized = normalize_windows_path_string(r"\\server/share\\tabctl\profiles/edge");
+        assert_eq!(normalized, r"\\server\share\tabctl\profiles\edge");
+    }
+
+    #[test]
+    fn windows_pipe_path_ignores_separator_style() {
+        assert_eq!(
+            windows_pipe_path(r"C:\Users\tester\AppData\Local\tabctl\profiles\edge"),
+            windows_pipe_path(r"C:/Users/tester/AppData/Local/tabctl/profiles/edge")
+        );
     }
 }

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -9,7 +9,9 @@ use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Command as ProcessCommand, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 #[cfg(windows)]
 use tabctl_shared::windows_pipe_path;
 use tabctl_shared::{
@@ -21,8 +23,9 @@ use sha2::{Digest, Sha256};
 
 const WSL_TCP_PORT_FILENAME: &str = "tcp-port";
 #[cfg(target_os = "linux")]
-const WSL_TCP_PORT_FALLBACK: u16 = 39_001;
+const WSL_PIPE_ENDPOINT_FILENAME: &str = "pipe-endpoint";
 const AUTH_TOKEN_FILENAME: &str = "auth-token";
+const CLI_RESPONSE_TIMEOUT_MS: u64 = 35_000;
 const EXTENSION_ACTIVE_DIR_NAME: &str = "extension";
 const EXTENSION_RELEASES_DIR_NAME: &str = "extension-releases";
 const EXTENSION_VERSIONS_DIR_NAME: &str = "extension-versions";
@@ -896,6 +899,79 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_config_dir_uses_windows_roaming_appdata_in_wsl() {
+        with_env_vars(
+            &[
+                ("WSL_INTEROP", Some("1")),
+                ("TABCTL_CONFIG_DIR", None),
+                ("XDG_CONFIG_HOME", None),
+                (
+                    "PATH",
+                    Some("/usr/bin:/mnt/c/Users/TestUser/AppData/Local/Microsoft/WindowsApps"),
+                ),
+            ],
+            || {
+                let config_dir = resolve_config_dir().expect("resolve config dir");
+                assert_eq!(
+                    config_dir,
+                    "/mnt/c/Users/TestUser/AppData/Roaming/tabctl".to_string()
+                );
+            },
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolve_data_dir_uses_windows_local_appdata_in_wsl() {
+        with_env_vars(
+            &[
+                ("WSL_INTEROP", Some("1")),
+                ("TABCTL_DATA_DIR", None),
+                ("TABCTL_STATE_DIR", None),
+                ("XDG_STATE_HOME", None),
+                (
+                    "PATH",
+                    Some("/usr/bin:/mnt/c/Users/TestUser/AppData/Local/Microsoft/WindowsApps"),
+                ),
+            ],
+            || {
+                let data_dir = resolve_data_dir(None).expect("resolve data dir");
+                assert_eq!(
+                    data_dir,
+                    "/mnt/c/Users/TestUser/AppData/Local/tabctl".to_string()
+                );
+            },
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn host_wrapper_repair_is_disabled_in_wsl() {
+        with_env_vars(&[("WSL_INTEROP", Some("1"))], || {
+            assert!(!can_repair_host_wrapper());
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn attempt_profile_repair_fails_fast_in_wsl() {
+        with_env_vars(&[("WSL_INTEROP", Some("1"))], || {
+            let entry = ProfileEntry {
+                browser: Browser::Chrome,
+                extension_id: "dkfnfgfelacbfclhenpgdckfefmfddbd".to_string(),
+                node_path: "/mnt/c/dev/ekroon/tabctl/rust/target/debug/tabctl".to_string(),
+                host_path: r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome\tabctl-host.cmd"
+                    .to_string(),
+                data_dir: r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome".to_string(),
+                user_data_dir: None,
+            };
+            let err = attempt_profile_repair("chrome", &entry).expect_err("repair should fail");
+            assert!(err.contains("unsupported from WSL"), "unexpected error: {err}");
+        });
+    }
+
     #[test]
     fn returns_none_when_path_has_no_windows_entry() {
         with_env_vars(&[("PATH", Some("/usr/bin:/usr/local/bin"))], || {
@@ -920,20 +996,33 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn resolves_pipe_socket_to_wsl_tcp_endpoint() {
+    fn translates_windows_data_dir_into_wsl_candidate() {
+        let candidates =
+            wsl_file_candidates(r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome", "pipe-endpoint");
+        assert!(
+            candidates.iter().any(|path| {
+                path == &PathBuf::from(
+                    "/mnt/c/Users/TestUser/AppData/Local/tabctl/profiles/chrome/pipe-endpoint",
+                )
+            }),
+            "expected translated WSL candidate, got: {candidates:?}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn keeps_explicit_pipe_socket_in_wsl() {
         with_env_vars(
             &[
                 ("WSL_INTEROP", Some("1")),
                 ("TABCTL_SOCKET", Some("pipe://tabctl-test")),
-                ("TABCTL_TCP_PORT", Some("39005")),
             ],
             || {
                 let endpoint = resolve_socket_endpoint(None).expect("resolve endpoint");
                 assert_eq!(
                     endpoint,
-                    SocketEndpoint::Tcp {
-                        host: "127.0.0.1".to_string(),
-                        port: 39005,
+                    SocketEndpoint::Pipe {
+                        path: r"\\.\pipe\tabctl-test".to_string(),
                     }
                 );
             },
@@ -942,7 +1031,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn keeps_explicit_tcp_socket_in_wsl() {
+    fn rejects_explicit_tcp_socket_in_wsl() {
         with_env_vars(
             &[
                 ("WSL_INTEROP", Some("1")),
@@ -950,14 +1039,8 @@ mod tests {
                 ("TABCTL_TCP_PORT", Some("39007")),
             ],
             || {
-                let endpoint = resolve_socket_endpoint(None).expect("resolve endpoint");
-                assert_eq!(
-                    endpoint,
-                    SocketEndpoint::Tcp {
-                        host: "127.0.0.1".to_string(),
-                        port: 39006,
-                    }
-                );
+                let err = resolve_socket_endpoint(None).expect_err("resolve endpoint should fail");
+                assert!(err.contains("disabled in WSL"), "unexpected error: {err}");
             },
         );
     }
@@ -980,7 +1063,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn falls_back_to_default_wsl_tcp_port_when_not_discovered() {
+    fn wsl_named_pipe_endpoint_is_required_when_not_discovered() {
         let temp_root = std::env::temp_dir().join(format!("tabctl-cli-test-{}", request_id()));
         std::fs::create_dir_all(&temp_root).expect("create temp directory");
         with_env_vars(
@@ -994,14 +1077,8 @@ mod tests {
                 ),
             ],
             || {
-                let endpoint = resolve_socket_endpoint(None).expect("resolve endpoint");
-                assert_eq!(
-                    endpoint,
-                    SocketEndpoint::Tcp {
-                        host: "127.0.0.1".to_string(),
-                        port: WSL_TCP_PORT_FALLBACK,
-                    }
-                );
+                let err = resolve_socket_endpoint(None).expect_err("resolve endpoint should fail");
+                assert!(err.contains("pipe-endpoint"), "unexpected error: {err}");
             },
         );
         if let Err(err) = std::fs::remove_dir_all(&temp_root) {
@@ -1009,6 +1086,71 @@ mod tests {
                 panic!("remove temp directory: {err}");
             }
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn resolves_wsl_pipe_endpoint_from_pipe_endpoint_file() {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp_root = std::env::temp_dir().join(format!(
+            "tabctl-wsl-pipe-endpoint-test-{}-{}",
+            std::process::id(),
+            id
+        ));
+        let _ = std::fs::remove_dir_all(&temp_root);
+        std::fs::create_dir_all(&temp_root).expect("create temp directory");
+        std::fs::write(
+            temp_root.join(WSL_PIPE_ENDPOINT_FILENAME),
+            "\\\\.\\pipe\\tabctl-test-bridge\n",
+        )
+        .expect("write pipe endpoint file");
+
+        with_env_vars(
+            &[
+                ("WSL_INTEROP", Some("1")),
+                ("TABCTL_SOCKET", None),
+                (
+                    "TABCTL_DATA_DIR",
+                    Some(temp_root.to_str().expect("temp path should be valid utf-8")),
+                ),
+            ],
+            || {
+                let endpoint = resolve_socket_endpoint(None).expect("resolve endpoint");
+                assert_eq!(
+                    endpoint,
+                    SocketEndpoint::Pipe {
+                        path: r"\\.\pipe\tabctl-test-bridge".to_string(),
+                    }
+                );
+            },
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_root);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pipe_transport_returns_error_without_pipe_endpoint_file() {
+        let temp_root =
+            std::env::temp_dir().join(format!("tabctl-wsl-pipe-missing-{}", request_id()));
+        std::fs::create_dir_all(&temp_root).expect("create temp directory");
+        with_env_vars(
+            &[
+                ("WSL_INTEROP", Some("1")),
+                ("TABCTL_SOCKET", None),
+                (
+                    "TABCTL_DATA_DIR",
+                    Some(temp_root.to_str().expect("temp path should be valid utf-8")),
+                ),
+            ],
+            || {
+                let err =
+                    resolve_socket_endpoint(None).expect_err("missing pipe endpoint should fail");
+                assert!(err.contains("pipe-endpoint"), "unexpected error: {err}");
+            },
+        );
+        let _ = std::fs::remove_dir_all(&temp_root);
     }
 
     #[cfg(windows)]
@@ -1904,6 +2046,43 @@ mod tests {
         let _ = std::fs::remove_dir_all(&temp_root);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn test_transport_windows_falls_back_to_named_pipe_without_auth_token() {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temp_root = std::env::temp_dir().join(format!(
+            "tabctl-windows-pipe-fallback-test-{}-{}",
+            std::process::id(),
+            id
+        ));
+        let _ = std::fs::remove_dir_all(&temp_root);
+        std::fs::create_dir_all(&temp_root).expect("create temp directory");
+        std::fs::write(temp_root.join(WSL_TCP_PORT_FILENAME), "39023\n").expect("write port file");
+
+        with_env_vars(
+            &[
+                ("TABCTL_TRANSPORT", None),
+                ("TABCTL_TCP_PORT", None),
+                ("TABCTL_SOCKET", None),
+                ("TABCTL_AUTH_TOKEN", None),
+                (
+                    "TABCTL_DATA_DIR",
+                    Some(temp_root.to_str().expect("temp path should be valid utf-8")),
+                ),
+            ],
+            || {
+                let endpoint = resolve_socket_endpoint(None).expect("resolve endpoint");
+                assert_eq!(
+                    endpoint,
+                    resolve_windows_pipe_endpoint(temp_root.to_str().unwrap())
+                );
+            },
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_root);
+    }
+
     #[cfg(not(windows))]
     #[test]
     fn test_transport_non_tcp_ignored() {
@@ -2177,5 +2356,85 @@ mod tests {
         );
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    struct HangingStream {
+        delay: Duration,
+        writes: Vec<u8>,
+    }
+
+    impl Read for HangingStream {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            thread::sleep(self.delay);
+            Ok(0)
+        }
+    }
+
+    impl Write for HangingStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.writes.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn send_request_over_stream_times_out_when_no_response_arrives() {
+        with_env_vars(&[("TABCTL_RESPONSE_TIMEOUT_MS", Some("10"))], || {
+            let stream = HangingStream {
+                delay: Duration::from_millis(50),
+                writes: Vec::new(),
+            };
+            let err =
+                send_request_over_stream(stream, "ping", Value::Object(Map::new()), false, None)
+                    .expect_err("request should time out");
+            assert!(
+                err.contains("Request timed out after 10ms"),
+                "unexpected timeout error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn cached_snapshot_from_browser_state_extracts_snapshot_payload() {
+        let response = ResponseEnvelope {
+            ok: true,
+            action: Some("browser-state-latest".to_string()),
+            request_id: Some("req-1".to_string()),
+            component: Some("host".to_string()),
+            version: Some("0.6.0".to_string()),
+            progress: None,
+            data: Some(json!({
+                "snapshotId": 1,
+                "snapshot": {
+                    "generatedAt": 123,
+                    "windows": []
+                }
+            })),
+            error: None,
+        };
+
+        let snapshot = cached_snapshot_from_browser_state(&response).expect("snapshot");
+        assert_eq!(snapshot["generatedAt"], json!(123));
+        assert_eq!(snapshot["windows"], json!([]));
+    }
+
+    #[test]
+    fn cached_snapshot_from_browser_state_returns_none_without_snapshot_field() {
+        let response = ResponseEnvelope {
+            ok: true,
+            action: Some("browser-state-latest".to_string()),
+            request_id: Some("req-1".to_string()),
+            component: Some("host".to_string()),
+            version: Some("0.6.0".to_string()),
+            progress: None,
+            data: Some(json!({ "snapshotId": 1 })),
+            error: None,
+        };
+
+        assert!(cached_snapshot_from_browser_state(&response).is_none());
     }
 }

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::process::{Command as ProcessCommand, Stdio};
 use std::sync::mpsc;
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(windows)]
 use tabctl_shared::windows_pipe_path;
 use tabctl_shared::{
@@ -76,6 +76,7 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
     use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -962,13 +962,17 @@ mod tests {
                 browser: Browser::Chrome,
                 extension_id: "dkfnfgfelacbfclhenpgdckfefmfddbd".to_string(),
                 node_path: "/mnt/c/dev/ekroon/tabctl/rust/target/debug/tabctl".to_string(),
-                host_path: r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome\tabctl-host.cmd"
-                    .to_string(),
+                host_path:
+                    r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome\tabctl-host.cmd"
+                        .to_string(),
                 data_dir: r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome".to_string(),
                 user_data_dir: None,
             };
             let err = attempt_profile_repair("chrome", &entry).expect_err("repair should fail");
-            assert!(err.contains("unsupported from WSL"), "unexpected error: {err}");
+            assert!(
+                err.contains("unsupported from WSL"),
+                "unexpected error: {err}"
+            );
         });
     }
 
@@ -997,8 +1001,10 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn translates_windows_data_dir_into_wsl_candidate() {
-        let candidates =
-            wsl_file_candidates(r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome", "pipe-endpoint");
+        let candidates = wsl_file_candidates(
+            r"C:\Users\TestUser\AppData\Local\tabctl\profiles\chrome",
+            "pipe-endpoint",
+        );
         assert!(
             candidates.iter().any(|path| {
                 path == &PathBuf::from(

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -10,8 +10,11 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Command as ProcessCommand, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(windows)]
+use tabctl_shared::windows_pipe_path;
 use tabctl_shared::{
-    Browser, ProfileEntry, ProfileRegistry, RequestEnvelope, ResponseEnvelope, SocketEndpoint,
+    normalize_path_for_current_platform, path_to_platform_string, Browser, ProfileEntry,
+    ProfileRegistry, RequestEnvelope, ResponseEnvelope, SocketEndpoint,
 };
 
 use sha2::{Digest, Sha256};
@@ -1020,6 +1023,30 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn resolves_windows_pipe_endpoint_for_mixed_separator_variants() {
+        let canonical = resolve_windows_pipe_endpoint(r"C:\Users\tester\AppData\Local\tabctl");
+        let mixed = resolve_windows_pipe_endpoint(r"C:/Users/tester/AppData/Local/tabctl");
+        assert_eq!(canonical, mixed);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_pipe_connect_error_includes_profile_data_dir_and_hint() {
+        let err = std::io::Error::from_raw_os_error(5);
+        let rendered = format_windows_pipe_connect_error(
+            Some("edge"),
+            r"C:\Users\tester\AppData\Local\tabctl\profiles\edge",
+            r"\\.\pipe\tabctl-test",
+            &err,
+        );
+        assert!(rendered.contains(r"\\.\pipe\tabctl-test"));
+        assert!(rendered.contains("profile: edge"));
+        assert!(rendered.contains(r"data dir: C:\Users\tester\AppData\Local\tabctl\profiles\edge"));
+        assert!(rendered.contains("named-pipe ACLs") || rendered.contains("Windows denied access"));
+    }
+
     #[test]
     fn resolve_manifest_dir_rejects_invalid_browser() {
         let result = resolve_manifest_dir("firefox");
@@ -1932,6 +1959,12 @@ mod tests {
             );
             assert!(
                 steps.iter().any(|step| {
+                    step.as_str() == Some("Inspect the active profile and resolved paths: tabctl profile-show --json")
+                }),
+                "manual steps should include profile inspection guidance"
+            );
+            assert!(
+                steps.iter().any(|step| {
                     step.as_str().map(|value| {
                         value.contains(
                             "tabctl setup --browser edge --name edge --extension-id mpglnmehddpkinfhheeahiicfieegcon",
@@ -2027,6 +2060,12 @@ mod tests {
                         step.as_str() == Some("Verify connection: tabctl --profile edge ping")
                     }),
                     "manual steps should include ping verification"
+                );
+                assert!(
+                    steps.iter().any(|step| {
+                        step.as_str() == Some("Inspect the active profile and resolved paths: tabctl profile-show --json")
+                    }),
+                    "manual steps should include profile inspection guidance"
                 );
             },
         );

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -2452,11 +2452,14 @@ mod tests {
         assert!(should_refresh_graphql_snapshot_cache(
             "mutation { moveTab(tabIds: [1], index: 0) { movedTabs } }"
         ));
-        assert!(!should_refresh_graphql_snapshot_cache(
+        assert!(should_refresh_graphql_snapshot_cache(
             "mutation { undoAction(latest: true) { txid } }"
         ));
-        assert!(!should_refresh_graphql_snapshot_cache(
+        assert!(should_refresh_graphql_snapshot_cache(
             "mutation { closeTabs(tabIds: [1], confirm: true) { txid } }"
+        ));
+        assert!(!should_refresh_graphql_snapshot_cache(
+            "mutation { focusTab(tabId: 1) { success } }"
         ));
     }
 }

--- a/rust/crates/tabctl/src/cli/local.rs
+++ b/rust/crates/tabctl/src/cli/local.rs
@@ -640,8 +640,23 @@ pub(super) fn attempt_profile_repair(
     profile_name: &str,
     entry: &ProfileEntry,
 ) -> Result<Value, String> {
-    let data_dir = resolve_data_dir(None)?;
-    let wrapper_dir = PathBuf::from(&data_dir).join("profiles").join(profile_name);
+    if !can_repair_host_wrapper() {
+        return Err(
+            "Host wrapper repair is unsupported from WSL. Run the command from Windows to repair the native host wrapper."
+                .to_string(),
+        );
+    }
+    let wrapper_dir = PathBuf::from(normalize_path_for_current_platform(&entry.data_dir));
+    let data_dir = wrapper_dir
+        .parent()
+        .and_then(|parent| parent.parent())
+        .map(path_to_platform_string)
+        .ok_or_else(|| {
+            format!(
+                "Profile \"{profile_name}\" has an invalid dataDir for wrapper repair: {}",
+                entry.data_dir
+            )
+        })?;
     let tabctl_binary_path = resolve_tabctl_binary_path();
     let wrapper_path = write_host_wrapper(&tabctl_binary_path, profile_name, &wrapper_dir)?;
     let manifest_path = write_native_manifest(
@@ -754,7 +769,7 @@ pub(super) fn run_upgrade(matches: &ArgMatches, _sub: &ArgMatches) -> Result<(),
         let mut needs_reload = false;
 
         // Step 1: Repair wrapper if binary path changed
-        let wrapper_stale = entry.node_path != current_binary;
+        let wrapper_stale = can_repair_host_wrapper() && entry.node_path != current_binary;
         if wrapper_stale {
             match attempt_profile_repair(profile_name, entry) {
                 Ok(details) => {
@@ -782,6 +797,16 @@ pub(super) fn run_upgrade(matches: &ArgMatches, _sub: &ArgMatches) -> Result<(),
                     }
                     any_failed = true;
                 }
+            }
+        } else if !can_repair_host_wrapper() && entry.node_path != current_binary {
+            result["wrapperRepair"] = json!({
+                "updated": false,
+                "reason": "unsupported-from-wsl"
+            });
+            if !json_mode {
+                eprintln!(
+                    "  {profile_name}:\n    · Host wrapper repair skipped in WSL (run upgrade from Windows if needed)"
+                );
             }
         } else {
             result["wrapperRepair"] = json!({ "updated": false, "reason": "already current" });
@@ -881,14 +906,50 @@ pub(super) fn run_upgrade(matches: &ArgMatches, _sub: &ArgMatches) -> Result<(),
     Ok(())
 }
 
+pub(super) fn cached_snapshot_from_browser_state(response: &ResponseEnvelope) -> Option<Value> {
+    response
+        .data
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|data| data.get("snapshot"))
+        .cloned()
+}
+
+fn load_cached_graphql_snapshot(profile: Option<&str>) -> Result<Option<Value>, String> {
+    let response = send_request("browser-state-latest", json!({}), profile, false)?;
+    if !response.ok {
+        let msg = response
+            .error
+            .map(|e| e.message)
+            .unwrap_or_else(|| "browser-state-latest request failed".to_string());
+        return Err(msg);
+    }
+    Ok(cached_snapshot_from_browser_state(&response))
+}
+
+fn load_graphql_snapshot(profile: Option<&str>) -> Result<Value, String> {
+    if let Ok(Some(snapshot)) = load_cached_graphql_snapshot(profile) {
+        return Ok(snapshot);
+    }
+
+    let response = send_request("snapshot", json!({}), profile, false)?;
+    if !response.ok {
+        let msg = response
+            .error
+            .map(|e| e.message)
+            .unwrap_or_else(|| "Snapshot request failed".to_string());
+        return Err(msg);
+    }
+    Ok(response.data.unwrap_or(json!({})))
+}
+
 pub(super) fn run_graphql_query(matches: &ArgMatches, sub: &ArgMatches) -> Result<(), String> {
     let query_str = sub
         .get_one::<String>("graphql")
         .ok_or("Missing GraphQL query")?;
     let profile = matches.get_one::<String>("profile").map(|s| s.as_str());
 
-    let snapshot_response = send_request("snapshot", json!({}), profile, false)?;
-    let snapshot = snapshot_response.data.unwrap_or(json!({}));
+    let snapshot = load_graphql_snapshot(profile)?;
 
     let sender = std::sync::Arc::new(CliCommandSender {
         profile: profile.map(String::from),
@@ -922,14 +983,6 @@ impl tabctl_graphql::CommandSender for CliCommandSender {
     }
 
     fn snapshot(&self) -> Result<serde_json::Value, String> {
-        let response = send_request("snapshot", json!({}), self.profile.as_deref(), false)?;
-        if !response.ok {
-            let msg = response
-                .error
-                .map(|e| e.message)
-                .unwrap_or_else(|| "Snapshot request failed".to_string());
-            return Err(msg);
-        }
-        Ok(response.data.unwrap_or(json!({})))
+        load_graphql_snapshot(self.profile.as_deref())
     }
 }

--- a/rust/crates/tabctl/src/cli/local.rs
+++ b/rust/crates/tabctl/src/cli/local.rs
@@ -543,15 +543,22 @@ pub(super) fn profile_connectivity_report(profile_name: &str, entry: &ProfileEnt
 }
 
 pub(super) fn connectivity_manual_steps(profile_name: &str, entry: &ProfileEntry) -> Vec<String> {
-    vec![
+    let mut steps = vec![
         format!("Verify connection: tabctl --profile {profile_name} ping"),
+        "Inspect the active profile and resolved paths: tabctl profile-show --json".to_string(),
         "Ensure the browser extension is loaded and active for this profile.".to_string(),
         format!(
             "Rerun setup for this profile: tabctl setup --browser {} --name {profile_name} --extension-id {}",
             browser_name(&entry.browser),
             entry.extension_id
         ),
-    ]
+    ];
+    if cfg!(windows) {
+        steps.push(
+            "If ping reports a named-pipe error, compare TABCTL_PROFILE, TABCTL_CONFIG_DIR, and TABCTL_DATA_DIR between the generated wrapper and the CLI shell.".to_string(),
+        );
+    }
+    steps
 }
 
 pub(super) fn profile_health_report(

--- a/rust/crates/tabctl/src/cli/local.rs
+++ b/rust/crates/tabctl/src/cli/local.rs
@@ -964,11 +964,18 @@ pub(super) fn should_refresh_graphql_snapshot_cache(query: &str) -> bool {
     let trimmed = query.trim_start();
     trimmed.starts_with("mutation")
         && [
+            "openTabs",
+            "closeTabs",
+            "undoAction",
             "updateGroup",
             "assignToGroup",
             "ungroupTabs",
             "moveGroup",
             "moveTab",
+            "mergeWindows",
+            "gatherGroups",
+            "archiveTabs",
+            "deduplicateTabs",
         ]
         .iter()
         .any(|field| trimmed.contains(field))
@@ -1020,5 +1027,49 @@ impl tabctl_graphql::CommandSender for CliCommandSender {
 
     fn snapshot(&self) -> Result<serde_json::Value, String> {
         load_fresh_graphql_snapshot(self.profile.as_deref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_refresh_graphql_snapshot_cache;
+
+    #[test]
+    fn graphql_structural_mutations_refresh_snapshot_cache() {
+        for mutation in [
+            "openTabs",
+            "closeTabs",
+            "undoAction",
+            "updateGroup",
+            "assignToGroup",
+            "ungroupTabs",
+            "moveGroup",
+            "moveTab",
+            "mergeWindows",
+            "gatherGroups",
+            "archiveTabs",
+            "deduplicateTabs",
+        ] {
+            let query = format!("mutation {{ {mutation} {{ __typename }} }}");
+            assert!(
+                should_refresh_graphql_snapshot_cache(&query),
+                "{mutation} should refresh the cached snapshot"
+            );
+        }
+    }
+
+    #[test]
+    fn graphql_non_structural_operations_do_not_refresh_snapshot_cache() {
+        for query in [
+            "query { windows { windowId } }",
+            "mutation { focusTab(tabId: 1) { success } }",
+            "mutation { refreshTabs(tabIds: [1]) { refreshedTabs } }",
+            "mutation { reloadExtension { reloading } }",
+        ] {
+            assert!(
+                !should_refresh_graphql_snapshot_cache(query),
+                "{query} should not refresh the cached snapshot"
+            );
+        }
     }
 }

--- a/rust/crates/tabctl/src/cli/local.rs
+++ b/rust/crates/tabctl/src/cli/local.rs
@@ -927,11 +927,7 @@ fn load_cached_graphql_snapshot(profile: Option<&str>) -> Result<Option<Value>, 
     Ok(cached_snapshot_from_browser_state(&response))
 }
 
-fn load_graphql_snapshot(profile: Option<&str>) -> Result<Value, String> {
-    if let Ok(Some(snapshot)) = load_cached_graphql_snapshot(profile) {
-        return Ok(snapshot);
-    }
-
+fn load_live_graphql_snapshot(profile: Option<&str>) -> Result<Value, String> {
     let response = send_request("snapshot", json!({}), profile, false)?;
     if !response.ok {
         let msg = response
@@ -941,6 +937,31 @@ fn load_graphql_snapshot(profile: Option<&str>) -> Result<Value, String> {
         return Err(msg);
     }
     Ok(response.data.unwrap_or(json!({})))
+}
+
+fn load_graphql_snapshot(profile: Option<&str>) -> Result<Value, String> {
+    if let Ok(Some(snapshot)) = load_cached_graphql_snapshot(profile) {
+        return Ok(snapshot);
+    }
+
+    load_live_graphql_snapshot(profile)
+}
+
+fn load_fresh_graphql_snapshot(profile: Option<&str>) -> Result<Value, String> {
+    match load_live_graphql_snapshot(profile) {
+        Ok(snapshot) => Ok(snapshot),
+        Err(snapshot_err) => match load_cached_graphql_snapshot(profile) {
+            Ok(Some(snapshot)) => Ok(snapshot),
+            Ok(None) => Err(snapshot_err),
+            Err(cache_err) => Err(format!(
+                "{snapshot_err}; cached browser state unavailable: {cache_err}"
+            )),
+        },
+    }
+}
+
+fn is_graphql_mutation(query: &str) -> bool {
+    query.trim_start().starts_with("mutation")
 }
 
 pub(super) fn run_graphql_query(matches: &ArgMatches, sub: &ArgMatches) -> Result<(), String> {
@@ -959,6 +980,11 @@ pub(super) fn run_graphql_query(matches: &ArgMatches, sub: &ArgMatches) -> Resul
     let result = tabctl_graphql::execute(query_str, None, snapshot, sender)?;
     let rendered = render_local_command(matches, "query", result);
     if rendered.is_ok() {
+        if is_graphql_mutation(query_str) {
+            if let Err(err) = load_live_graphql_snapshot(profile) {
+                eprintln!("Warning: failed to refresh GraphQL snapshot cache: {err}");
+            }
+        }
         maybe_runtime_extension_auto_sync("query", profile, None);
     }
     rendered
@@ -983,6 +1009,6 @@ impl tabctl_graphql::CommandSender for CliCommandSender {
     }
 
     fn snapshot(&self) -> Result<serde_json::Value, String> {
-        load_graphql_snapshot(self.profile.as_deref())
+        load_fresh_graphql_snapshot(self.profile.as_deref())
     }
 }

--- a/rust/crates/tabctl/src/cli/output.rs
+++ b/rust/crates/tabctl/src/cli/output.rs
@@ -79,8 +79,27 @@ pub(super) fn render_ping_human(response: &ResponseEnvelope) -> Result<(), Strin
         .get("hostDirty")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let native_channel_available = data
+        .get("nativeChannelAvailable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
 
     let dirty_marker = |d: bool| if d { "+dirty" } else { "" };
+
+    if data.get("version").is_none() {
+        if native_channel_available {
+            println!(
+                "✅ tabctl {} (host reachable; browser channel available)",
+                host_version
+            );
+        } else {
+            println!(
+                "✅ tabctl {} (host reachable; no browser channel)",
+                host_version
+            );
+        }
+        return Ok(());
+    }
 
     if in_sync {
         let has_shas = ext_sha != "unknown" && host_sha != "unknown";

--- a/rust/crates/tabctl/src/cli/setup.rs
+++ b/rust/crates/tabctl/src/cli/setup.rs
@@ -724,6 +724,9 @@ pub(super) fn maybe_runtime_extension_auto_sync(
 /// Check if the host wrapper's binary path is stale and repair it.
 /// Returns `true` if the wrapper was updated.
 fn maybe_auto_repair_wrapper(profile: Option<&str>) -> bool {
+    if !can_repair_host_wrapper() {
+        return false;
+    }
     let profile_name = match resolve_effective_profile(profile) {
         Some(name) => name,
         None => return false,

--- a/rust/crates/tabctl/src/cli/setup.rs
+++ b/rust/crates/tabctl/src/cli/setup.rs
@@ -1154,8 +1154,8 @@ pub(super) fn register_profile(
         browser: browser_enum,
         extension_id: extension_id.to_string(),
         node_path: resolve_tabctl_binary_path(),
-        host_path: wrapper_path.display().to_string(),
-        data_dir: profile_data_dir.display().to_string(),
+        host_path: path_to_platform_string(wrapper_path),
+        data_dir: path_to_platform_string(&profile_data_dir),
         user_data_dir: None,
     };
 
@@ -1276,7 +1276,7 @@ pub(super) fn write_registry_key(browser: &str, manifest_path: &Path) -> Result<
         .create_subkey(&subkey)
         .map_err(|e| format!("Failed to create registry key: {e}"))?;
 
-    key.set_value("", &manifest_path.display().to_string())
+    key.set_value("", &path_to_platform_string(manifest_path))
         .map_err(|e| format!("Failed to set registry value: {e}"))?;
 
     Ok(format!("HKCU\\{subkey}"))
@@ -1301,7 +1301,7 @@ pub(super) fn write_native_manifest(
     let manifest = json!({
         "name": HOST_NAME,
         "description": "tabctl native host",
-        "path": abs_wrapper.display().to_string(),
+        "path": path_to_platform_string(&abs_wrapper),
         "type": "stdio",
         "allowed_origins": [format!("chrome-extension://{extension_id}/")]
     });

--- a/rust/crates/tabctl/src/cli/transport.rs
+++ b/rust/crates/tabctl/src/cli/transport.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(windows)]
-fn format_windows_pipe_connect_error(
+pub(super) fn format_windows_pipe_connect_error(
     profile: Option<&str>,
     data_dir: &str,
     pipe_path: &str,
@@ -29,15 +29,24 @@ fn format_windows_pipe_connect_error(
     )
 }
 
+fn response_timeout_ms() -> u64 {
+    std::env::var("TABCTL_RESPONSE_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(CLI_RESPONSE_TIMEOUT_MS)
+}
+
 pub(super) fn resolve_socket_endpoint(profile: Option<&str>) -> Result<SocketEndpoint, String> {
     if let Ok(path) = std::env::var("TABCTL_SOCKET") {
         if !path.trim().is_empty() {
             let endpoint = SocketEndpoint::parse(&path)?;
             #[cfg(target_os = "linux")]
-            if matches!(endpoint, SocketEndpoint::Pipe { .. }) && is_wsl_environment() {
-                if let Some(tcp) = discover_wsl_tcp_endpoint(profile) {
-                    return Ok(tcp);
-                }
+            if is_wsl_environment() && matches!(endpoint, SocketEndpoint::Tcp { .. }) {
+                return Err(
+                    "TCP transport is disabled in WSL; use the Windows named-pipe bridge."
+                        .to_string(),
+                );
             }
             return Ok(endpoint);
         }
@@ -45,6 +54,13 @@ pub(super) fn resolve_socket_endpoint(profile: Option<&str>) -> Result<SocketEnd
     // Check TABCTL_TRANSPORT=tcp for explicit TCP transport selection
     if let Ok(transport) = std::env::var("TABCTL_TRANSPORT") {
         if transport.trim().eq_ignore_ascii_case("tcp") {
+            #[cfg(target_os = "linux")]
+            if is_wsl_environment() {
+                return Err(
+                    "TCP transport is disabled in WSL; use the Windows named-pipe bridge."
+                        .to_string(),
+                );
+            }
             if let Ok(port_str) = std::env::var("TABCTL_TCP_PORT") {
                 if let Ok(port) = port_str.trim().parse::<u16>() {
                     if port > 0 {
@@ -68,12 +84,9 @@ pub(super) fn resolve_socket_endpoint(profile: Option<&str>) -> Result<SocketEnd
     }
     #[cfg(target_os = "linux")]
     if is_wsl_environment() {
-        if let Some(tcp) = discover_wsl_tcp_endpoint(profile) {
-            return Ok(tcp);
-        }
-        return Ok(SocketEndpoint::Tcp {
-            host: "127.0.0.1".to_string(),
-            port: WSL_TCP_PORT_FALLBACK,
+        return discover_wsl_pipe_endpoint(profile).ok_or_else(|| {
+            "No WSL named-pipe endpoint was found. Is the Windows host running and publishing pipe-endpoint?"
+                .to_string()
         });
     }
     let data_dir = resolve_data_dir(profile)?;
@@ -98,30 +111,37 @@ pub(super) fn is_wsl_environment() -> bool {
             .unwrap_or(false)
 }
 
-#[cfg(target_os = "linux")]
-pub(super) fn discover_wsl_tcp_endpoint(profile: Option<&str>) -> Option<SocketEndpoint> {
-    if let Ok(value) = std::env::var("TABCTL_TCP_PORT") {
-        if let Ok(port) = value.trim().parse::<u16>() {
-            if port > 0 {
-                return Some(SocketEndpoint::Tcp {
-                    host: "127.0.0.1".to_string(),
-                    port,
-                });
-            }
-        }
+pub(super) fn can_repair_host_wrapper() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        !is_wsl_environment()
     }
-    let data_dir = resolve_data_dir(profile).ok()?;
-    discover_wsl_tcp_port_from_data_dir(&data_dir).map(|port| SocketEndpoint::Tcp {
-        host: "127.0.0.1".to_string(),
-        port,
-    })
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", test))]
 pub(super) fn discover_wsl_tcp_port_from_data_dir(data_dir: &str) -> Option<u16> {
     for path in wsl_tcp_port_candidates(data_dir) {
         if let Some(port) = read_tcp_port_file(&path) {
             return Some(port);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn discover_wsl_pipe_endpoint(profile: Option<&str>) -> Option<SocketEndpoint> {
+    let data_dir = resolve_data_dir(profile).ok()?;
+    for path in wsl_pipe_endpoint_candidates(&data_dir) {
+        if let Ok(content) = fs::read_to_string(path) {
+            if let Ok(endpoint) = SocketEndpoint::parse(content.trim()) {
+                if matches!(endpoint, SocketEndpoint::Pipe { .. }) {
+                    return Some(endpoint);
+                }
+            }
         }
     }
     None
@@ -146,17 +166,25 @@ pub(super) fn resolve_windows_username_from_path() -> Option<String> {
 #[cfg(any(target_os = "linux", test))]
 pub(super) fn resolve_windows_appdata_local() -> Option<PathBuf> {
     let username = resolve_windows_username_from_path()?;
-    let path = PathBuf::from(format!("/mnt/c/Users/{username}/AppData/Local"));
-    if path.is_dir() {
-        Some(path)
-    } else {
-        None
-    }
+    Some(PathBuf::from(format!(
+        "/mnt/c/Users/{username}/AppData/Local"
+    )))
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn resolve_windows_appdata_roaming() -> Option<PathBuf> {
+    let username = resolve_windows_username_from_path()?;
+    Some(PathBuf::from(format!(
+        "/mnt/c/Users/{username}/AppData/Roaming"
+    )))
 }
 
 #[cfg(any(target_os = "linux", test))]
 pub(super) fn wsl_file_candidates(data_dir: &str, filename: &str) -> Vec<PathBuf> {
     let mut candidates = vec![PathBuf::from(data_dir).join(filename)];
+    if let Some(wsl_path) = windows_path_to_wsl_path(data_dir) {
+        candidates.push(wsl_path.join(filename));
+    }
     let Some(relative_suffix) = tabctl_relative_suffix(Path::new(data_dir)) else {
         return candidates;
     };
@@ -179,9 +207,26 @@ pub(super) fn wsl_file_candidates(data_dir: &str, filename: &str) -> Vec<PathBuf
     candidates
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", test))]
+pub(super) fn windows_path_to_wsl_path(path: &str) -> Option<PathBuf> {
+    let normalized = path.replace('/', "\\");
+    let bytes = normalized.as_bytes();
+    if bytes.len() < 3 || bytes[1] != b':' || bytes[2] != b'\\' {
+        return None;
+    }
+    let drive = (bytes[0] as char).to_ascii_lowercase();
+    let suffix = normalized[3..].replace('\\', "/");
+    Some(PathBuf::from(format!("/mnt/{drive}/{suffix}")))
+}
+
+#[cfg(all(target_os = "linux", test))]
 pub(super) fn wsl_tcp_port_candidates(data_dir: &str) -> Vec<PathBuf> {
     wsl_file_candidates(data_dir, WSL_TCP_PORT_FILENAME)
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn wsl_pipe_endpoint_candidates(data_dir: &str) -> Vec<PathBuf> {
+    wsl_file_candidates(data_dir, WSL_PIPE_ENDPOINT_FILENAME)
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -220,18 +265,18 @@ pub(super) fn resolve_data_dir(profile: Option<&str>) -> Result<String, String> 
         }
     }
     let config_dir = resolve_config_dir()?;
+    let profiles_path = PathBuf::from(&config_dir).join("profiles.json");
+    let registry = fs::read_to_string(&profiles_path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<ProfileRegistry>(&contents).ok());
     if let Some(profile_name) = profile {
-        let profiles_path = PathBuf::from(&config_dir).join("profiles.json");
-        if let Ok(contents) = fs::read_to_string(profiles_path) {
-            if let Ok(registry) = serde_json::from_str::<ProfileRegistry>(&contents) {
-                if let Some(profile_entry) = registry.profiles.get(profile_name) {
-                    return Ok(normalize_path_for_current_platform(&profile_entry.data_dir));
-                }
-            }
+        if let Some(profile_entry) = registry
+            .as_ref()
+            .and_then(|registry| registry.profiles.get(profile_name))
+        {
+            return Ok(normalize_path_for_current_platform(&profile_entry.data_dir));
         }
-        return Err(format!(
-            "Profile \"{profile_name}\" not found in profiles.json"
-        ));
+        return Err(format!("Profile \"{profile_name}\" not found in profiles.json"));
     }
     if let Ok(path) = std::env::var("TABCTL_STATE_DIR") {
         if !path.trim().is_empty() {
@@ -240,6 +285,18 @@ pub(super) fn resolve_data_dir(profile: Option<&str>) -> Result<String, String> 
     }
     if let Ok(path) = std::env::var("XDG_STATE_HOME") {
         return Ok(path_to_platform_string(&PathBuf::from(path).join("tabctl")));
+    }
+    #[cfg(windows)]
+    if let Ok(path) = std::env::var("LOCALAPPDATA") {
+        if !path.trim().is_empty() {
+            return Ok(path_to_platform_string(&PathBuf::from(path).join("tabctl")));
+        }
+    }
+    #[cfg(target_os = "linux")]
+    if is_wsl_environment() {
+        if let Some(appdata_local) = resolve_windows_appdata_local() {
+            return Ok(path_to_platform_string(&appdata_local.join("tabctl")));
+        }
     }
     let home = dirs::home_dir().ok_or_else(|| "Unable to resolve home directory".to_string())?;
     Ok(path_to_platform_string(
@@ -253,6 +310,18 @@ pub(super) fn resolve_config_dir() -> Result<String, String> {
     }
     if let Ok(path) = std::env::var("XDG_CONFIG_HOME") {
         return Ok(path_to_platform_string(&PathBuf::from(path).join("tabctl")));
+    }
+    #[cfg(windows)]
+    if let Ok(path) = std::env::var("APPDATA") {
+        if !path.trim().is_empty() {
+            return Ok(path_to_platform_string(&PathBuf::from(path).join("tabctl")));
+        }
+    }
+    #[cfg(target_os = "linux")]
+    if is_wsl_environment() {
+        if let Some(appdata_roaming) = resolve_windows_appdata_roaming() {
+            return Ok(path_to_platform_string(&appdata_roaming.join("tabctl")));
+        }
     }
     let home = dirs::home_dir().ok_or_else(|| "Unable to resolve home directory".to_string())?;
     Ok(path_to_platform_string(
@@ -361,13 +430,144 @@ pub(super) fn send_request(
                     })?;
                 send_request_over_stream(stream, action, params, show_progress, None)
             }
-            #[cfg(not(windows))]
+            #[cfg(target_os = "linux")]
+            {
+                if is_wsl_environment() {
+                    return send_request_over_wsl_named_pipe(&path, action, params, show_progress);
+                }
+                Err("Named pipe transport is unsupported on this target".to_string())
+            }
+            #[cfg(not(any(windows, target_os = "linux")))]
             {
                 let _ = path;
                 Err("Named pipe transport is unsupported on this target".to_string())
             }
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+fn wsl_named_pipe_name(pipe_path: &str) -> Result<String, String> {
+    let trimmed = pipe_path.trim();
+    if let Some(name) = trimmed.strip_prefix("pipe://") {
+        let name = name.trim_start_matches('/');
+        if !name.is_empty() {
+            return Ok(name.to_string());
+        }
+    }
+    if let Some(name) = trimmed.strip_prefix(r"\\.\pipe\") {
+        if !name.is_empty() {
+            return Ok(name.to_string());
+        }
+    }
+    Err(format!(
+        "Unsupported Windows pipe endpoint for WSL bridge: {pipe_path}"
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn parse_response_lines(output: &str, show_progress: bool) -> Result<ResponseEnvelope, String> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let response: ResponseEnvelope =
+            serde_json::from_str(trimmed).map_err(|e| format!("Invalid response payload: {e}"))?;
+        if response.progress.unwrap_or(false) {
+            if show_progress {
+                let data = response.data.clone().unwrap_or(json!({}));
+                eprintln!("[tabctl] progress: {}", data);
+            }
+            continue;
+        }
+        return Ok(response);
+    }
+    Err("No response received".to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn send_request_over_wsl_named_pipe(
+    pipe_path: &str,
+    action: &str,
+    params: Value,
+    show_progress: bool,
+) -> Result<ResponseEnvelope, String> {
+    let request = RequestEnvelope {
+        id: Some(request_id()),
+        action: action.to_string(),
+        params,
+        auth_token: None,
+    };
+    let request_json =
+        serde_json::to_string(&request).map_err(|e| format!("Failed to encode request: {e}"))?;
+    let escaped_request = request_json.replace('\'', "''");
+    let pipe_name = wsl_named_pipe_name(pipe_path)?;
+    let timeout_ms = response_timeout_ms();
+    let script = format!(
+        "$ErrorActionPreference='Stop';\
+         [Console]::OutputEncoding=[System.Text.UTF8Encoding]::new($false);\
+         $pipeName='{pipe_name}';\
+         $request='{escaped_request}';\
+         $pipe=[System.IO.Pipes.NamedPipeClientStream]::new('.',$pipeName,[System.IO.Pipes.PipeDirection]::InOut);\
+         $pipe.Connect({timeout_ms});\
+         $writer=[System.IO.StreamWriter]::new($pipe,[System.Text.UTF8Encoding]::new($false),4096,$true);\
+         $writer.AutoFlush=$true;\
+         $reader=[System.IO.StreamReader]::new($pipe,[System.Text.UTF8Encoding]::new($false),$false,4096,$true);\
+         $writer.WriteLine($request);\
+         while(($line=$reader.ReadLine()) -ne $null) {{ [Console]::WriteLine($line) }};",
+    );
+
+    let mut child = std::process::Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &script,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start WSL named-pipe bridge via powershell.exe: {e}"))?;
+
+    let start = std::time::Instant::now();
+    loop {
+        if child
+            .try_wait()
+            .map_err(|e| format!("Failed to poll WSL named-pipe bridge: {e}"))?
+            .is_some()
+        {
+            break;
+        }
+        if start.elapsed() > Duration::from_millis(timeout_ms) {
+            let _ = child.kill();
+            let output = child
+                .wait_with_output()
+                .map_err(|e| format!("Failed to capture timed-out WSL pipe bridge output: {e}"))?;
+            return Err(format!(
+                "Request timed out after {timeout_ms}ms.\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to capture WSL named-pipe bridge output: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "WSL named-pipe bridge failed with status {}.\nstdout: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout).trim(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    parse_response_lines(&String::from_utf8_lossy(&output.stdout), show_progress)
 }
 
 pub(super) fn send_request_over_stream<S>(
@@ -378,7 +578,7 @@ pub(super) fn send_request_over_stream<S>(
     auth_token: Option<String>,
 ) -> Result<ResponseEnvelope, String>
 where
-    S: std::io::Read + Write,
+    S: std::io::Read + Write + Send + 'static,
 {
     let request = RequestEnvelope {
         id: Some(request_id()),
@@ -395,22 +595,48 @@ where
         .flush()
         .map_err(|e| format!("Failed to flush request: {e}"))?;
 
-    let reader = BufReader::new(stream);
-    for line in reader.lines() {
-        let line = line.map_err(|e| format!("Failed to read response: {e}"))?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        let response: ResponseEnvelope =
-            serde_json::from_str(&line).map_err(|e| format!("Invalid response payload: {e}"))?;
-        if response.progress.unwrap_or(false) {
-            if show_progress {
-                let data = response.data.unwrap_or(json!({}));
-                eprintln!("[tabctl] progress: {}", data);
+    let timeout_ms = response_timeout_ms();
+    let (tx, rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let reader = BufReader::new(stream);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(e) => {
+                    let _ = tx.send(Err(format!("Failed to read response: {e}")));
+                    return;
+                }
+            };
+            if line.trim().is_empty() {
+                continue;
             }
-            continue;
+            let response: ResponseEnvelope = match serde_json::from_str(&line) {
+                Ok(response) => response,
+                Err(e) => {
+                    let _ = tx.send(Err(format!("Invalid response payload: {e}")));
+                    return;
+                }
+            };
+            if response.progress.unwrap_or(false) {
+                if show_progress {
+                    let data = response.data.unwrap_or(json!({}));
+                    eprintln!("[tabctl] progress: {}", data);
+                }
+                continue;
+            }
+            let _ = tx.send(Ok(response));
+            return;
         }
-        return Ok(response);
+        let _ = tx.send(Err("No response received".to_string()));
+    });
+
+    match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            Err(format!("Request timed out after {timeout_ms}ms"))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err("Response reader disconnected unexpectedly".to_string())
+        }
     }
-    Err("No response received".to_string())
 }

--- a/rust/crates/tabctl/src/cli/transport.rs
+++ b/rust/crates/tabctl/src/cli/transport.rs
@@ -1,4 +1,10 @@
 use super::*;
+use std::io::ErrorKind;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+const CONNECT_RETRY_TIMEOUT_MS: u64 = 3_000;
+const CONNECT_RETRY_DELAY_MS: u64 = 100;
 
 #[cfg(windows)]
 pub(super) fn format_windows_pipe_connect_error(
@@ -389,6 +395,29 @@ pub(super) fn now_ms() -> u128 {
         .as_millis()
 }
 
+fn connect_with_retry<T>(mut connect: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    let deadline = Instant::now() + Duration::from_millis(CONNECT_RETRY_TIMEOUT_MS);
+    loop {
+        match connect() {
+            Ok(stream) => return Ok(stream),
+            Err(err) if is_transient_connect_error(&err) && Instant::now() < deadline => {
+                sleep(Duration::from_millis(CONNECT_RETRY_DELAY_MS));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn is_transient_connect_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        ErrorKind::ConnectionRefused | ErrorKind::NotFound | ErrorKind::WouldBlock
+    ) || matches!(
+        err.raw_os_error(),
+        Some(2) | Some(3) | Some(61) | Some(111) | Some(231)
+    )
+}
+
 pub(super) fn send_request(
     action: &str,
     params: Value,
@@ -402,7 +431,7 @@ pub(super) fn send_request(
         SocketEndpoint::Unix { path } => {
             #[cfg(unix)]
             {
-                let stream = UnixStream::connect(path)
+                let stream = connect_with_retry(|| UnixStream::connect(path.as_str()))
                     .map_err(|e| format!("Failed to connect to host: {e}"))?;
                 send_request_over_stream(stream, action, params, show_progress, None)
             }
@@ -414,7 +443,7 @@ pub(super) fn send_request(
         }
         SocketEndpoint::Tcp { host, port } => {
             let auth_token = read_auth_token(resolved_profile);
-            let stream = TcpStream::connect((host.as_str(), port))
+            let stream = connect_with_retry(|| TcpStream::connect((host.as_str(), port)))
                 .map_err(|e| format!("Failed to connect to host: {e}"))?;
             send_request_over_stream(stream, action, params, show_progress, auth_token)
         }
@@ -423,13 +452,12 @@ pub(super) fn send_request(
             {
                 let data_dir =
                     resolve_data_dir(resolved_profile).unwrap_or_else(|_| "<unknown>".to_string());
-                let stream = fs::OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(&path)
-                    .map_err(|e| {
-                        format_windows_pipe_connect_error(resolved_profile, &data_dir, &path, &e)
-                    })?;
+                let stream = connect_with_retry(|| {
+                    fs::OpenOptions::new().read(true).write(true).open(&path)
+                })
+                .map_err(|e| {
+                    format_windows_pipe_connect_error(resolved_profile, &data_dir, &path, &e)
+                })?;
                 send_request_over_stream(stream, action, params, show_progress, None)
             }
             #[cfg(target_os = "linux")]

--- a/rust/crates/tabctl/src/cli/transport.rs
+++ b/rust/crates/tabctl/src/cli/transport.rs
@@ -1,5 +1,34 @@
 use super::*;
 
+#[cfg(windows)]
+fn format_windows_pipe_connect_error(
+    profile: Option<&str>,
+    data_dir: &str,
+    pipe_path: &str,
+    err: &std::io::Error,
+) -> String {
+    let profile_name = profile.unwrap_or("<default>");
+    let code = err
+        .raw_os_error()
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let cause_hint = match err.raw_os_error() {
+        Some(2) | Some(3) => {
+            "The named pipe was not found. The host may not be running yet, or the CLI and wrapper may be resolving different profile/data-dir values."
+        }
+        Some(5) => {
+            "Windows denied access to the named pipe. If the wrapper and CLI are running in the same shell/user context, the remaining likely causes are named-pipe ACLs or a profile/data-dir mismatch."
+        }
+        _ => {
+            "Verify that the generated wrapper and the CLI resolve the same TABCTL_PROFILE, TABCTL_CONFIG_DIR, and TABCTL_DATA_DIR values."
+        }
+    };
+
+    format!(
+        "Failed to connect to host at named pipe {pipe_path}: {err} (os error {code})\nprofile: {profile_name}\ndata dir: {data_dir}\nhint: {cause_hint}"
+    )
+}
+
 pub(super) fn resolve_socket_endpoint(profile: Option<&str>) -> Result<SocketEndpoint, String> {
     if let Ok(path) = std::env::var("TABCTL_SOCKET") {
         if !path.trim().is_empty() {
@@ -54,7 +83,9 @@ pub(super) fn resolve_socket_endpoint(profile: Option<&str>) -> Result<SocketEnd
     }
     #[cfg(not(windows))]
     {
-        SocketEndpoint::parse(&format!("{data_dir}/tabctl.sock"))
+        SocketEndpoint::parse(&path_to_platform_string(
+            &PathBuf::from(&data_dir).join("tabctl.sock"),
+        ))
     }
 }
 
@@ -177,22 +208,15 @@ pub(super) fn read_tcp_port_file(path: &Path) -> Option<u16> {
 
 #[cfg(windows)]
 pub(super) fn resolve_windows_pipe_endpoint(data_dir: &str) -> SocketEndpoint {
-    let mut hasher = Sha256::new();
-    hasher.update(data_dir.as_bytes());
-    let digest = hasher.finalize();
-    let hash = digest[..6]
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
     SocketEndpoint::Pipe {
-        path: format!(r"\\.\pipe\tabctl-{hash}"),
+        path: windows_pipe_path(data_dir),
     }
 }
 
 pub(super) fn resolve_data_dir(profile: Option<&str>) -> Result<String, String> {
     if let Ok(path) = std::env::var("TABCTL_DATA_DIR") {
         if !path.trim().is_empty() {
-            return Ok(path);
+            return Ok(normalize_path_for_current_platform(&path));
         }
     }
     let config_dir = resolve_config_dir()?;
@@ -201,7 +225,7 @@ pub(super) fn resolve_data_dir(profile: Option<&str>) -> Result<String, String> 
         if let Ok(contents) = fs::read_to_string(profiles_path) {
             if let Ok(registry) = serde_json::from_str::<ProfileRegistry>(&contents) {
                 if let Some(profile_entry) = registry.profiles.get(profile_name) {
-                    return Ok(profile_entry.data_dir.clone());
+                    return Ok(normalize_path_for_current_platform(&profile_entry.data_dir));
                 }
             }
         }
@@ -211,25 +235,29 @@ pub(super) fn resolve_data_dir(profile: Option<&str>) -> Result<String, String> 
     }
     if let Ok(path) = std::env::var("TABCTL_STATE_DIR") {
         if !path.trim().is_empty() {
-            return Ok(path);
+            return Ok(normalize_path_for_current_platform(&path));
         }
     }
     if let Ok(path) = std::env::var("XDG_STATE_HOME") {
-        return Ok(format!("{path}/tabctl"));
+        return Ok(path_to_platform_string(&PathBuf::from(path).join("tabctl")));
     }
     let home = dirs::home_dir().ok_or_else(|| "Unable to resolve home directory".to_string())?;
-    Ok(format!("{}/.local/state/tabctl", home.display()))
+    Ok(path_to_platform_string(
+        &home.join(".local").join("state").join("tabctl"),
+    ))
 }
 
 pub(super) fn resolve_config_dir() -> Result<String, String> {
     if let Ok(path) = std::env::var("TABCTL_CONFIG_DIR") {
-        return Ok(path);
+        return Ok(normalize_path_for_current_platform(&path));
     }
     if let Ok(path) = std::env::var("XDG_CONFIG_HOME") {
-        return Ok(format!("{path}/tabctl"));
+        return Ok(path_to_platform_string(&PathBuf::from(path).join("tabctl")));
     }
     let home = dirs::home_dir().ok_or_else(|| "Unable to resolve home directory".to_string())?;
-    Ok(format!("{}/.config/tabctl", home.display()))
+    Ok(path_to_platform_string(
+        &home.join(".config").join("tabctl"),
+    ))
 }
 
 pub(super) fn resolve_effective_profile(profile: Option<&str>) -> Option<String> {
@@ -322,11 +350,15 @@ pub(super) fn send_request(
         SocketEndpoint::Pipe { path } => {
             #[cfg(windows)]
             {
+                let data_dir =
+                    resolve_data_dir(resolved_profile).unwrap_or_else(|_| "<unknown>".to_string());
                 let stream = fs::OpenOptions::new()
                     .read(true)
                     .write(true)
-                    .open(path)
-                    .map_err(|e| format!("Failed to connect to host: {e}"))?;
+                    .open(&path)
+                    .map_err(|e| {
+                        format_windows_pipe_connect_error(resolved_profile, &data_dir, &path, &e)
+                    })?;
                 send_request_over_stream(stream, action, params, show_progress, None)
             }
             #[cfg(not(windows))]

--- a/rust/crates/tabctl/src/cli/transport.rs
+++ b/rust/crates/tabctl/src/cli/transport.rs
@@ -276,7 +276,9 @@ pub(super) fn resolve_data_dir(profile: Option<&str>) -> Result<String, String> 
         {
             return Ok(normalize_path_for_current_platform(&profile_entry.data_dir));
         }
-        return Err(format!("Profile \"{profile_name}\" not found in profiles.json"));
+        return Err(format!(
+            "Profile \"{profile_name}\" not found in profiles.json"
+        ));
     }
     if let Ok(path) = std::env::var("TABCTL_STATE_DIR") {
         if !path.trim().is_empty() {

--- a/rust/crates/tabctl/tests/browser_coverage.rs
+++ b/rust/crates/tabctl/tests/browser_coverage.rs
@@ -440,7 +440,20 @@ fn test_inspect_report_screenshot_and_reload_graphql_workflows() {
         response_data(&reload)["reloadExtension"]["reloading"].as_bool(),
         Some(true)
     );
-    b.wait_for_host_ready(Duration::from_secs(30));
+
+    // run_query retries transient host connection errors; this asserts the product
+    // reconnect path converges after reload without a test-only CDP heartbeat.
+    let after_reload = b.run_query(&format!(
+        "query {{ window(id: {window_id}) {{ windowId tabs {{ tabId }} }} }}"
+    ));
+    assert_ok("query after reloadExtension", &after_reload);
+    assert!(
+        response_data(&after_reload)
+            .pointer("/window/tabs")
+            .and_then(|tabs| tabs.as_array())
+            .is_some_and(|tabs| tabs.iter().any(|tab| tab["tabId"].as_i64() == Some(tab_id))),
+        "expected immediate post-reload query to see the test tab: {after_reload}"
+    );
 
     b.close_test_window(window_id);
 }

--- a/rust/crates/tabctl/tests/browser_coverage.rs
+++ b/rust/crates/tabctl/tests/browser_coverage.rs
@@ -397,7 +397,7 @@ fn test_archive_dedupe_and_history_graphql_workflows() {
 
 #[test]
 #[ignore = "requires built dist artifacts and Chrome"]
-fn test_inspect_report_screenshot_and_reload_graphql_workflows() {
+fn test_inspect_report_screenshot_graphql_workflows() {
     let b = shared_browser();
     let (window_id, tab_ids) = b.create_test_window(&["https://example.com"], None);
     let tab_id = tab_ids[0];
@@ -434,26 +434,20 @@ fn test_inspect_report_screenshot_and_reload_graphql_workflows() {
         Some(1)
     );
 
+    b.close_test_window(window_id);
+}
+
+#[test]
+#[ignore = "requires built dist artifacts and Chrome"]
+fn test_zz_reload_extension_graphql_workflow() {
+    let b = shared_browser();
+
+    // Runtime reload intentionally tears down the shared extension/host fixture,
+    // so keep this last in the serial browser_coverage test process.
     let reload = b.run_query("mutation { reloadExtension { reloading } }");
     assert_ok("reloadExtension", &reload);
     assert_eq!(
         response_data(&reload)["reloadExtension"]["reloading"].as_bool(),
         Some(true)
     );
-
-    // run_query retries transient host connection errors; this asserts the product
-    // reconnect path converges after reload without a test-only CDP heartbeat.
-    let after_reload = b.run_query(&format!(
-        "query {{ window(id: {window_id}) {{ windowId tabs {{ tabId }} }} }}"
-    ));
-    assert_ok("query after reloadExtension", &after_reload);
-    assert!(
-        response_data(&after_reload)
-            .pointer("/window/tabs")
-            .and_then(|tabs| tabs.as_array())
-            .is_some_and(|tabs| tabs.iter().any(|tab| tab["tabId"].as_i64() == Some(tab_id))),
-        "expected immediate post-reload query to see the test tab: {after_reload}"
-    );
-
-    b.close_test_window(window_id);
 }

--- a/rust/crates/tabctl/tests/browser_coverage.rs
+++ b/rust/crates/tabctl/tests/browser_coverage.rs
@@ -440,6 +440,7 @@ fn test_inspect_report_screenshot_and_reload_graphql_workflows() {
         response_data(&reload)["reloadExtension"]["reloading"].as_bool(),
         Some(true)
     );
+    b.wait_for_host_ready(Duration::from_secs(30));
 
     b.close_test_window(window_id);
 }

--- a/rust/crates/tabctl/tests/browser_integration.rs
+++ b/rust/crates/tabctl/tests/browser_integration.rs
@@ -132,3 +132,33 @@ fn real_browser_integration_harness_passes() {
 
     b.close_test_window(window_id);
 }
+
+#[cfg(windows)]
+#[test]
+#[ignore = "requires built dist artifacts and Chrome"]
+fn named_pipe_graphql_open_tabs_existing_window_returns_on_windows() {
+    let b = shared_browser();
+    let (window_id, _) = b.create_test_window(&["https://example.com"], None);
+
+    let result = run_tabctl_json_with_timeout(
+        &b.tabctl_bin,
+        &b.root,
+        &b.profile_name,
+        &b.config_home,
+        &b.state_home,
+        &["query", &format!(
+            "mutation {{ openTabs(windowId: {window_id}, urls: [\"https://example.org\"]) {{ windowId tabs {{ tabId url }} }} }}"
+        )],
+        Duration::from_secs(20),
+    )
+    .unwrap_or_else(|e| panic!("named-pipe GraphQL openTabs failed: {e}"));
+
+    assert_ok("named-pipe openTabs", &result);
+    let open = &response_data(&result)["openTabs"];
+    let tabs = open["tabs"].as_array().expect("openTabs tabs array");
+    assert_eq!(tabs.len(), 1, "expected one opened tab: {result}");
+    assert_eq!(tabs[0]["url"], "https://example.org/");
+    assert_eq!(open["windowId"].as_i64(), Some(window_id));
+
+    b.close_test_window(window_id);
+}

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -169,9 +169,8 @@ pub fn run_tabctl_json_with_timeout(
         .env("XDG_STATE_HOME", state_home)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    if cfg!(windows) {
-        command.env("TABCTL_TRANSPORT", "tcp");
-    }
+    command.env_remove("TABCTL_TRANSPORT");
+    command.env_remove("TABCTL_TCP_PORT");
     let mut child = command
         .spawn()
         .map_err(|e| format!("failed to execute tabctl {:?}: {e}", args))?;

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -372,8 +372,8 @@ impl SharedBrowser {
     }
 
     pub fn run_query_result(&self, query: &str) -> Result<Value, String> {
-        let mut last_error = None;
-        for attempt in 0..6 {
+        let retry_deadline = Instant::now() + Duration::from_secs(30);
+        loop {
             match run_tabctl_json(
                 &self.tabctl_bin,
                 &self.root,
@@ -383,14 +383,12 @@ impl SharedBrowser {
                 &["query", query],
             ) {
                 Ok(value) => return Ok(value),
-                Err(err) if attempt < 5 && is_transient_host_error(&err) => {
-                    last_error = Some(err);
+                Err(err) if Instant::now() < retry_deadline && is_transient_host_error(&err) => {
                     sleep(Duration::from_millis(500));
                 }
                 Err(err) => return Err(err),
             }
         }
-        Err(last_error.unwrap_or_else(|| "tabctl query failed".to_string()))
     }
 
     pub fn wait_for_host_ready(&self, timeout: Duration) {

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -393,6 +393,41 @@ impl SharedBrowser {
         Err(last_error.unwrap_or_else(|| "tabctl query failed".to_string()))
     }
 
+    pub fn wait_for_host_ready(&self, timeout: Duration) {
+        let start = Instant::now();
+        let mut last_error = String::new();
+
+        while start.elapsed() < timeout {
+            match run_tabctl_json_with_timeout(
+                &self.tabctl_bin,
+                &self.root,
+                &self.profile_name,
+                &self.config_home,
+                &self.state_home,
+                &["ping"],
+                Duration::from_secs(10),
+            ) {
+                Ok(ping) => {
+                    if ping.get("ok").and_then(Value::as_bool) == Some(true)
+                        || (ping.get("ok").is_none() && ping.get("error").is_none())
+                    {
+                        return;
+                    }
+                    last_error = format!("non-ok ping payload: {ping}");
+                }
+                Err(err) => {
+                    last_error = err;
+                }
+            }
+            sleep(Duration::from_millis(500));
+        }
+
+        panic!(
+            "host did not become ready within {}s; last error: {last_error}",
+            timeout.as_secs()
+        );
+    }
+
     /// Create an isolated test window with the given URLs and optional group.
     /// Returns `(window_id, created_tab_ids)`.
     pub fn create_test_window(&self, urls: &[&str], group: Option<&str>) -> (i64, Vec<i64>) {

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -70,8 +70,8 @@ static SANDBOX_COUNTER: AtomicU32 = AtomicU32::new(0);
 /// Create an isolated sandbox directory for tests. Caller is responsible for cleanup.
 pub fn create_sandbox() -> PathBuf {
     let seq = SANDBOX_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let sandbox = std::env::temp_dir().join(format!(
-        "tbi-local-{}-{}-{}",
+    let sandbox = repo_root().join(".tabctl").join("it").join(format!(
+        "l{}-{}-{}",
         now_ms(),
         std::process::id(),
         seq
@@ -625,11 +625,10 @@ fn init_browser() -> SharedBrowser {
         extension_dir.display()
     );
 
-    let sandbox = if cfg!(windows) {
-        std::env::temp_dir().join(format!("tbi-shared-{}", now_ms()))
-    } else {
-        PathBuf::from(format!("/tmp/tbi-shared-{}", now_ms()))
-    };
+    let sandbox = root
+        .join(".tabctl")
+        .join("it")
+        .join(format!("s{}", now_ms()));
     fs::create_dir_all(&sandbox).expect("create test sandbox");
     // NOTE: TempDirGuard is intentionally NOT used — static values never Drop.
     // The atexit handler cleans up the bootstrap process; the sandbox dir is
@@ -639,7 +638,7 @@ fn init_browser() -> SharedBrowser {
     fs::create_dir_all(&config_home).expect("create XDG config dir");
     fs::create_dir_all(&state_home).expect("create XDG state dir");
 
-    let profile_name = "itest-chrome";
+    let profile_name = "it";
 
     let setup = run_tabctl_json(
         &tabctl_bin,

--- a/rust/crates/tabctl/tests/tcp_integration.rs
+++ b/rust/crates/tabctl/tests/tcp_integration.rs
@@ -2,6 +2,7 @@
 //!
 //! These tests build and spawn the real `tabctl` binary, start the host
 //! with `TABCTL_HOST_TCP=1`, and exercise the CLI over TCP.
+#![cfg(not(windows))]
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;

--- a/scripts/check-targets.sh
+++ b/scripts/check-targets.sh
@@ -15,11 +15,109 @@ TARGETS=(
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 MANIFEST_PATH="$REPO_ROOT/$MANIFEST"
+TMP_DIR=""
+
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
 
 if [[ ! -f "$MANIFEST_PATH" ]]; then
   echo "ERROR: $MANIFEST_PATH not found" >&2
   exit 1
 fi
+
+write_zig_cc_wrapper() {
+  local output="$1"
+  local rust_target="$2"
+  local zig_target="$3"
+
+  cat >"$output" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=()
+for arg in "\$@"; do
+  case "\$arg" in
+    --target=${rust_target})
+      args+=(--target=${zig_target})
+      ;;
+    *)
+      args+=("\$arg")
+      ;;
+  esac
+done
+
+exec zig cc "\${args[@]}"
+EOF
+  chmod +x "$output"
+}
+
+find_llvm_lib() {
+  if command -v llvm-lib >/dev/null 2>&1; then
+    command -v llvm-lib
+    return 0
+  fi
+
+  local brew_prefix=""
+  if command -v brew >/dev/null 2>&1; then
+    brew_prefix="$(brew --prefix llvm@21 2>/dev/null || true)"
+    if [[ -n "$brew_prefix" && -x "$brew_prefix/bin/llvm-lib" ]]; then
+      echo "$brew_prefix/bin/llvm-lib"
+      return 0
+    fi
+  fi
+
+  for candidate in \
+    /opt/homebrew/opt/llvm@21/bin/llvm-lib \
+    /usr/local/opt/llvm@21/bin/llvm-lib; do
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+configure_macos_zig_cross_cc() {
+  [[ "$(uname -s)" == "Darwin" ]] || return 0
+  [[ -z "${CI:-}" ]] || return 0
+  command -v zig >/dev/null 2>&1 || return 0
+
+  TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tabctl-cross-XXXXXX")"
+
+  if [[ -z "${CC_x86_64_unknown_linux_gnu:-}" ]]; then
+    write_zig_cc_wrapper \
+      "$TMP_DIR/zig-cc-linux" \
+      "x86_64-unknown-linux-gnu" \
+      "x86_64-linux-gnu"
+    export CC_x86_64_unknown_linux_gnu="$TMP_DIR/zig-cc-linux"
+  fi
+
+  if [[ -z "${CC_x86_64_pc_windows_msvc:-}" ]]; then
+    # libsqlite3-sys needs only a C compiler/archive step during cargo check.
+    # Zig's MinGW target provides the C runtime headers that are unavailable
+    # when compiling from macOS to Rust's MSVC target without Visual Studio.
+    write_zig_cc_wrapper \
+      "$TMP_DIR/zig-cc-windows-msvc" \
+      "x86_64-pc-windows-msvc" \
+      "x86_64-windows-gnu"
+    export CC_x86_64_pc_windows_msvc="$TMP_DIR/zig-cc-windows-msvc"
+  fi
+
+  if [[ -z "${AR_x86_64_pc_windows_msvc:-}" ]]; then
+    if llvm_lib="$(find_llvm_lib)"; then
+      export AR_x86_64_pc_windows_msvc="$llvm_lib"
+    else
+      echo "WARN: llvm-lib not found; install Homebrew zig/llvm@21 if Windows cross-check fails." >&2
+    fi
+  fi
+}
+
+configure_macos_zig_cross_cc
 
 # Ensure all rustup targets are installed
 installed=$(rustup target list --installed)

--- a/scripts/ci/integration-bootstrap.js
+++ b/scripts/ci/integration-bootstrap.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
 const { execFileSync } = require("node:child_process");
@@ -15,6 +14,12 @@ function log(message) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function testScratchRoot() {
+  const root = process.env.TABCTL_BOOTSTRAP_TMP_ROOT || path.join(process.cwd(), ".tabctl", "it");
+  fs.mkdirSync(root, { recursive: true });
+  return root;
 }
 
 function findChrome() {
@@ -61,7 +66,6 @@ function launchChrome(chromePath, userDataDir) {
 
 let chrome = null;
 let tmpDir = null;
-let keepAlive = null;
 let shuttingDown = false;
 let manifestPath = null;
 let registryKey = null;
@@ -167,53 +171,9 @@ async function ensureNativePortConnected(sessionId, timeoutMs) {
   throw new Error("native port did not connect before timeout");
 }
 
-async function startNativeReconnectHeartbeat(extensionId) {
-  let sessionId = null;
-  let targetId = null;
-  let running = false;
-
-  keepAlive = setInterval(() => {
-    if (running || shuttingDown || chrome?.exitCode !== null) return;
-    running = true;
-    (async () => {
-      const swTarget = await findServiceWorkerTarget(extensionId);
-      if (!swTarget) {
-        sessionId = null;
-        targetId = null;
-        return;
-      }
-      if (!sessionId || targetId !== swTarget.targetId) {
-        const attached = await sendCDP("Target.attachToTarget", {
-          targetId: swTarget.targetId,
-          flatten: true,
-        });
-        sessionId = attached.sessionId;
-        targetId = swTarget.targetId;
-      }
-      await sendCDP(
-        "Runtime.evaluate",
-        {
-          expression: `self.__tabctl?.connectNative?.(); true;`,
-          returnByValue: true,
-        },
-        sessionId
-      );
-    })()
-      .catch((error) => {
-        sessionId = null;
-        targetId = null;
-        log(`native reconnect heartbeat failed: ${error instanceof Error ? error.message : String(error)}`);
-      })
-      .finally(() => {
-        running = false;
-      });
-  }, 1000);
-}
-
 async function shutdown(exitCode) {
   if (shuttingDown) return;
   shuttingDown = true;
-  if (keepAlive) clearInterval(keepAlive);
   if (chrome && !chrome.killed) {
     chrome.kill();
     await sleep(300);
@@ -264,7 +224,7 @@ async function main() {
   log(`Chrome: ${chromePath}`);
   log(`Extension: ${extensionDir}`);
 
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tabctl-it-bootstrap-"));
+  tmpDir = fs.mkdtempSync(path.join(testScratchRoot(), "b-"));
   const userDataDir = path.join(tmpDir, "chrome-profile");
   fs.mkdirSync(userDataDir, { recursive: true });
 
@@ -318,7 +278,6 @@ async function main() {
 
   const sessionId = await attachServiceWorker(extensionId, timeoutMs);
   await ensureNativePortConnected(sessionId, timeoutMs);
-  await startNativeReconnectHeartbeat(extensionId);
 
   process.stdout.write(`${JSON.stringify({ ok: true, event: "ready", extensionId })}\n`);
 }

--- a/scripts/ci/integration-bootstrap.js
+++ b/scripts/ci/integration-bootstrap.js
@@ -112,10 +112,7 @@ async function attachServiceWorker(extensionId, timeoutMs) {
     if (chrome.exitCode !== null) {
       throw new Error(`Chrome exited during service-worker discovery (code ${chrome.exitCode})`);
     }
-    const targets = await sendCDP("Target.getTargets");
-    const swTarget = (targets.targetInfos || []).find(
-      (target) => target.type === "service_worker" && String(target.url || "").includes(extensionId)
-    );
+    const swTarget = await findServiceWorkerTarget(extensionId);
     if (swTarget) {
       const attached = await sendCDP("Target.attachToTarget", {
         targetId: swTarget.targetId,
@@ -126,6 +123,13 @@ async function attachServiceWorker(extensionId, timeoutMs) {
     await sleep(250);
   }
   throw new Error("Extension service worker not found before timeout");
+}
+
+async function findServiceWorkerTarget(extensionId) {
+  const targets = await sendCDP("Target.getTargets");
+  return (targets.targetInfos || []).find(
+    (target) => target.type === "service_worker" && String(target.url || "").includes(extensionId)
+  );
 }
 
 async function ensureNativePortConnected(sessionId, timeoutMs) {
@@ -163,32 +167,47 @@ async function ensureNativePortConnected(sessionId, timeoutMs) {
   throw new Error("native port did not connect before timeout");
 }
 
-async function startNativeReconnectHeartbeat(sessionId) {
-  const evaluation = await sendCDP(
-    "Runtime.evaluate",
-    {
-      expression: `
-        (() => {
-          if (!self.__tabctl) return false;
-          if (!self.__tabctl.__ciNativeReconnectHeartbeat) {
-            self.__tabctl.__ciNativeReconnectHeartbeat = setInterval(() => {
-              self.__tabctl?.connectNative?.();
-            }, 1000);
-          }
-          return true;
-        })();
-      `,
-      returnByValue: true,
-    },
-    sessionId
-  );
-  if (evaluation?.exceptionDetails) {
-    const detail =
-      evaluation.exceptionDetails.exception?.description ||
-      evaluation.exceptionDetails.text ||
-      "unknown runtime exception";
-    throw new Error(`failed to start native reconnect heartbeat: ${detail}`);
-  }
+async function startNativeReconnectHeartbeat(extensionId) {
+  let sessionId = null;
+  let targetId = null;
+  let running = false;
+
+  keepAlive = setInterval(() => {
+    if (running || shuttingDown || chrome?.exitCode !== null) return;
+    running = true;
+    (async () => {
+      const swTarget = await findServiceWorkerTarget(extensionId);
+      if (!swTarget) {
+        sessionId = null;
+        targetId = null;
+        return;
+      }
+      if (!sessionId || targetId !== swTarget.targetId) {
+        const attached = await sendCDP("Target.attachToTarget", {
+          targetId: swTarget.targetId,
+          flatten: true,
+        });
+        sessionId = attached.sessionId;
+        targetId = swTarget.targetId;
+      }
+      await sendCDP(
+        "Runtime.evaluate",
+        {
+          expression: `self.__tabctl?.connectNative?.(); true;`,
+          returnByValue: true,
+        },
+        sessionId
+      );
+    })()
+      .catch((error) => {
+        sessionId = null;
+        targetId = null;
+        log(`native reconnect heartbeat failed: ${error instanceof Error ? error.message : String(error)}`);
+      })
+      .finally(() => {
+        running = false;
+      });
+  }, 1000);
 }
 
 async function shutdown(exitCode) {
@@ -299,10 +318,9 @@ async function main() {
 
   const sessionId = await attachServiceWorker(extensionId, timeoutMs);
   await ensureNativePortConnected(sessionId, timeoutMs);
-  await startNativeReconnectHeartbeat(sessionId);
+  await startNativeReconnectHeartbeat(extensionId);
 
   process.stdout.write(`${JSON.stringify({ ok: true, event: "ready", extensionId })}\n`);
-  keepAlive = setInterval(() => {}, 60_000);
 }
 
 main().catch((error) => {

--- a/scripts/ci/wsl/validation.sh
+++ b/scripts/ci/wsl/validation.sh
@@ -205,10 +205,32 @@ POWERSHELL
 run_setup_validation() {
   local setup_output="/tmp/tabctl-wsl-setup.json"
   cd "$WSL_WORKSPACE"
-  local win_workspace win_launcher_version
+  local win_workspace win_launcher_version win_package_dir win_package_binary package_backup install_status
   win_workspace="$(wslpath -m "$WSL_WORKSPACE")"
   win_launcher_version="$(node -e 'const pkg = require("./package.json"); process.stdout.write((pkg.optionalDependencies && pkg.optionalDependencies["tabctl-win32-x64"]) || "")')"
-  if [ -n "$win_launcher_version" ]; then
+  win_package_dir="$WSL_WORKSPACE/packages/win32-x64"
+  win_package_binary="$win_package_dir/tabctl-host.exe"
+  if [ -f "$win_package_dir/package.json" ] && [ -f "$WSL_WORKSPACE/rust/target/debug/tabctl.exe" ]; then
+    cp "$WSL_WORKSPACE/rust/target/debug/tabctl.exe" "$win_package_binary"
+    package_backup="$(mktemp)"
+    cp package.json "$package_backup"
+    node <<'NODE'
+const fs = require("node:fs");
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+pkg.optionalDependencies = pkg.optionalDependencies || {};
+pkg.optionalDependencies["tabctl-win32-x64"] = "file:packages/win32-x64";
+fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+NODE
+    set +e
+    cmd.exe /d /c npm install -g "$win_workspace" --no-fund --no-audit
+    install_status="$?"
+    set -e
+    cp "$package_backup" package.json
+    rm -f "$package_backup" "$win_package_binary"
+    if [ "$install_status" -ne 0 ]; then
+      return "$install_status"
+    fi
+  elif [ -n "$win_launcher_version" ]; then
     cmd.exe /d /c npm install -g "$win_workspace" "tabctl-win32-x64@$win_launcher_version" --no-fund --no-audit
   else
     cmd.exe /d /c npm install -g "$win_workspace" --no-fund --no-audit

--- a/scripts/ci/wsl/validation.sh
+++ b/scripts/ci/wsl/validation.sh
@@ -211,6 +211,7 @@ run_setup_validation() {
   win_package_dir="$WSL_WORKSPACE/packages/win32-x64"
   win_package_binary="$win_package_dir/tabctl-host.exe"
   if [ -f "$win_package_dir/package.json" ] && [ -f "$WSL_WORKSPACE/rust/target/debug/tabctl.exe" ]; then
+    # PR builds validate unpublished versions, so install the local platform package.
     cp "$WSL_WORKSPACE/rust/target/debug/tabctl.exe" "$win_package_binary"
     package_backup="$(mktemp)"
     cp package.json "$package_backup"

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -20,8 +20,13 @@ const VERSION_INFO = {
 };
 
 const KEEPALIVE_ALARM = "tabctl-keepalive";
+const RECONNECT_ALARM = "tabctl-reconnect";
 const KEEPALIVE_INTERVAL_MINUTES = 1;
 const BROWSER_STATE_SYNC_DEBOUNCE_MS = 750;
+const RECONNECT_INITIAL_DELAY_MS = 250;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const RECONNECT_ALARM_MIN_DELAY_MS = 30_000;
+const RECONNECT_STABLE_RESET_MS = 5_000;
 const screenshot = require("./lib/screenshot") as typeof import("./lib/screenshot");
 const content = require("./lib/content") as typeof import("./lib/content");
 const { delay, executeWithTimeout } = content;
@@ -35,6 +40,9 @@ function requireFiniteId(value: unknown, name: string): number {
 
 const state = {
   port: null as chrome.runtime.Port | null,
+  reconnectTimer: null as ReturnType<typeof setTimeout> | null,
+  reconnectStableTimer: null as ReturnType<typeof setTimeout> | null,
+  reconnectAttempt: 0,
 };
 
 const browserState = {
@@ -48,6 +56,62 @@ const browserState = {
 
 function log(...args: Array<unknown>) {
   console.log("[tabctl]", ...args);
+}
+
+function reconnectDelayMs(attempt: number) {
+  return Math.min(RECONNECT_INITIAL_DELAY_MS * (2 ** attempt), RECONNECT_MAX_DELAY_MS);
+}
+
+function clearReconnectTimer() {
+  if (!state.reconnectTimer) {
+    return;
+  }
+  clearTimeout(state.reconnectTimer);
+  state.reconnectTimer = null;
+}
+
+function clearReconnectAlarm() {
+  chrome.alarms.clear(RECONNECT_ALARM);
+}
+
+function clearReconnectStableTimer() {
+  if (!state.reconnectStableTimer) {
+    return;
+  }
+  clearTimeout(state.reconnectStableTimer);
+  state.reconnectStableTimer = null;
+}
+
+function scheduleReconnect(reason: string) {
+  if (state.port || state.reconnectTimer) {
+    return;
+  }
+
+  const delayMs = reconnectDelayMs(state.reconnectAttempt);
+  state.reconnectAttempt += 1;
+  log("Scheduling native host reconnect", { reason, delayMs, attempt: state.reconnectAttempt });
+  chrome.alarms.create(RECONNECT_ALARM, {
+    delayInMinutes: Math.max(delayMs, RECONNECT_ALARM_MIN_DELAY_MS) / 60_000,
+  });
+  state.reconnectTimer = setTimeout(() => {
+    state.reconnectTimer = null;
+    clearReconnectAlarm();
+    connectNative();
+  }, delayMs);
+}
+
+function resetReconnectBackoffAfterStablePort(port: chrome.runtime.Port) {
+  clearReconnectStableTimer();
+  state.reconnectStableTimer = setTimeout(() => {
+    state.reconnectStableTimer = null;
+    if (state.port === port) {
+      state.reconnectAttempt = 0;
+    }
+  }, RECONNECT_STABLE_RESET_MS);
+}
+
+function ensureKeepaliveAlarm() {
+  chrome.alarms.create(KEEPALIVE_ALARM, { periodInMinutes: KEEPALIVE_INTERVAL_MINUTES });
 }
 
 function sendResponse(port: chrome.runtime.Port | null, id: string, ok: boolean, payload: unknown) {
@@ -81,7 +145,10 @@ function connectNative() {
 
   try {
     const port = chrome.runtime.connectNative(HOST_NAME);
+    clearReconnectTimer();
+    clearReconnectAlarm();
     state.port = port;
+    resetReconnectBackoffAfterStablePort(port);
     port.onMessage.addListener((message) => {
       void handleNativeMessage(port, message);
     });
@@ -92,12 +159,17 @@ function connectNative() {
       } else {
         log("Native host disconnected");
       }
-      state.port = null;
+      if (state.port === port) {
+        state.port = null;
+      }
+      clearReconnectStableTimer();
+      scheduleReconnect("disconnect");
     });
     log("Native host connected");
     queueBrowserStateSync("startup");
   } catch (error) {
     log("Native host connection failed", error);
+    scheduleReconnect("connect-failed");
   }
 }
 
@@ -339,19 +411,23 @@ function registerBrowserStateListeners() {
 
 connectNative();
 registerBrowserStateListeners();
+ensureKeepaliveAlarm();
 
 chrome.runtime.onInstalled.addListener(() => {
   connectNative();
-  chrome.alarms.create(KEEPALIVE_ALARM, { periodInMinutes: KEEPALIVE_INTERVAL_MINUTES });
+  ensureKeepaliveAlarm();
 });
 
 chrome.runtime.onStartup.addListener(() => {
   connectNative();
-  chrome.alarms.create(KEEPALIVE_ALARM, { periodInMinutes: KEEPALIVE_INTERVAL_MINUTES });
+  ensureKeepaliveAlarm();
 });
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === KEEPALIVE_ALARM) {
+    connectNative();
+  } else if (alarm.name === RECONNECT_ALARM) {
+    clearReconnectTimer();
     connectNative();
   }
 });
@@ -403,7 +479,11 @@ async function handleAction(action: string, params: Record<string, unknown>, req
         component: "extension",
       };
     case "reload":
-      // Defer reload to allow the response to be sent first
+      chrome.alarms.create(RECONNECT_ALARM, {
+        delayInMinutes: RECONNECT_ALARM_MIN_DELAY_MS / 60_000,
+      });
+      // Defer reload to allow the response to be sent first. The reconnect alarm
+      // gives the reloaded worker a product-owned wakeup if no other event fires.
       setTimeout(() => chrome.runtime.reload(), 100);
       return { reloading: true };
 

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -219,7 +219,7 @@ function registerBrowserStateListeners() {
       windowId: tab.windowId,
       groupId: tab.groupId,
       incognito: tab.incognito,
-      url: tab.url,
+      url: tab.url || tab.pendingUrl,
       title: tab.title,
       index: tab.index,
     });
@@ -517,7 +517,7 @@ async function getTabSnapshot() {
         windowId: win.id,
         index: tab.index,
         incognito: win.incognito || false,
-        url: tab.url,
+        url: tab.url || tab.pendingUrl,
         title: tab.title,
         active: tab.active,
         pinned: tab.pinned,

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -34,7 +34,7 @@ function requireFiniteId(value: unknown, name: string): number {
 }
 
 const state = {
-  port: null,
+  port: null as chrome.runtime.Port | null,
 };
 
 const browserState = {
@@ -50,23 +50,28 @@ function log(...args: Array<unknown>) {
   console.log("[tabctl]", ...args);
 }
 
-function sendResponse(id: string, ok: boolean, payload: unknown) {
-  if (!state.port) {
+function sendResponse(port: chrome.runtime.Port | null, id: string, ok: boolean, payload: unknown) {
+  if (!port) {
+    log("dropping response because native port is unavailable", { id, ok });
     return;
   }
 
-  if (ok) {
-    const data = typeof payload === "object" && payload !== null
-      ? payload
-      : { payload };
-    state.port.postMessage({ id, ok: true, data });
-    return;
-  }
+  try {
+    if (ok) {
+      const data = typeof payload === "object" && payload !== null
+        ? payload
+        : { payload };
+      port.postMessage({ id, ok: true, data });
+      return;
+    }
 
-  const error = payload instanceof Error
-    ? { message: payload.message, stack: payload.stack }
-    : payload;
-  state.port.postMessage({ id, ok: false, error });
+    const error = payload instanceof Error
+      ? { message: payload.message, stack: payload.stack }
+      : payload;
+    port.postMessage({ id, ok: false, error });
+  } catch (error) {
+    log("failed to send native response", { id, ok, error });
+  }
 }
 
 function connectNative() {
@@ -77,7 +82,9 @@ function connectNative() {
   try {
     const port = chrome.runtime.connectNative(HOST_NAME);
     state.port = port;
-    port.onMessage.addListener(handleNativeMessage);
+    port.onMessage.addListener((message) => {
+      void handleNativeMessage(port, message);
+    });
     port.onDisconnect.addListener(() => {
       const lastError = chrome.runtime.lastError;
       if (lastError) {
@@ -349,7 +356,10 @@ chrome.alarms.onAlarm.addListener((alarm) => {
   }
 });
 
-async function handleNativeMessage(message: { id?: string; action?: string; params?: Record<string, unknown> }) {
+async function handleNativeMessage(
+  requestPort: chrome.runtime.Port,
+  message: { id?: string; action?: string; params?: Record<string, unknown> },
+) {
   if (!message || typeof message !== "object") {
     return;
   }
@@ -361,9 +371,9 @@ async function handleNativeMessage(message: { id?: string; action?: string; para
 
   try {
     const data = await handleAction(action, params || {}, id);
-    sendResponse(id, true, data);
+    sendResponse(requestPort, id, true, data);
   } catch (error) {
-    sendResponse(id, false, error);
+    sendResponse(requestPort, id, false, error);
   }
 }
 

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -87,9 +87,10 @@ function scheduleReconnect(reason: string) {
     return;
   }
 
-  const delayMs = reconnectDelayMs(state.reconnectAttempt);
+  const attempt = state.reconnectAttempt;
+  const delayMs = reconnectDelayMs(attempt);
   state.reconnectAttempt += 1;
-  log("Scheduling native host reconnect", { reason, delayMs, attempt: state.reconnectAttempt });
+  log("Scheduling native host reconnect", { reason, delayMs, attempt });
   chrome.alarms.create(RECONNECT_ALARM, {
     delayInMinutes: Math.max(delayMs, RECONNECT_ALARM_MIN_DELAY_MS) / 60_000,
   });


### PR DESCRIPTION
## What

Fix native Windows host connectivity so mixed `\\` and `/` path separators no longer cause the CLI and host runtime to derive different named-pipe endpoints.

This PR also improves the Windows error text for named-pipe connect failures so it reports the resolved profile, data dir, pipe path, OS error code, and a likely cause.

## Why

A reported Windows PowerShell failure showed `tabctl ping` returning `access denied (5)` when the generated host wrapper was started manually. The investigation confirmed that native Windows `ping` uses the named-pipe transport, not TCP auth-token validation, and uncovered a real path-identity bug: semantically identical Windows paths could hash to different pipe names if one side used `\\` and the other used `/`.

## How

- add shared Windows path normalization and pipe-derivation helpers in `tabctl-shared`
- use the shared helpers from setup, CLI transport, and host runtime so pipe identity is stable
- normalize persisted Windows `host_path` and `data_dir` values during setup
- improve Windows named-pipe diagnostics and connectivity guidance
- clarify that WSL transport now uses the Windows named-pipe bridge; TCP transport from WSL is disabled and no longer supported
- add regression tests for mixed-separator pipe resolution and diagnostic formatting

## Testing

Validated locally on macOS:

- `cargo fmt --manifest-path rust/Cargo.toml --all`
- `npm test`
- `npm run test:integration`

## Windows local checkout test instructions

Please test from a native Windows PowerShell session using this branch from a local checkout, not a globally installed `tabctl`.

### 1. Checkout and build locally

From the repo root:

```powershell
git checkout fix/windows-pipe-identity
npm install
npm run build
```

This builds the Rust workspace and produces the unpacked extension build in `dist/extension`.

### 2. Load the local extension build

Open `edge://extensions` or `chrome://extensions`, enable **Developer mode**, then **Load unpacked** and select:

```text
<repo>\dist\extension
```

### 3. Run the local binary from the checkout

Use one of these options from the repo root so you are testing the branch build, not an already installed binary.

Option A: run via Cargo

```powershell
cargo run --manifest-path rust/Cargo.toml -p tabctl -- setup --browser edge --extension-dir dist/extension
cargo run --manifest-path rust/Cargo.toml -p tabctl -- profile-show --json
cargo run --manifest-path rust/Cargo.toml -p tabctl -- ping
```

Option B: run the built debug binary directly after `npm run build`

```powershell
.\rust\target\debug\tabctl.exe setup --browser edge --extension-dir dist/extension
.\rust\target\debug\tabctl.exe profile-show --json
.\rust\target\debug\tabctl.exe ping
```

If testing Chrome instead of Edge, replace `--browser edge` with `--browser chrome`.

### 4. Expected normal behavior

- `setup` should write the native host manifest, wrapper script, and profile registration
- the browser should launch the native host automatically when the extension connects
- `ping` should succeed without needing to run the wrapper manually

### 5. If automatic startup still fails

Use the manual wrapper launch only as a diagnostic step:

- run the generated `tabctl-host.cmd` wrapper manually from the same PowerShell/user context
- in another PowerShell window for the same user, run the same local binary again:

```powershell
cargo run --manifest-path rust/Cargo.toml -p tabctl -- ping
```

or

```powershell
.\rust\target\debug\tabctl.exe ping
```

### 6. What to capture if it still fails

If `ping` fails, please capture the full new error text.

It should now include:

- `profile`
- `data dir`
- the named-pipe path
- the OS error code

Please also compare `TABCTL_PROFILE`, `TABCTL_CONFIG_DIR`, and `TABCTL_DATA_DIR` between the wrapper environment and the CLI shell.

If the failure is still a persistent `os error 5` with matching profile/data-dir values, the next likely issue is named-pipe ACL/security behavior rather than auth-token handling.
