### PR TITLE
fix(setup): hard-fail on missing extension id and guard manifest overwrites (0.6.0-rc.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.4",
+      "version": "0.6.0-rc.5",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"
@@ -24,7 +24,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.4"
+        "tabctl-win32-x64": "0.6.0-rc.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -52,7 +52,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.4"
+    "tabctl-win32-x64": "0.6.0-rc.5"
   },
   "dependencies": {
     "normalize-url": "^8.1.1"

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.4",
+  "version": "0.6.0-rc.5",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -655,9 +655,9 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "clap",
  "dirs",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "indexmap",
  "juniper",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "getrandom",
  "rusqlite",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.4"
+version = "0.6.0-rc.5"

--- a/rust/crates/host/src/host_impl/dispatch.rs
+++ b/rust/crates/host/src/host_impl/dispatch.rs
@@ -300,10 +300,10 @@ pub(super) fn handle_client(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::host_impl::protocol::read_native_message;
+    use crate::host_impl::protocol::{create_id, now_ms, read_native_message};
+    use std::fs;
     use std::io::{Cursor, Result as IoResult};
     use std::net::{TcpListener, TcpStream};
-    use std::path::PathBuf;
     use std::time::{Duration, Instant};
     use tabctl_shared::{NativeMessage, ResponseEnvelope};
 
@@ -323,9 +323,19 @@ mod tests {
     }
 
     fn test_state(native_channel_available: bool) -> Arc<Mutex<HostState>> {
+        // Each call gets its own temp subdirectory so the undo log, focus DB,
+        // and HostState's derived `state.db` (derived from the undo log's
+        // parent) never collide between tests and never land in the crate
+        // working directory.
+        let base = std::env::temp_dir().join(format!(
+            "tabctl-host-dispatch-{}-{}",
+            now_ms(),
+            create_id("test")
+        ));
+        fs::create_dir_all(&base).expect("create dispatch test temp dir");
         Arc::new(Mutex::new(HostState::new_with_native_channel(
-            PathBuf::from("dispatch-test-undo.jsonl"),
-            PathBuf::from("dispatch-test-focus.json"),
+            base.join("dispatch-test-undo.jsonl"),
+            base.join("dispatch-test-focus.json"),
             None,
             native_channel_available,
         )))

--- a/rust/crates/host/src/host_impl/dispatch.rs
+++ b/rust/crates/host/src/host_impl/dispatch.rs
@@ -609,7 +609,7 @@ mod tests {
         )
         .expect("write native response");
 
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let deadline = Instant::now() + Duration::from_secs(5);
         loop {
             let output = String::from_utf8(client_sink.lock().unwrap().clone()).unwrap();
             if output.contains("\"requestId\":\"req-21\"") {

--- a/rust/crates/tabctl/src/cli/commands.rs
+++ b/rust/crates/tabctl/src/cli/commands.rs
@@ -165,6 +165,15 @@ pub(super) fn command_setup() -> Command {
                 .long("user-data-dir")
                 .value_name("path"),
         )
+        .arg(
+            Arg::new("force")
+                .long("force")
+                .short('f')
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Overwrite an existing native messaging manifest even if it points at a different profile or extension id",
+                ),
+        )
 }
 
 pub(super) fn command_extension_fetch() -> Command {

--- a/rust/crates/tabctl/src/cli/impls.rs
+++ b/rust/crates/tabctl/src/cli/impls.rs
@@ -1357,6 +1357,7 @@ mod tests {
             &wrapper,
             "abcdefghijklmnopqrstuvwxyz012345",
             Some(dir.to_str().unwrap()),
+            false,
         );
         assert!(
             result.is_ok(),
@@ -1626,8 +1627,13 @@ mod tests {
         // udd and its NativeMessagingHosts child should not exist yet
         assert!(!udd.exists());
 
-        let result =
-            write_native_manifest("edge", &wrapper, "extid123", Some(udd.to_str().unwrap()));
+        let result = write_native_manifest(
+            "edge",
+            &wrapper,
+            "extid123",
+            Some(udd.to_str().unwrap()),
+            false,
+        );
         assert!(
             result.is_ok(),
             "should create NMH subdir: {:?}",
@@ -1653,9 +1659,14 @@ mod tests {
         let wrapper = dir.join("tabctl-host.sh");
         fs::write(&wrapper, "#!/bin/bash\n").unwrap();
 
-        let manifest_path =
-            write_native_manifest("chrome", &wrapper, "testextid", Some(dir.to_str().unwrap()))
-                .unwrap();
+        let manifest_path = write_native_manifest(
+            "chrome",
+            &wrapper,
+            "testextid",
+            Some(dir.to_str().unwrap()),
+            false,
+        )
+        .unwrap();
 
         let content: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
@@ -1887,6 +1898,257 @@ mod tests {
                     manifest_json["allowed_origins"][0],
                     json!(format!("chrome-extension://{extension_id}/"))
                 );
+            },
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_setup_without_extension_id_fails_when_no_active_extension() {
+        let dir = std::env::temp_dir().join(format!("tabctl-test-e2e-noextid-{}", request_id()));
+        let _ = fs::remove_dir_all(&dir);
+        let config_dir = dir.join("config");
+        let data_dir = dir.join("data");
+        let udd = dir.join("user-data");
+
+        with_env_vars(
+            &[
+                ("TABCTL_CONFIG_DIR", Some(config_dir.to_str().unwrap())),
+                ("TABCTL_DATA_DIR", Some(data_dir.to_str().unwrap())),
+                ("TABCTL_SETUP_FETCH_EXTENSION", Some("0")),
+            ],
+            || {
+                let matches = build_cli()
+                    .try_get_matches_from([
+                        "tabctl",
+                        "--json",
+                        "setup",
+                        "--browser",
+                        "edge",
+                        "--skip-extension-download",
+                        "--user-data-dir",
+                        udd.to_str().unwrap(),
+                    ])
+                    .expect("parse args");
+
+                let (_, sub) = matches.subcommand().expect("subcommand");
+                let result = run_setup(&matches, sub);
+                assert!(
+                    result.is_err(),
+                    "run_setup should fail when no extension id is resolvable, got: {:?}",
+                    result.ok()
+                );
+                let err = result.unwrap_err();
+                assert!(
+                    err.contains("--extension-id"),
+                    "error should suggest passing --extension-id: {err}"
+                );
+
+                let wrapper = data_dir
+                    .join("profiles")
+                    .join("edge")
+                    .join(if cfg!(windows) {
+                        "tabctl-host.cmd"
+                    } else {
+                        "tabctl-host.sh"
+                    });
+                assert!(
+                    !wrapper.exists(),
+                    "wrapper script should not be written when setup fails early"
+                );
+
+                let manifest_path = udd
+                    .join("NativeMessagingHosts")
+                    .join(format!("{HOST_NAME}.json"));
+                assert!(
+                    !manifest_path.exists(),
+                    "native manifest should not be written when setup fails early"
+                );
+
+                let profiles = config_dir.join("profiles.json");
+                assert!(
+                    !profiles.exists(),
+                    "profiles.json should not be written when setup fails early"
+                );
+            },
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_setup_refuses_to_overwrite_existing_manifest_for_different_profile() {
+        let dir = std::env::temp_dir().join(format!("tabctl-test-noforce-{}", request_id()));
+        let _ = fs::remove_dir_all(&dir);
+        let config_dir = dir.join("config");
+        let data_dir = dir.join("data");
+        let udd = dir.join("user-data");
+        let local_extension_dir = dir.join("local-extension");
+        fs::create_dir_all(&local_extension_dir).expect("create local extension dir");
+        fs::write(
+            local_extension_dir.join("manifest.json"),
+            r#"{"manifest_version":3,"name":"Tab Control","version":"0.6.0"}"#,
+        )
+        .expect("write local extension manifest");
+        fs::write(
+            local_extension_dir.join("background.js"),
+            "self.addEventListener('install', () => {});",
+        )
+        .expect("write local extension background");
+
+        with_env_vars(
+            &[
+                ("TABCTL_CONFIG_DIR", Some(config_dir.to_str().unwrap())),
+                ("TABCTL_DATA_DIR", Some(data_dir.to_str().unwrap())),
+                ("TABCTL_SETUP_FETCH_EXTENSION", Some("0")),
+            ],
+            || {
+                // First setup with --name edge-smoke writes the native manifest.
+                let matches_smoke = build_cli()
+                    .try_get_matches_from([
+                        "tabctl",
+                        "--json",
+                        "setup",
+                        "--browser",
+                        "edge",
+                        "--name",
+                        "edge-smoke",
+                        "--extension-dir",
+                        local_extension_dir.to_str().unwrap(),
+                        "--user-data-dir",
+                        udd.to_str().unwrap(),
+                    ])
+                    .expect("parse smoke args");
+                let (_, sub_smoke) = matches_smoke.subcommand().expect("subcommand");
+                run_setup(&matches_smoke, sub_smoke).expect("smoke setup should succeed");
+
+                let manifest_path = udd
+                    .join("NativeMessagingHosts")
+                    .join(format!("{HOST_NAME}.json"));
+                let smoke_manifest =
+                    fs::read_to_string(&manifest_path).expect("smoke manifest should exist");
+
+                // Second setup with default --name=edge should refuse to overwrite.
+                let matches_edge = build_cli()
+                    .try_get_matches_from([
+                        "tabctl",
+                        "--json",
+                        "setup",
+                        "--browser",
+                        "edge",
+                        "--extension-dir",
+                        local_extension_dir.to_str().unwrap(),
+                        "--user-data-dir",
+                        udd.to_str().unwrap(),
+                    ])
+                    .expect("parse edge args");
+                let (_, sub_edge) = matches_edge.subcommand().expect("subcommand");
+                let result = run_setup(&matches_edge, sub_edge);
+                assert!(
+                    result.is_err(),
+                    "edge setup should refuse to overwrite smoke manifest, got: {:?}",
+                    result.ok()
+                );
+                let err = result.unwrap_err();
+                assert!(
+                    err.contains("--force"),
+                    "error should mention --force: {err}"
+                );
+                assert!(
+                    err.contains("Refusing to overwrite"),
+                    "error should explain refusal: {err}"
+                );
+
+                // Manifest on disk must be unchanged.
+                let still =
+                    fs::read_to_string(&manifest_path).expect("manifest should still exist");
+                assert_eq!(still, smoke_manifest, "manifest should not be modified");
+
+                // Third setup with --force succeeds and rewrites the manifest.
+                let matches_force = build_cli()
+                    .try_get_matches_from([
+                        "tabctl",
+                        "--json",
+                        "setup",
+                        "--browser",
+                        "edge",
+                        "--force",
+                        "--extension-dir",
+                        local_extension_dir.to_str().unwrap(),
+                        "--user-data-dir",
+                        udd.to_str().unwrap(),
+                    ])
+                    .expect("parse force args");
+                let (_, sub_force) = matches_force.subcommand().expect("subcommand");
+                run_setup(&matches_force, sub_force).expect("--force setup should succeed");
+
+                let after_force =
+                    fs::read_to_string(&manifest_path).expect("manifest should exist after force");
+                let parsed: Value = serde_json::from_str(&after_force).expect("valid JSON");
+                let path_in_manifest = parsed["path"].as_str().expect("path field");
+                assert!(
+                    path_in_manifest.contains(&format!("profiles{sep}edge{sep}", sep = std::path::MAIN_SEPARATOR)),
+                    "after --force, manifest path should target the default edge profile, got: {path_in_manifest}"
+                );
+            },
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn run_setup_is_idempotent_when_manifest_content_matches() {
+        let dir = std::env::temp_dir().join(format!("tabctl-test-idempotent-{}", request_id()));
+        let _ = fs::remove_dir_all(&dir);
+        let config_dir = dir.join("config");
+        let data_dir = dir.join("data");
+        let udd = dir.join("user-data");
+        let local_extension_dir = dir.join("local-extension");
+        fs::create_dir_all(&local_extension_dir).expect("create local extension dir");
+        fs::write(
+            local_extension_dir.join("manifest.json"),
+            r#"{"manifest_version":3,"name":"Tab Control","version":"0.6.0"}"#,
+        )
+        .expect("write local extension manifest");
+        fs::write(
+            local_extension_dir.join("background.js"),
+            "self.addEventListener('install', () => {});",
+        )
+        .expect("write local extension background");
+
+        with_env_vars(
+            &[
+                ("TABCTL_CONFIG_DIR", Some(config_dir.to_str().unwrap())),
+                ("TABCTL_DATA_DIR", Some(data_dir.to_str().unwrap())),
+                ("TABCTL_SETUP_FETCH_EXTENSION", Some("0")),
+            ],
+            || {
+                let args = [
+                    "tabctl",
+                    "--json",
+                    "setup",
+                    "--browser",
+                    "edge",
+                    "--extension-dir",
+                    local_extension_dir.to_str().unwrap(),
+                    "--user-data-dir",
+                    udd.to_str().unwrap(),
+                ];
+
+                let matches1 = build_cli()
+                    .try_get_matches_from(args)
+                    .expect("parse args 1");
+                let (_, sub1) = matches1.subcommand().expect("subcommand");
+                run_setup(&matches1, sub1).expect("first setup should succeed");
+
+                // Second invocation with identical args should succeed (no --force needed).
+                let matches2 = build_cli()
+                    .try_get_matches_from(args)
+                    .expect("parse args 2");
+                let (_, sub2) = matches2.subcommand().expect("subcommand");
+                run_setup(&matches2, sub2)
+                    .expect("second setup with identical args should succeed without --force");
             },
         );
 

--- a/rust/crates/tabctl/src/cli/local.rs
+++ b/rust/crates/tabctl/src/cli/local.rs
@@ -664,6 +664,7 @@ pub(super) fn attempt_profile_repair(
         &wrapper_path,
         &entry.extension_id,
         entry.user_data_dir.as_deref(),
+        true,
     )?;
     register_profile(
         &data_dir,

--- a/rust/crates/tabctl/src/cli/setup.rs
+++ b/rust/crates/tabctl/src/cli/setup.rs
@@ -913,6 +913,21 @@ pub(super) fn run_setup(matches: &ArgMatches, sub: &ArgMatches) -> Result<(), St
         }
     };
 
+    if effective_extension_id.is_none() {
+        // Without a known extension id we cannot write the native messaging
+        // manifest (allowed_origins) or register a usable profile, so setup
+        // would silently produce a broken installation. Fail loudly instead.
+        let warnings_summary =
+            serde_json::to_string(&setup_warnings).unwrap_or_else(|_| "[]".to_string());
+        return Err(format!(
+            "Could not resolve extension id for browser '{browser}'. \
+             No --extension-id was provided and tabctl could not derive one \
+             from the active extension directory. Pass --extension-id <id> \
+             explicitly, or rerun setup after the extension sync succeeds. \
+             Setup warnings: {warnings_summary}"
+        ));
+    }
+
     let mut actual_wrapper_path = wrapper_path.clone();
     let mut actual_manifest_path = data_dir.clone();
     let mut is_default_profile = false;
@@ -932,7 +947,9 @@ pub(super) fn run_setup(matches: &ArgMatches, sub: &ArgMatches) -> Result<(), St
         let wrapper_file = write_host_wrapper(&wrapper_path, profile_name, &profile_data_dir)?;
 
         let user_data_dir = sub.get_one::<String>("user-data-dir").map(|s| s.as_str());
-        let manifest_path = write_native_manifest(browser, &wrapper_file, ext_id, user_data_dir)?;
+        let force = sub.get_flag("force");
+        let manifest_path =
+            write_native_manifest(browser, &wrapper_file, ext_id, user_data_dir, force)?;
 
         #[cfg(windows)]
         {
@@ -1290,6 +1307,7 @@ pub(super) fn write_native_manifest(
     wrapper_path: &Path,
     extension_id: &str,
     user_data_dir: Option<&str>,
+    force: bool,
 ) -> Result<PathBuf, String> {
     let manifest_dir = if let Some(udd) = user_data_dir {
         PathBuf::from(udd).join("NativeMessagingHosts")
@@ -1310,6 +1328,41 @@ pub(super) fn write_native_manifest(
     });
 
     let manifest_path = manifest_dir.join(format!("{HOST_NAME}.json"));
+
+    if !force && manifest_path.exists() {
+        if let Ok(existing_raw) = fs::read_to_string(&manifest_path) {
+            if let Ok(existing) = serde_json::from_str::<Value>(&existing_raw) {
+                if existing != manifest {
+                    let existing_path = existing
+                        .get("path")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<unknown>");
+                    let existing_origins = existing
+                        .get("allowed_origins")
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    let new_path = manifest
+                        .get("path")
+                        .and_then(Value::as_str)
+                        .unwrap_or("<unknown>");
+                    let new_origins = manifest
+                        .get("allowed_origins")
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    return Err(format!(
+                        "Refusing to overwrite existing native messaging manifest at {manifest_display}.\n  \
+                         existing path: {existing_path}\n  \
+                         existing allowed_origins: {existing_origins}\n  \
+                         new path: {new_path}\n  \
+                         new allowed_origins: {new_origins}\n\
+                         Pass --force to overwrite, or pick a different --browser/--name combination.",
+                        manifest_display = manifest_path.display()
+                    ));
+                }
+            }
+        }
+    }
+
     let content = serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?;
     fs::write(&manifest_path, content)
         .map_err(|e| format!("failed to write native manifest: {e}"))?;

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -654,6 +654,7 @@ fn init_browser() -> SharedBrowser {
             profile_name,
             "--extension-dir",
             extension_dir.to_str().expect("extension path to utf8"),
+            "--force",
         ],
     )
     .expect("setup command should succeed");

--- a/rust/crates/tabctl/tests/local_commands.rs
+++ b/rust/crates/tabctl/tests/local_commands.rs
@@ -67,6 +67,7 @@ fn test_profile_lifecycle() {
             profile_a,
             "--extension-dir",
             ext_str,
+            "--force",
         ],
     )
     .expect("setup profile-a should succeed");
@@ -86,6 +87,7 @@ fn test_profile_lifecycle() {
             profile_b,
             "--extension-dir",
             ext_str,
+            "--force",
         ],
     )
     .expect("setup profile-b should succeed");
@@ -196,6 +198,7 @@ fn test_doctor_command() {
             profile,
             "--extension-dir",
             ext_str,
+            "--force",
         ],
     );
 
@@ -240,6 +243,7 @@ fn test_policy_command() {
             profile,
             "--extension-dir",
             ext_str,
+            "--force",
         ],
     );
 


### PR DESCRIPTION
## Summary

Hardens `tabctl setup` against two silent failure modes uncovered while debugging `tabctl setup --browser edge`.

### Bug 1 — silent no-op when extension id can't be resolved
Previously `tabctl setup --browser <b>` could exit 0 without writing the wrapper, native messaging manifest, or profile entry when no `--extension-id` was given and the extension directory was missing. Users were left with a broken host and no error.

**Fix:** hard-fail with an actionable error message.

### Bug 2 — silent manifest overwrite between profiles
Running setup with a different `--name` silently overwrites the single per-browser native messaging manifest, repointing the browser at the wrong profile's wrapper. The CLI and extension then talk to different sockets (`host_unavailable`).

**Fix:** new `--force`/`-f` flag. Without it, setup refuses to overwrite an existing manifest pointing at a different profile and prints a structured diff. Idempotent when content matches; falls through on read/parse errors. `attempt_profile_repair` passes `force=true` (repair intent is to fix a known-stale manifest).

### Drive-by: test hygiene
`test_state` in `dispatch.rs` previously created `dispatch-test-undo.jsonl`, `dispatch-test-focus.json`, and (via parent-derivation) `state.db` in the crate working directory. Now allocates a unique `temp_dir()` subdir per call.

### Release
- Bumps to `0.6.0-rc.5`.

## Test plan
- New unit tests cover all three behaviours (hard-fail, refuse-overwrite, idempotent).
- `npm test` + `npm run test:integration` green locally (pre-push hook).
- No more stray artifacts in `rust/crates/host/` after a full test run.