### PR TITLE
feat(read): add readTabs GraphQL query

### DIFF
--- a/.github/skills/smoke-test/SKILL.md
+++ b/.github/skills/smoke-test/SKILL.md
@@ -1,37 +1,51 @@
 ---
 name: smoke-test
-description: 'Run the tabctl end-of-task smoke test: unit tests, integration tests (if available), and a live browser smoke test in a dedicated TEST- window. Use when finishing a task, before releasing, or to verify the extension and host are wired up correctly.'
+description: 'Run the tabctl end-of-task smoke test with the current GraphQL-first CLI: unit tests, integration tests when available, an isolated browser smoke test, readTabs markdown extraction, and safe mutation/undo checks in a disposable TEST window. Use when finishing a task, before releasing, or verifying the extension/host/browser path.'
 license: MIT
 allowed-tools: Bash
 ---
 
 # Smoke Test
 
-Run the full end-of-task verification sequence for tabctl: unit tests, integration tests, and a live browser smoke test using a disposable test window. Always run this after making code changes.
+Run the full end-of-task verification sequence for tabctl: unit tests, integration tests, and a live browser smoke test using an isolated browser profile. Always run this after code changes.
 
-The live browser steps use a **dedicated, agent-controlled Edge instance** started by
-`scripts/smoke-browser.js`. This instance is fully isolated — it uses a temp profile dir,
-loads the local `dist/extension` build, and is torn down at the end. The user's real browser
-is never touched.
+The live browser steps use a **dedicated, agent-controlled Edge/Chrome instance** started by `scripts/smoke-browser.js`. This instance is isolated: it uses a temp profile dir, loads the local `dist/extension` build, and is torn down at the end. The user's real browser is never touched.
+
+## Current CLI model
+
+Browser operations are **GraphQL-first**. Do not use removed legacy subcommands such as `tabctl list`, `tabctl open`, `tabctl close`, `tabctl archive`, `tabctl report`, `tabctl analyze`, `tabctl inspect`, `tabctl screenshot`, `tabctl group-list`, or `tabctl undo`.
+
+Use:
+
+```bash
+$TABCTL query --profile "$SMOKE_PROFILE" 'query { ... }'
+$TABCTL query --profile "$SMOKE_PROFILE" 'mutation { ... }'
+```
+
+If an operation shape is uncertain, inspect the live schema first:
+
+```bash
+$TABCTL schema
+```
 
 ## Prerequisites
 
 - `npm run build` has been run so `dist/extension/manifest.json` exists.
 - `jq` is available for JSON extraction.
-- Edge (or Chrome) is installed on the machine.
-- The debug binary `./rust/target/debug/tabctl` exists (built by `npm run build`).
+- Edge or Chrome is installed.
+- The debug binary `./rust/target/debug/tabctl` exists.
 
 ## Step 0: Start the smoke browser
 
-Start an isolated browser instance and capture the profile name. Run this first; keep the
-process alive for the entire smoke test, then kill it at the end.
+Start an isolated browser and capture the generated profile name. Keep the process alive for the whole smoke test.
 
 ```bash
-SMOKE_LOG=$(mktemp)
-node scripts/smoke-browser.js > "$SMOKE_LOG" &
+SMOKE_LOG="/tmp/tabctl-smoke-$(date +%s).log"
+node scripts/smoke-browser.js > "$SMOKE_LOG" 2>&1 &
 SMOKE_PID=$!
+echo "Smoke browser PID: $SMOKE_PID"
+echo "Smoke browser log: $SMOKE_LOG"
 
-# Wait for the ready JSON line (up to 40 seconds).
 for i in $(seq 1 40); do
   if [ -s "$SMOKE_LOG" ] && grep -q '"ok":true' "$SMOKE_LOG" 2>/dev/null; then
     break
@@ -41,143 +55,308 @@ done
 
 if ! grep -q '"ok":true' "$SMOKE_LOG" 2>/dev/null; then
   echo "smoke-browser did not start in time" >&2
-  kill "$SMOKE_PID" 2>/dev/null || true
+  cat "$SMOKE_LOG" >&2
   exit 1
 fi
 
 SMOKE_PROFILE=$(jq -r '.profile' "$SMOKE_LOG")
-echo "Smoke profile: $SMOKE_PROFILE"
-
-# Use the debug binary so new features are available.
 TABCTL="./rust/target/debug/tabctl"
+echo "Smoke profile: $SMOKE_PROFILE"
 ```
 
-The script sets up a named tabctl profile (`smoke-<timestamp>`) and launches Edge with
-`--load-extension` pointing at the synced active extension dir. It stays running until killed.
+If using the Copilot CLI Bash tool, prefer an async shell session for the smoke browser and stop that session at teardown. If you must use `kill`, run it with a literal numeric PID, e.g. `kill 12345`; avoid variable-expanded `kill "$SMOKE_PID"` in environments that reject non-literal PIDs.
 
-## Step 1: Unit tests (no browser required)
+## Step 1: Unit tests
 
 ```bash
 npm test
 ```
 
-All tests must pass. If any fail, stop and fix before continuing.
+All tests must pass. If they fail, stop and fix before continuing.
 
-## Step 2: Integration tests (isolated headless Chrome)
+## Step 2: Integration tests
 
 ```bash
 npm run test:integration
 ```
 
-These run against an isolated headless Chrome instance — no real tabs are touched. Run if
-Chrome is available (always in CI, usually locally). If unavailable, note it and continue.
+These run against isolated headless Chrome. If Chrome is unavailable locally, note that and continue with the live smoke browser checks.
 
-## Step 3: Connectivity ping
+## Step 3: Connectivity
+
+Run both the CLI ping command and GraphQL ping:
 
 ```bash
 $TABCTL ping --profile "$SMOKE_PROFILE"
+
+$TABCTL query --profile "$SMOKE_PROFILE" \
+  'query { ping { ok latencyMs } }'
 ```
 
-Must succeed. If it fails, the smoke browser is not connected — check its stderr output
-and fix before proceeding.
+Both must succeed before any live browser mutation.
 
-## Step 4: Live browser smoke test (read-only)
+## Step 4: Read-only GraphQL smoke
+
+Use GraphQL queries instead of removed read-only subcommands:
 
 ```bash
-$TABCTL list --profile "$SMOKE_PROFILE" --all
-$TABCTL analyze --profile "$SMOKE_PROFILE" --stale-days 30
-$TABCTL report --profile "$SMOKE_PROFILE" --format json
+$TABCTL query --profile "$SMOKE_PROFILE" '
+query {
+  tabs(limit: 20) {
+    total
+    items { tabId windowId url title groupId groupTitle active }
+  }
+}'
+
+$TABCTL query --profile "$SMOKE_PROFILE" '
+query {
+  analyze(staleDays: 30) {
+    totalTabs
+    staleTabs
+    duplicateTabs
+  }
+}'
+
+$TABCTL query --profile "$SMOKE_PROFILE" '
+query {
+  reportTabs {
+    totals { tabs }
+    entries { tabId windowId url title description }
+  }
+}'
 ```
 
-Confirm output looks reasonable: tabs listed, no unexpected errors.
+Confirm the responses have `data`, no `errors`, and sensible counts.
 
-## Step 5: Mutation smoke test (dedicated test window)
+## Step 5: Markdown extraction smoke
 
-Run this entire block as a script. It creates a disposable test window, captures IDs, and
-runs close + archive round-trips with undo verification.
+When the task is to verify agent-consumable page content, open the target page in the isolated browser and read it with `readTabs`.
+
+Example for `https://nos.nl`:
 
 ```bash
-set -euo pipefail
+NOS_OPEN=$($TABCTL query --profile "$SMOKE_PROFILE" '
+mutation {
+  openTabs(urls: ["https://nos.nl"], newWindow: true) {
+    windowId
+    tabs { tabId url title }
+  }
+}')
 
-# --- Setup ---
+NOS_WIN=$(echo "$NOS_OPEN" | jq -r '.data.openTabs.windowId')
+NOS_TAB=$(echo "$NOS_OPEN" | jq -r '.data.openTabs.tabs[0].tabId')
+echo "NOS window: $NOS_WIN  tab: $NOS_TAB"
+
+sleep 3
+
+NOS_READ=$($TABCTL query --profile "$SMOKE_PROFILE" "
+query {
+  readTabs(tabIds: [$NOS_TAB], extract: true, maxChars: 50000, timeoutMs: 15000) {
+    totals { tabs tasks }
+    entries {
+      tabId
+      url
+      title
+      chars
+      truncated
+      extracted
+      markdown
+    }
+  }
+}")
+
+echo "$NOS_READ" | jq -r '.data.readTabs.entries[0] |
+  "url: \(.url)\ntitle: \(.title)\nchars: \(.chars)\ntruncated: \(.truncated)\nextracted: \(.extracted)\n\n--- MARKDOWN PREVIEW ---\n\(.markdown[:1200])"'
+```
+
+Success criteria:
+
+- `readTabs.totals.tabs` is `1`.
+- `entries[0].chars` is greater than `0`.
+- `entries[0].markdown` contains readable Markdown, not raw empty HTML.
+- `entries[0].truncated` is acceptable only if `maxChars` was intentionally low.
+
+Keep `NOS_TAB` and `NOS_WIN` for cleanup.
+
+## Step 6: Mutation smoke test
+
+Run mutations only against windows/tabs created by this smoke test. The setup below creates a disposable window and group, then verifies close/undo, archive/undo, screenshot, and inspect.
+
+```bash
 ts=$(date +%s)
 GROUP="TEST-Smoke-${ts}"
 
-# Create test window; capture its windowId from the JSON response
-WIN=$($TABCTL open --profile "$SMOKE_PROFILE" --new-window \
-  --url https://example.com \
-  --url https://example.org \
-  --url https://example.net \
-  --group "$GROUP" | jq '.windowId')
+OPEN_JSON=$($TABCTL query --profile "$SMOKE_PROFILE" "
+mutation {
+  openTabs(
+    urls: [\"https://example.com\", \"https://example.org\", \"https://example.net\"],
+    newWindow: true,
+    group: \"$GROUP\"
+  ) {
+    windowId
+    groupId
+    tabs { tabId windowId url title groupId groupTitle }
+  }
+}")
 
-echo "Test window: $WIN  group: $GROUP"
+WIN=$(echo "$OPEN_JSON" | jq -r '.data.openTabs.windowId')
+TAB_IDS=$(echo "$OPEN_JSON" | jq -r '.data.openTabs.tabs | map(.tabId) | join(",")')
+FIRST_TAB=$(echo "$OPEN_JSON" | jq -r '.data.openTabs.tabs[0].tabId')
+echo "Test window: $WIN  group: $GROUP  tabs: $TAB_IDS"
 
-# Verify: three tabs, group present
-$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
-$TABCTL group-list --profile "$SMOKE_PROFILE" --window "$WIN"
+$TABCTL query --profile "$SMOKE_PROFILE" "
+query {
+  window(id: $WIN) {
+    windowId
+    tabs { tabId url groupTitle index }
+    groups { groupId title color collapsed tabCount }
+  }
+}"
 
-# --- Close + undo ---
-TAB=$($TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN" | jq '.windows[0].tabs[0].tabId')
-echo "Closing tab $TAB"
+CLOSE_JSON=$($TABCTL query --profile "$SMOKE_PROFILE" "
+mutation {
+  closeTabs(tabIds: [$FIRST_TAB], confirm: true) {
+    txid
+    closedTabs
+  }
+}")
+CLOSE_TXID=$(echo "$CLOSE_JSON" | jq -r '.data.closeTabs.txid')
+echo "Closed tab $FIRST_TAB with txid=$CLOSE_TXID"
 
-TXID=$($TABCTL close --profile "$SMOKE_PROFILE" --tab "$TAB" --confirm | jq -r '.txid')
-echo "Closed (txid=$TXID). Verifying tab is gone:"
-$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
+$TABCTL query --profile "$SMOKE_PROFILE" "
+mutation {
+  undoAction(txid: \"$CLOSE_TXID\") {
+    txid
+    summary
+  }
+}"
 
-$TABCTL undo --profile "$SMOKE_PROFILE" "$TXID"
-echo "Undone. Verifying tab restored:"
-$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
+$TABCTL query --profile "$SMOKE_PROFILE" "
+query {
+  window(id: $WIN) {
+    tabs { tabId url groupTitle index }
+  }
+}"
 
-# --- Archive + undo ---
-echo "Archiving window $WIN"
-TXID=$($TABCTL archive --profile "$SMOKE_PROFILE" --window "$WIN" | jq -r '.txid')
-echo "Archived (txid=$TXID). Expected groups in Archive window:"
-$TABCTL group-list --profile "$SMOKE_PROFILE" --all | grep -i "TEST-Smoke\|Ungrouped" || true
+ARCHIVE_JSON=$($TABCTL query --profile "$SMOKE_PROFILE" "
+mutation {
+  archiveTabs(windowId: $WIN) {
+    txid
+    archivedTabs
+  }
+}")
+ARCHIVE_TXID=$(echo "$ARCHIVE_JSON" | jq -r '.data.archiveTabs.txid')
+echo "Archived window $WIN with txid=$ARCHIVE_TXID"
 
-$TABCTL undo --profile "$SMOKE_PROFILE" "$TXID"
-echo "Undone. Test window restored:"
-$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
+$TABCTL query --profile "$SMOKE_PROFILE" "
+mutation {
+  undoAction(txid: \"$ARCHIVE_TXID\") {
+    txid
+    summary
+  }
+}"
 
-# --- Screenshot + inspect check ---
-FIRST_TAB=$($TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN" | jq '.windows[0].tabs[0].tabId')
-$TABCTL screenshot --profile "$SMOKE_PROFILE" --tab "$FIRST_TAB" --mode viewport
-$TABCTL inspect --profile "$SMOKE_PROFILE" --tab "$FIRST_TAB" --signal page-meta --progress
+RESTORED_FIRST_TAB=$($TABCTL query --profile "$SMOKE_PROFILE" "
+query {
+  tabs(windowId: $WIN, limit: 10) {
+    items { tabId }
+  }
+}" | jq -r '.data.tabs.items[0].tabId')
 
-# --- Clean up test window ---
-$TABCTL close --profile "$SMOKE_PROFILE" --window "$WIN" --confirm
-echo "Test window $WIN closed. Smoke test complete."
+$TABCTL query --profile "$SMOKE_PROFILE" "
+query {
+  captureScreenshots(tabIds: [$RESTORED_FIRST_TAB], mode: \"viewport\") {
+    totals { tabs tiles }
+    entries { tabId tiles { index width height } error { message } }
+  }
+}"
+
+$TABCTL query --profile "$SMOKE_PROFILE" "
+query {
+  inspectTabs(tabIds: [$RESTORED_FIRST_TAB], signals: [\"page-meta\"], waitFor: \"dom\") {
+    totals { tabs signals tasks }
+    entries { tabId signals { name valueJson } }
+  }
+}"
 ```
 
-If `set -euo pipefail` causes the script to abort early, run sections individually and check
-each output before proceeding.
+Success criteria:
 
-## Step 6: Tear down the smoke browser
+- The test window exists after `openTabs`.
+- `closeTabs.closedTabs` is `1`.
+- `undoAction` for close restores the tab.
+- `archiveTabs.archivedTabs` is greater than `0`.
+- `undoAction` for archive restores the test window.
+- Screenshot and inspect return `data` without unexpected `errors`.
+
+## Step 7: Cleanup smoke-created browser state
+
+Close tabs created by the markdown and mutation smoke tests. `closeTabs` requires tab IDs, so query the window first if needed.
 
 ```bash
-kill "$SMOKE_PID" 2>/dev/null || true
-rm -f "$SMOKE_LOG"
-echo "Smoke browser stopped."
+if [ -n "${NOS_TAB:-}" ] && [ "$NOS_TAB" != "null" ]; then
+  $TABCTL query --profile "$SMOKE_PROFILE" "
+  mutation {
+    closeTabs(tabIds: [$NOS_TAB], confirm: true) {
+      txid
+      closedTabs
+    }
+  }" || true
+fi
+
+if [ -n "${WIN:-}" ] && [ "$WIN" != "null" ]; then
+  CLEANUP_TABS=$($TABCTL query --profile "$SMOKE_PROFILE" "
+  query {
+    tabs(windowId: $WIN, limit: 50) {
+      items { tabId }
+    }
+  }" | jq -r '.data.tabs.items | map(.tabId) | join(",")')
+
+  if [ -n "$CLEANUP_TABS" ]; then
+    $TABCTL query --profile "$SMOKE_PROFILE" "
+    mutation {
+      closeTabs(tabIds: [$CLEANUP_TABS], confirm: true) {
+        txid
+        closedTabs
+      }
+    }" || true
+  fi
+fi
 ```
 
-`smoke-browser.js` handles its own cleanup on shutdown: it removes the tabctl profile and
-deletes the temp dir automatically.
+## Step 8: Tear down the smoke browser
+
+Stop the `scripts/smoke-browser.js` process and remove the log.
+
+```bash
+echo "Smoke browser PID was: $SMOKE_PID"
+echo "Smoke browser log was: $SMOKE_LOG"
+rm -f "$SMOKE_LOG"
+```
+
+If using a normal shell, terminate the printed numeric PID with `kill <PID>`. If using the Copilot CLI Bash tool with an async shell session, stop that shell session instead. `smoke-browser.js` removes the tabctl profile and temp dir during shutdown.
 
 ## Summary checklist
 
-- [ ] `npm test` passes
-- [ ] `npm run test:integration` passes (or skipped with note)
-- [ ] Smoke browser started (`smoke-browser.js` ready signal received)
-- [ ] `tabctl ping --profile $SMOKE_PROFILE` succeeds
-- [ ] Read-only commands (`list`, `analyze`, `report`) return sensible output
-- [ ] Test window created with `TEST-Smoke-<timestamp>` group
-- [ ] Close + undo round-trip verified (tab disappeared, then restored)
-- [ ] Archive + undo round-trip verified (groups appeared, then window restored)
-- [ ] Test window cleaned up
-- [ ] Smoke browser stopped (`kill $SMOKE_PID`)
+- [ ] `npm test` passes.
+- [ ] `npm run test:integration` passes, or Chrome unavailability is noted.
+- [ ] Smoke browser started and emitted `{"ok":true,...}`.
+- [ ] `tabctl ping --profile "$SMOKE_PROFILE"` succeeds.
+- [ ] GraphQL `query { ping { ok latencyMs } }` succeeds.
+- [ ] Read-only GraphQL queries (`tabs`, `analyze`, `reportTabs`) return `data` and no unexpected `errors`.
+- [ ] Markdown extraction with `readTabs` returns non-empty Markdown for the target page, e.g. `https://nos.nl`.
+- [ ] Test window created with a `TEST-Smoke-<timestamp>` group.
+- [ ] Close + undo round-trip verified.
+- [ ] Archive + undo round-trip verified.
+- [ ] Screenshot and inspect checks return successful GraphQL data.
+- [ ] Smoke-created tabs/windows are cleaned up.
+- [ ] Smoke browser process is stopped.
 
 ## Hard stops
 
-- Never run mutations outside the `TEST-Smoke-*` window.
-- Never run `tabctl archive --all` or `tabctl close --confirm` without an explicit `--window`, `--group`, or `--tab` scope.
-- Never skip `--profile "$SMOKE_PROFILE"` — always target the smoke browser, not the user's real profile.
-- If `tabctl ping` fails, check `smoke-browser.js` stderr output and fix the connection before any live browser steps.
+- Never mutate the user's real profile; always use `--profile "$SMOKE_PROFILE"`.
+- Never run mutations against tabs/windows that the smoke test did not create.
+- Never use removed legacy CLI subcommands in this skill; use `tabctl query`.
+- Never call `archiveTabs` without `windowId` or explicit `tabIds`.
+- Never call `closeTabs` without explicit `tabIds` and `confirm: true` for execution.
+- If ping fails, inspect the smoke-browser log and fix the connection before any live browser step.

--- a/.github/skills/smoke-test/SKILL.md
+++ b/.github/skills/smoke-test/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: smoke-test
+description: 'Run the tabctl end-of-task smoke test: unit tests, integration tests (if available), and a live browser smoke test in a dedicated TEST- window. Use when finishing a task, before releasing, or to verify the extension and host are wired up correctly.'
+license: MIT
+allowed-tools: Bash
+---
+
+# Smoke Test
+
+Run the full end-of-task verification sequence for tabctl: unit tests, integration tests, and a live browser smoke test using a disposable test window. Always run this after making code changes.
+
+## Prerequisites
+
+- Edge (or Chrome) is open and the extension is loaded.
+- The native host manifest is installed (`tabctl setup --browser edge --extension-id <id>`).
+- A stable `tabctl` binary is on PATH (production install or `cargo run -p tabctl --` during development).
+- `jq` is available for JSON extraction.
+
+If the extension is not connected, `tabctl ping` will fail. Fix the connection before proceeding.
+
+## Step 1: Verify active profile
+
+```bash
+tabctl profile-show --json
+```
+
+Check `name` and `browser`. If multiple profiles are configured, confirm you are targeting the right browser. Append `--profile <name>` to all subsequent `tabctl` commands if needed.
+
+## Step 2: Unit tests (no browser required)
+
+```bash
+npm test
+```
+
+All tests must pass. If any fail, stop and fix before continuing.
+
+## Step 3: Integration tests (isolated headless Chrome)
+
+```bash
+npm run test:integration
+```
+
+These run against an isolated headless Chrome instance — no real tabs are touched. Run if Chrome is available (always in CI, usually locally). If unavailable in the current environment, note it and continue.
+
+## Step 4: Connectivity ping
+
+```bash
+tabctl ping
+```
+
+Must succeed. If it fails, the extension or native host is not connected — do not proceed with the live smoke test.
+
+## Step 5: Live browser smoke test (read-only)
+
+```bash
+tabctl list --all
+tabctl analyze --stale-days 30
+tabctl report --format json
+```
+
+Confirm output looks reasonable: tabs listed, no unexpected errors.
+
+## Step 6: Mutation smoke test (dedicated test window)
+
+Run this entire block as a script. It creates a disposable test window, captures IDs, and runs close + archive round-trips with undo verification.
+
+```bash
+set -euo pipefail
+
+# --- Setup ---
+ts=$(date +%s)
+GROUP="TEST-Smoke-${ts}"
+
+# Create test window; capture its windowId from the JSON response
+WIN=$(tabctl open --new-window \
+  --url https://example.com \
+  --url https://example.org \
+  --url https://example.net \
+  --group "$GROUP" | jq '.windowId')
+
+echo "Test window: $WIN  group: $GROUP"
+
+# Verify: three tabs, group present
+tabctl list --window "$WIN"
+tabctl group-list --window "$WIN"
+
+# --- Close + undo ---
+# Pick the first tab in the test window
+TAB=$(tabctl list --window "$WIN" | jq '.windows[0].tabs[0].tabId')
+echo "Closing tab $TAB"
+
+TXID=$(tabctl close --tab "$TAB" --confirm | jq -r '.txid')
+echo "Closed (txid=$TXID). Verifying tab is gone:"
+tabctl list --window "$WIN"
+
+tabctl undo "$TXID"
+echo "Undone. Verifying tab restored:"
+tabctl list --window "$WIN"
+
+# --- Archive + undo ---
+echo "Archiving window $WIN"
+TXID=$(tabctl archive --window "$WIN" | jq -r '.txid')
+echo "Archived (txid=$TXID). Expected groups in Archive window:"
+echo "  W# - ${GROUP}   (grouped tabs)"
+echo "  W# - Ungrouped  (ungrouped tab)"
+tabctl group-list --all | grep -i "TEST-Smoke\|Ungrouped" || true
+
+tabctl undo "$TXID"
+echo "Undone. Test window restored:"
+tabctl list --window "$WIN"
+
+# --- Screenshot check (run if screenshot/inspect was changed) ---
+FIRST_TAB=$(tabctl list --window "$WIN" | jq '.windows[0].tabs[0].tabId')
+tabctl screenshot --tab "$FIRST_TAB" --mode viewport
+tabctl inspect --tab "$FIRST_TAB" --signal page-meta --progress
+
+# --- Clean up ---
+tabctl close --window "$WIN" --confirm
+echo "Test window $WIN closed. Smoke test complete."
+```
+
+If `set -euo pipefail` causes the script to abort early, run sections individually and check each output before proceeding.
+
+## Summary checklist
+
+- [ ] `npm test` passes
+- [ ] `npm run test:integration` passes (or skipped with note)
+- [ ] `tabctl ping` succeeds
+- [ ] Read-only commands (`list`, `analyze`, `report`) return sensible output
+- [ ] Test window created with `TEST-Smoke-<timestamp>` group
+- [ ] Close + undo round-trip verified (tab disappeared, then restored)
+- [ ] Archive + undo round-trip verified (groups appeared, then window restored)
+- [ ] Test window cleaned up
+
+## Hard stops
+
+- Never run mutations outside the `TEST-Smoke-*` window.
+- Never run `tabctl archive --all` or `tabctl close --confirm` without an explicit `--window`, `--group`, or `--tab` scope.
+- If `tabctl ping` fails, fix the connection before any live browser steps.

--- a/.github/skills/smoke-test/SKILL.md
+++ b/.github/skills/smoke-test/SKILL.md
@@ -9,24 +9,53 @@ allowed-tools: Bash
 
 Run the full end-of-task verification sequence for tabctl: unit tests, integration tests, and a live browser smoke test using a disposable test window. Always run this after making code changes.
 
+The live browser steps use a **dedicated, agent-controlled Edge instance** started by
+`scripts/smoke-browser.js`. This instance is fully isolated — it uses a temp profile dir,
+loads the local `dist/extension` build, and is torn down at the end. The user's real browser
+is never touched.
+
 ## Prerequisites
 
-- Edge (or Chrome) is open and the extension is loaded.
-- The native host manifest is installed (`tabctl setup --browser edge --extension-id <id>`).
-- A stable `tabctl` binary is on PATH (production install or `cargo run -p tabctl --` during development).
+- `npm run build` has been run so `dist/extension/manifest.json` exists.
 - `jq` is available for JSON extraction.
+- Edge (or Chrome) is installed on the machine.
+- The debug binary `./rust/target/debug/tabctl` exists (built by `npm run build`).
 
-If the extension is not connected, `tabctl ping` will fail. Fix the connection before proceeding.
+## Step 0: Start the smoke browser
 
-## Step 1: Verify active profile
+Start an isolated browser instance and capture the profile name. Run this first; keep the
+process alive for the entire smoke test, then kill it at the end.
 
 ```bash
-tabctl profile-show --json
+SMOKE_LOG=$(mktemp)
+node scripts/smoke-browser.js > "$SMOKE_LOG" &
+SMOKE_PID=$!
+
+# Wait for the ready JSON line (up to 40 seconds).
+for i in $(seq 1 40); do
+  if [ -s "$SMOKE_LOG" ] && grep -q '"ok":true' "$SMOKE_LOG" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if ! grep -q '"ok":true' "$SMOKE_LOG" 2>/dev/null; then
+  echo "smoke-browser did not start in time" >&2
+  kill "$SMOKE_PID" 2>/dev/null || true
+  exit 1
+fi
+
+SMOKE_PROFILE=$(jq -r '.profile' "$SMOKE_LOG")
+echo "Smoke profile: $SMOKE_PROFILE"
+
+# Use the debug binary so new features are available.
+TABCTL="./rust/target/debug/tabctl"
 ```
 
-Check `name` and `browser`. If multiple profiles are configured, confirm you are targeting the right browser. Append `--profile <name>` to all subsequent `tabctl` commands if needed.
+The script sets up a named tabctl profile (`smoke-<timestamp>`) and launches Edge with
+`--load-extension` pointing at the synced active extension dir. It stays running until killed.
 
-## Step 2: Unit tests (no browser required)
+## Step 1: Unit tests (no browser required)
 
 ```bash
 npm test
@@ -34,35 +63,38 @@ npm test
 
 All tests must pass. If any fail, stop and fix before continuing.
 
-## Step 3: Integration tests (isolated headless Chrome)
+## Step 2: Integration tests (isolated headless Chrome)
 
 ```bash
 npm run test:integration
 ```
 
-These run against an isolated headless Chrome instance — no real tabs are touched. Run if Chrome is available (always in CI, usually locally). If unavailable in the current environment, note it and continue.
+These run against an isolated headless Chrome instance — no real tabs are touched. Run if
+Chrome is available (always in CI, usually locally). If unavailable, note it and continue.
 
-## Step 4: Connectivity ping
+## Step 3: Connectivity ping
 
 ```bash
-tabctl ping
+$TABCTL ping --profile "$SMOKE_PROFILE"
 ```
 
-Must succeed. If it fails, the extension or native host is not connected — do not proceed with the live smoke test.
+Must succeed. If it fails, the smoke browser is not connected — check its stderr output
+and fix before proceeding.
 
-## Step 5: Live browser smoke test (read-only)
+## Step 4: Live browser smoke test (read-only)
 
 ```bash
-tabctl list --all
-tabctl analyze --stale-days 30
-tabctl report --format json
+$TABCTL list --profile "$SMOKE_PROFILE" --all
+$TABCTL analyze --profile "$SMOKE_PROFILE" --stale-days 30
+$TABCTL report --profile "$SMOKE_PROFILE" --format json
 ```
 
 Confirm output looks reasonable: tabs listed, no unexpected errors.
 
-## Step 6: Mutation smoke test (dedicated test window)
+## Step 5: Mutation smoke test (dedicated test window)
 
-Run this entire block as a script. It creates a disposable test window, captures IDs, and runs close + archive round-trips with undo verification.
+Run this entire block as a script. It creates a disposable test window, captures IDs, and
+runs close + archive round-trips with undo verification.
 
 ```bash
 set -euo pipefail
@@ -72,7 +104,7 @@ ts=$(date +%s)
 GROUP="TEST-Smoke-${ts}"
 
 # Create test window; capture its windowId from the JSON response
-WIN=$(tabctl open --new-window \
+WIN=$($TABCTL open --profile "$SMOKE_PROFILE" --new-window \
   --url https://example.com \
   --url https://example.org \
   --url https://example.net \
@@ -81,59 +113,71 @@ WIN=$(tabctl open --new-window \
 echo "Test window: $WIN  group: $GROUP"
 
 # Verify: three tabs, group present
-tabctl list --window "$WIN"
-tabctl group-list --window "$WIN"
+$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
+$TABCTL group-list --profile "$SMOKE_PROFILE" --window "$WIN"
 
 # --- Close + undo ---
-# Pick the first tab in the test window
-TAB=$(tabctl list --window "$WIN" | jq '.windows[0].tabs[0].tabId')
+TAB=$($TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN" | jq '.windows[0].tabs[0].tabId')
 echo "Closing tab $TAB"
 
-TXID=$(tabctl close --tab "$TAB" --confirm | jq -r '.txid')
+TXID=$($TABCTL close --profile "$SMOKE_PROFILE" --tab "$TAB" --confirm | jq -r '.txid')
 echo "Closed (txid=$TXID). Verifying tab is gone:"
-tabctl list --window "$WIN"
+$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
 
-tabctl undo "$TXID"
+$TABCTL undo --profile "$SMOKE_PROFILE" "$TXID"
 echo "Undone. Verifying tab restored:"
-tabctl list --window "$WIN"
+$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
 
 # --- Archive + undo ---
 echo "Archiving window $WIN"
-TXID=$(tabctl archive --window "$WIN" | jq -r '.txid')
+TXID=$($TABCTL archive --profile "$SMOKE_PROFILE" --window "$WIN" | jq -r '.txid')
 echo "Archived (txid=$TXID). Expected groups in Archive window:"
-echo "  W# - ${GROUP}   (grouped tabs)"
-echo "  W# - Ungrouped  (ungrouped tab)"
-tabctl group-list --all | grep -i "TEST-Smoke\|Ungrouped" || true
+$TABCTL group-list --profile "$SMOKE_PROFILE" --all | grep -i "TEST-Smoke\|Ungrouped" || true
 
-tabctl undo "$TXID"
+$TABCTL undo --profile "$SMOKE_PROFILE" "$TXID"
 echo "Undone. Test window restored:"
-tabctl list --window "$WIN"
+$TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN"
 
-# --- Screenshot check (run if screenshot/inspect was changed) ---
-FIRST_TAB=$(tabctl list --window "$WIN" | jq '.windows[0].tabs[0].tabId')
-tabctl screenshot --tab "$FIRST_TAB" --mode viewport
-tabctl inspect --tab "$FIRST_TAB" --signal page-meta --progress
+# --- Screenshot + inspect check ---
+FIRST_TAB=$($TABCTL list --profile "$SMOKE_PROFILE" --window "$WIN" | jq '.windows[0].tabs[0].tabId')
+$TABCTL screenshot --profile "$SMOKE_PROFILE" --tab "$FIRST_TAB" --mode viewport
+$TABCTL inspect --profile "$SMOKE_PROFILE" --tab "$FIRST_TAB" --signal page-meta --progress
 
-# --- Clean up ---
-tabctl close --window "$WIN" --confirm
+# --- Clean up test window ---
+$TABCTL close --profile "$SMOKE_PROFILE" --window "$WIN" --confirm
 echo "Test window $WIN closed. Smoke test complete."
 ```
 
-If `set -euo pipefail` causes the script to abort early, run sections individually and check each output before proceeding.
+If `set -euo pipefail` causes the script to abort early, run sections individually and check
+each output before proceeding.
+
+## Step 6: Tear down the smoke browser
+
+```bash
+kill "$SMOKE_PID" 2>/dev/null || true
+rm -f "$SMOKE_LOG"
+echo "Smoke browser stopped."
+```
+
+`smoke-browser.js` handles its own cleanup on shutdown: it removes the tabctl profile and
+deletes the temp dir automatically.
 
 ## Summary checklist
 
 - [ ] `npm test` passes
 - [ ] `npm run test:integration` passes (or skipped with note)
-- [ ] `tabctl ping` succeeds
+- [ ] Smoke browser started (`smoke-browser.js` ready signal received)
+- [ ] `tabctl ping --profile $SMOKE_PROFILE` succeeds
 - [ ] Read-only commands (`list`, `analyze`, `report`) return sensible output
 - [ ] Test window created with `TEST-Smoke-<timestamp>` group
 - [ ] Close + undo round-trip verified (tab disappeared, then restored)
 - [ ] Archive + undo round-trip verified (groups appeared, then window restored)
 - [ ] Test window cleaned up
+- [ ] Smoke browser stopped (`kill $SMOKE_PID`)
 
 ## Hard stops
 
 - Never run mutations outside the `TEST-Smoke-*` window.
 - Never run `tabctl archive --all` or `tabctl close --confirm` without an explicit `--window`, `--group`, or `--tab` scope.
-- If `tabctl ping` fails, fix the connection before any live browser steps.
+- Never skip `--profile "$SMOKE_PROFILE"` — always target the smoke browser, not the user's real profile.
+- If `tabctl ping` fails, check `smoke-browser.js` stderr output and fix the connection before any live browser steps.

--- a/.github/skills/smoke-test/SKILL.md
+++ b/.github/skills/smoke-test/SKILL.md
@@ -9,6 +9,14 @@ allowed-tools: Bash
 
 Run the full end-of-task verification sequence for tabctl: unit tests, integration tests, and a live browser smoke test using an isolated browser profile. Always run this after code changes.
 
+Prefer the progress-reporting smoke runner:
+
+```bash
+npm run test:smoke
+```
+
+It prints each step before it starts, streams long-running test output, starts and stops the isolated smoke browser, validates GraphQL responses, and cleans up smoke-created tabs/windows. Use the manual commands below only when debugging an individual step.
+
 The live browser steps use a **dedicated, agent-controlled Edge/Chrome instance** started by `scripts/smoke-browser.js`. This instance is isolated: it uses a temp profile dir, loads the local `dist/extension` build, and is torn down at the end. The user's real browser is never touched.
 
 ## Current CLI model

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ The `skills/` directory contains agent skills installable via the Skills CLI (`n
 - `skills/tabctl/` — CLI usage guide for agents
 - `skills/release/` — Release automation (version bump → PR → merge → tag → release)
 - `skills/git-commit/` — Conventional commit message generation
+- `.github/skills/smoke-test/` — End-of-task smoke test: unit tests, integration tests, and live browser mutation + undo verification in a disposable `TEST-Smoke-*` window
 
 ## Principles (read first)
 - Only mutate tabs that the test itself created.
@@ -177,105 +178,22 @@ Notes:
 - Extension tests (e.g., `extension.tabs.test.ts`) use a lightweight chrome stub on `globalThis.chrome` that records API calls and returns predictable results.
 
 ## Required end-of-task checks
-Always finish with:
-1. `npm test` — all unit tests must pass
-2. `npm run test:integration` — all integration tests must pass (if Chrome is available)
-3. A minimal smoke test in a new window you create (safe URLs + unique `TEST-` prefix). Verify via `tabctl group-list` or `tabctl list`.
-4. A screenshot-first smoke step: capture a screenshot before running selector-based extraction.
-5. If multiple profiles are configured, verify the active profile with `tabctl profile-show` before running smoke tests.
 
-> **Note:** Hooks provide split enforcement (fast on commit, heavy on push). If you bypass with `--no-verify` or `--no-verify` on push, run required checks manually.
+Always finish by running the `/smoke-test` skill (`.github/skills/smoke-test/SKILL.md`). It covers:
+1. `npm test` — unit tests
+2. `npm run test:integration` — integration tests (if Chrome is available)
+3. Profile verification
+4. Read-only live browser checks (`ping`, `list`, `analyze`, `report`)
+5. Mutation round-trips (close + undo, archive + undo) in a disposable `TEST-Smoke-<timestamp>` window
+6. Clean up of the test window
 
-Example (recommended for development):
-```bash
-ts=$(date +%s)
-tabctl open --new-window --url https://example.com --url https://example.org --url https://example.net --group "TEST-Smoke-${ts}"
-tabctl group-list --window last-focused
-```
+> **Note:** Hooks provide split enforcement (fast on commit, heavy on push). If you bypass with `--no-verify` on push, run `npm test` and `npm run test:integration` manually.
 
+## Smoke tests and integration tests
 
-Screenshot-first example:
-```bash
-tabctl screenshot --tab <tabId> --mode viewport
-tabctl inspect --tab <tabId> --signal selector --selector "link=a[href]" --selector-attr href-url
-```
+See `.github/skills/smoke-test/SKILL.md` for the full procedure — safe read-only checks, controlled mutation tests (close + undo, archive + undo) in a disposable `TEST-Smoke-*` window, and synthetic undo sanity checks.
 
-## Safe smoke tests (no mutations)
-Run these anytime:
-- `tabctl ping`
-- `tabctl list`
-- `tabctl analyze --stale-days 30`
-- `tabctl inspect --tab <tabId> --signal page-meta --progress`
-- `tabctl inspect --tab <tabId> --signal selector --selector "price=.price" --progress`
-- `tabctl report --format json` (no `--out`)
-
-## Controlled mutation tests (real Edge, minimal risk)
-Only use a dedicated test window and clearly labeled groups.
-
-### Setup a test window
-1. Create a new Edge window.
-2. Open three safe URLs: `https://example.com`, `https://example.org`, `https://example.net`.
-3. Group the first two tabs and name the group `TEST-Tabctl-<timestamp>`.
-4. Leave the third tab ungrouped.
-
-### Archive test
-1. Run `tabctl list` to find the test window id.
-2. Archive only that window:
-   `tabctl archive --window <windowId>`
-3. Confirm in Edge:
-   - A single Archive window exists.
-   - A group named `W# - TEST-Tabctl-<timestamp>` exists.
-   - An `W# - Ungrouped` group exists for the ungrouped tab.
-4. Undo:
-   `tabctl undo <txid>`
-
-### Close test
-1. Open a new tab in the test window (e.g. `https://example.com`).
-2. Find its `tabId` via `tabctl list`.
-3. Close that tab only:
-   `tabctl close --tab <tabId> --confirm`
-4. Undo:
-   `tabctl undo <txid>`
-
-### Report test
-1. Run `tabctl report --window <windowId> --format md --out /tmp/tab-report.md`.
-2. Verify the report includes descriptions for the example pages.
-
-## Safe usage of analyze/close
-`tabctl close` only works with explicit targets and is blocked for protected tabs by policy.
-
-Recommended safe pattern:
-1. Use `npm run test:integration` for automated close/undo testing in an isolated browser.
-2. For manual testing, use a dedicated test profile or a brand-new Edge window with only test tabs.
-3. Run `tabctl analyze`.
-4. Use `tabctl close --tab <tabId> --confirm` for a single test tab.
-5. Run `tabctl undo <txid>` to restore.
-
-## Undo history sanity checks (synthetic)
-You can validate undo with a single safe tab by inserting a synthetic record.
-
-1. Append a single JSON line to `$XDG_STATE_HOME/tabctl/undo.jsonl` (or `~/.local/state/tabctl/undo.jsonl`) (manual or via a tiny script).
-2. Use a unique `txid` and a safe URL (`https://example.com`).
-
-Example line (single tab, forces a new window):
-
-```
-{"txid":"tx-test-undo-1","createdAt":1700000000000,"action":"close","summary":{"closedTabs":1},"undo":{"action":"close","tabs":[{"url":"https://example.com","title":"Example","pinned":false,"active":false,"from":{"windowId":0,"index":0,"groupId":-1,"groupTitle":null,"groupColor":null,"groupCollapsed":null}}]}}
-```
-
-Then run:
-- `tabctl undo tx-test-undo-1`
-
-This should open a single tab in a new window.
-
-## Integration tests (isolated headless Chrome)
-The integration test launches a headless Chrome with its own `--user-data-dir`, loads the extension via CDP, and runs real CLI commands against it. No real tabs are touched.
-
-Run:
-- `npm run test:integration`
-
-This covers destructive paths (close, undo) safely. To test additional destructive commands (archive, dedupe), add Rust-side scenarios in `rust/crates/tabctl/tests/browser_integration.rs` (keep `scripts/ci/integration-bootstrap.js` as thin browser bootstrap only).
-On Windows, the Rust browser integration test uses TCP transport (`TABCTL_TRANSPORT=tcp`) for CLI requests because named-pipe transport can intermittently stall in CI.
+Integration tests run against an isolated headless Chrome (`npm run test:integration`) and cover destructive paths safely. To test additional destructive commands (archive, dedupe), add Rust-side scenarios in `rust/crates/tabctl/tests/browser_integration.rs` (keep `scripts/ci/integration-bootstrap.js` as thin browser bootstrap only). On Windows, use `TABCTL_TRANSPORT=tcp`.
 
 ## Code architecture style
 

--- a/CLI.md
+++ b/CLI.md
@@ -64,8 +64,14 @@ Use `tabctl schema` when you need field discovery, then use `tabctl query` for b
 # Analyze duplicates and stale tabs
  tabctl query '{ analyze(windowId: 123, staleDays: 30) { totalTabs duplicateTabs staleTabs raw } }'
 
-# Inspect page metadata or selectors
+# Inspect page metadata
  tabctl query 'query { inspectTabs(tabIds: [456], signals: ["page-meta"]) { totals { tabs tasks } entries { tabId signals { name valueJson } } } }'
+
+# Inspect selectors with typed attrs and filters
+ tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true }, { name: "checkout_visible", selector: "#checkout", attr: "visible" }, { name: "checkout_style", selector: "#checkout", attr: "styles", styleProps: ["color", "background-color"] }, { name: "item_count", selector: ".line-item", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }]) { totals { tabs tasks } entries { tabId url signals { name valueJson } } } }'
+
+# Read page content as Markdown
+ tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 50000) { totals { tabs tasks } entries { tabId title url markdown chars truncated extracted error } } }'
 
 # Generate a report with descriptions
  tabctl query '{ reportTabs(windowId: 123) { totals { tabs } entries { tabId title url description } } }'
@@ -77,6 +83,60 @@ Use `tabctl schema` when you need field discovery, then use `tabctl query` for b
  tabctl query 'query { latestBrowserState { snapshotId reason groups { logicalGroupId title browserGroupId tabUrls } } }'
  tabctl query 'query { browserStateHistory(limit: 10) { snapshotId recordedAt reason eventCount eventKinds } }'
  tabctl query 'query { browserStateGroupHistory(title: "Inbox", limit: 10) { snapshotId logicalGroupId title browserGroupId tabUrls } }'
+```
+
+### inspectTabs
+
+`inspectTabs` can return built-in signals like `page-meta` and selector-derived signals from `SelectorSpecInput`.
+
+`SelectorSpecInput` fields:
+- `name` — result key for the selector
+- `selector` — CSS selector to run in the page
+- `attr` — extraction kind or attribute name
+- `all` — return all matching values as an array; ignored for `count`, `box`, `styles`, `visible`, `enabled`, and `checked`
+- `text` — filter matches by text content before returning values
+- `textMode` — `contains` (default), `exact`, or `starts-with`
+- `styleProps` — CSS property allowlist for `attr: "styles"`
+
+Supported `attr` values:
+- `text` — text content (default)
+- any DOM attribute name such as `aria-label` or `data-testid`
+- `href-url` / `src-url` — resolved HTTP(S) URLs
+- `html` — `outerHTML` for the matched element, truncated at the per-signal cap
+- `value` — `.value` for `input`, `textarea`, and `select`; otherwise `null`
+- `count` — number of matching elements after the text filter; always numeric
+- `box` — first match bounding box: `{x, y, width, height, top, right, bottom, left}`
+- `styles` — computed-style map for the requested `styleProps`
+- `visible` — `true` when the first match is rendered and not `display:none`, `visibility:hidden`, or `opacity:0`
+- `enabled` — `true` when the first match is not disabled and `aria-disabled != "true"`
+- `checked` — `true` for checked inputs, otherwise `aria-checked == "true"`
+
+Example:
+
+```bash
+tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true, text: "$", textMode: "contains" }, { name: "buy_now_visible", selector: "button.buy-now", attr: "visible" }, { name: "buy_now_style", selector: "button.buy-now", attr: "styles", styleProps: ["color", "background-color"] }, { name: "review_count", selector: ".review", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }, { name: "tos_checked", selector: "input[name=terms]", attr: "checked" }]) { entries { tabId url signals { name valueJson } } } }'
+```
+
+### readTabs
+
+`readTabs` reads each targeted tab's main-frame HTML and converts it to Markdown.
+
+Arguments:
+- scope via one of `windowId`, `groupId`, `groupTitle`, `tabIds`, or `ungrouped`
+- `extract` — best-effort content extraction before Markdown conversion; defaults to `true`
+- `maxChars` — maximum Markdown characters per tab; defaults to `50000`, max `200000`
+- `maxHtmlChars` — maximum raw HTML characters read per tab; defaults to `500000`, max `1000000`
+- `timeoutMs` — per-tab timeout in milliseconds; defaults to `15000`
+
+Caveats:
+- Extraction is heuristic; check `extracted` in the response to see whether it was applied.
+- v1 reads the main frame only; cross-origin iframes and shadow DOM are not traversed.
+- Non-scriptable URLs such as `chrome://` and `about:` are skipped automatically.
+
+Example:
+
+```bash
+tabctl query 'query { readTabs(groupTitle: "Research", extract: true, maxChars: 30000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId windowId title url markdown chars truncated extracted error } } }'
 ```
 
 ### Mutation examples

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ tabctl schema
 | `tabctl history` | Show recent undo history entries |
 | `tabctl setup`, `doctor`, `policy`, `profile-*` | Local/admin profile management |
 
+Read-only browser features include:
+- `inspectTabs` for page metadata and selector-based reads
+- `readTabs` for page HTML → Markdown conversion with best-effort extraction
+- `reportTabs`, `captureScreenshots`, and browser-state history queries for summaries and context
+
 See [CLI.md](CLI.md) for the full command reference, options, and examples.
 
 ## GraphQL examples
@@ -160,6 +165,12 @@ tabctl query '{ analyze(windowId: 123, staleDays: 30) { totalTabs duplicateTabs 
 
 # Inspect page metadata
 tabctl query 'query { inspectTabs(tabIds: [456], signals: ["page-meta"]) { entries { tabId signals { name valueJson } } } }'
+
+# Inspect selectors with typed attrs and filters
+tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true }, { name: "buy_now_visible", selector: "button.buy-now", attr: "visible" }, { name: "buy_now_style", selector: "button.buy-now", attr: "styles", styleProps: ["color", "background-color"] }, { name: "review_count", selector: ".review", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }]) { entries { tabId url signals { name valueJson } } } }'
+
+# Read tab content as Markdown (best-effort extraction by default)
+tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted error } } }'
 
 # Generate reports
 tabctl query '{ reportTabs(windowId: 123) { entries { tabId title url description } } }'
@@ -415,7 +426,8 @@ TABCTL_VERSION_MODE=release npm run build
 Notes:
 - Browser reads and mutations now go through GraphQL via `tabctl query`.
 - Reports include short descriptions from page metadata and a fallback snippet.
-- `inspectTabs` supports `page-meta` and `selector` signals.
+- `inspectTabs` supports `page-meta` plus selector reads with `all`, `text`, `textMode`, `styleProps`, and attrs such as `html`, `value`, `count`, `box`, `styles`, `visible`, `enabled`, and `checked`.
+- `readTabs` converts main-frame page HTML to Markdown, with best-effort content extraction enabled by default and status surfaced through `extracted`/`error` fields.
 - `captureScreenshots` returns tile metadata and image data from GraphQL.
 - `undoAction` accepts either an explicit `txid` or `latest: true`.
 - `tabctl history --json` returns a top-level JSON array.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.5",
+      "version": "0.6.0-rc.6",
       "license": "MIT",
       "dependencies": {
         "markdown-for-agents": "^1.3.4",
@@ -25,7 +25,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.5"
+        "tabctl-win32-x64": "0.6.0-rc.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -681,17 +681,7 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "version": "0.6.0-rc.5",
-      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.5.tgz",
-      "integrity": "sha512-gjcg/tqgirXhlNmQI49IOCcxVIWBkBuhwOqFgthEx88y+Kx80WtB5YfBdh321Htu5ryltUtMRQdRuoLBVxZ3kA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.0-rc.5",
       "license": "MIT",
       "dependencies": {
+        "markdown-for-agents": "^1.3.4",
         "normalize-url": "^8.1.1"
       },
       "bin": {
@@ -514,6 +515,85 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -556,6 +636,38 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/markdown-for-agents": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/markdown-for-agents/-/markdown-for-agents-1.3.4.tgz",
+      "integrity": "sha512-kyXaAd/A+6SrZdaEbzeKL1wyJck5lckIXeTa1w04SCqxpzV0vxAQDT7FlJfXsYdm426L/TB39p7HKMpM4uFVsA==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "htmlparser2": "^10.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/normalize-url": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
@@ -569,7 +681,17 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "optional": true
+      "version": "0.6.0-rc.5",
+      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.5.tgz",
+      "integrity": "sha512-gjcg/tqgirXhlNmQI49IOCcxVIWBkBuhwOqFgthEx88y+Kx80WtB5YfBdh321Htu5ryltUtMRQdRuoLBVxZ3kA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -42,6 +42,7 @@
     "test": "npm run build && npm run rust:verify",
     "test:unit": "npm run rust:test",
     "test:integration": "cargo test --manifest-path rust/Cargo.toml --test browser_integration --test browser_coverage --test browser_primitives --test local_commands -- --ignored --nocapture --test-threads=1",
+    "test:smoke": "node scripts/smoke-test.js",
     "clean": "node -e \"fs.rmSync('dist',{recursive:true,force:true})\" ",
     "prepare": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true"
   },
@@ -52,7 +53,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.5"
+    "tabctl-win32-x64": "0.6.0-rc.6"
   },
   "dependencies": {
     "markdown-for-agents": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tabctl-win32-x64": "0.6.0-rc.5"
   },
   "dependencies": {
+    "markdown-for-agents": "^1.3.4",
     "normalize-url": "^8.1.1"
   }
 }

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.5",
+  "version": "0.6.0-rc.6",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -623,9 +623,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "clap",
  "dirs",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "indexmap",
  "juniper",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "getrandom",
  "rusqlite",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.5"
+version = "0.6.0-rc.6"

--- a/rust/crates/graphql/src/schema.rs
+++ b/rust/crates/graphql/src/schema.rs
@@ -382,23 +382,40 @@ impl Query {
         #[graphql(description = "Wait timeout in ms.")] wait_timeout_ms: Option<i32>,
     ) -> FieldResult<InspectResult> {
         let mut params = scoped_params(window_id, group_id, group_title, ungrouped, tab_ids);
+        let has_selector_specs = selectors.as_ref().is_some_and(|s| !s.is_empty());
         if let Some(mut requested_signals) = signals {
-            if selectors.as_ref().is_some_and(|s| !s.is_empty())
-                && !requested_signals.iter().any(|s| s == "selector")
-            {
+            if has_selector_specs && !requested_signals.iter().any(|s| s == "selector") {
                 requested_signals.push("selector".to_string());
             }
             params.insert("signals".to_string(), serde_json::json!(requested_signals));
+        } else if has_selector_specs {
+            params.insert("signals".to_string(), serde_json::json!(["selector"]));
         }
         if let Some(selector_specs) = selectors {
             let values: Vec<serde_json::Value> = selector_specs
                 .into_iter()
                 .map(|selector| {
-                    serde_json::json!({
-                        "name": selector.name,
-                        "selector": selector.selector,
-                        "attr": selector.attr,
-                    })
+                    let mut obj = serde_json::Map::new();
+                    obj.insert("name".to_string(), serde_json::json!(selector.name));
+                    obj.insert("selector".to_string(), serde_json::json!(selector.selector));
+                    if let Some(attr) = &selector.attr {
+                        obj.insert("attr".to_string(), serde_json::json!(attr));
+                    }
+                    if let Some(all) = selector.all {
+                        if all {
+                            obj.insert("all".to_string(), serde_json::json!(true));
+                        }
+                    }
+                    if let Some(text) = &selector.text {
+                        obj.insert("text".to_string(), serde_json::json!(text));
+                    }
+                    if let Some(text_mode) = &selector.text_mode {
+                        obj.insert("textMode".to_string(), serde_json::json!(text_mode));
+                    }
+                    if let Some(style_props) = &selector.style_props {
+                        obj.insert("styleProps".to_string(), serde_json::json!(style_props));
+                    }
+                    serde_json::Value::Object(obj)
                 })
                 .collect();
             if !values.is_empty() {
@@ -424,6 +441,47 @@ impl Query {
             .map_err(|e| juniper::FieldError::new(e, juniper::Value::Null))?;
 
         Ok(parse_inspect_result(&response))
+    }
+
+    /// Read tabs as Markdown — convert each tab's page HTML to clean Markdown for agent consumption.
+    #[allow(clippy::too_many_arguments)]
+    fn read_tabs(
+        ctx: &GqlContext,
+        #[graphql(description = "Restrict to this window.")] window_id: Option<i32>,
+        #[graphql(description = "Restrict to this group (by group ID).")] group_id: Option<i32>,
+        #[graphql(description = "Restrict to tabs whose group has this title.")]
+        group_title: Option<String>,
+        #[graphql(description = "When true, read only ungrouped tabs.")] ungrouped: Option<bool>,
+        #[graphql(description = "Restrict to these specific tab IDs.")] tab_ids: Option<Vec<i32>>,
+        #[graphql(description = "Enable content extraction (strip nav/ads). Default: true.")]
+        extract: Option<bool>,
+        #[graphql(description = "Maximum raw HTML characters to read per tab. Default: 500000.")]
+        max_html_chars: Option<i32>,
+        #[graphql(description = "Maximum Markdown characters per tab. Default: 50000.")]
+        max_chars: Option<i32>,
+        #[graphql(description = "Timeout in ms for each tab read. Default: 15000.")]
+        timeout_ms: Option<i32>,
+    ) -> FieldResult<ReadTabResult> {
+        let mut params = scoped_params(window_id, group_id, group_title, ungrouped, tab_ids);
+        if let Some(v) = extract {
+            params.insert("extract".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = max_html_chars {
+            params.insert("maxHtmlChars".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = max_chars {
+            params.insert("maxChars".to_string(), serde_json::json!(v));
+        }
+        if let Some(v) = timeout_ms {
+            params.insert("timeoutMs".to_string(), serde_json::json!(v));
+        }
+
+        let response = ctx
+            .sender
+            .send("read-markdown", serde_json::Value::Object(params))
+            .map_err(|e| juniper::FieldError::new(e, juniper::Value::Null))?;
+
+        Ok(parse_read_result(&response))
     }
 
     /// Build a report of tab metadata and extracted descriptions.
@@ -812,6 +870,56 @@ fn parse_inspect_result(response: &serde_json::Value) -> InspectResult {
         .unwrap_or_default();
 
     InspectResult { totals, entries }
+}
+
+fn parse_read_result(response: &serde_json::Value) -> ReadTabResult {
+    let totals = ReadTabTotals {
+        tabs: response
+            .get("totals")
+            .and_then(|t| t.get("tabs"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32,
+        tasks: response
+            .get("totals")
+            .and_then(|t| t.get("tasks"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32,
+    };
+
+    let entries = response
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| {
+                    Some(ReadTabEntry {
+                        tab_id: e.get("tabId")?.as_i64()? as i32,
+                        window_id: e.get("windowId")?.as_i64()? as i32,
+                        url: e
+                            .get("url")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                        title: e.get("title").and_then(|v| v.as_str()).map(String::from),
+                        markdown: e
+                            .get("markdown")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                        chars: e.get("chars").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+                        truncated: e
+                            .get("truncated")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                        extracted: e.get("extracted").and_then(|v| v.as_bool()).unwrap_or(true),
+                        error: e.get("error").and_then(|v| v.as_str()).map(String::from),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    ReadTabResult { totals, entries }
 }
 
 fn parse_report_result(response: &serde_json::Value) -> ReportResult {
@@ -1867,6 +1975,14 @@ mod tests {
                         }
                     }]
                 })),
+                "read-markdown" => Ok(serde_json::json!({
+                    "totals": { "tabs": 1, "tasks": 1 },
+                    "entries": [{
+                        "tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A",
+                        "markdown": "# Hello\n\nWorld.", "chars": 16,
+                        "truncated": false, "extracted": true, "error": null
+                    }]
+                })),
                 "report" => Ok(serde_json::json!({
                     "generatedAt": 1700000001234.0,
                     "entries": [{
@@ -2173,6 +2289,63 @@ mod tests {
     }
 
     #[test]
+    fn query_inspect_tabs_selector_spec_extended() {
+        let result = exec(
+            r#"{
+                inspectTabs(windowId: 100, selectors: [
+                    { name: "price", selector: ".price", attr: "text", all: true, text: "USD", textMode: "contains" },
+                    { name: "style", selector: ".btn", attr: "styles", styleProps: ["color", "font-size"] }
+                ]) {
+                    totals { tabs }
+                    entries { tabId signals { name valueJson } }
+                }
+            }"#,
+        );
+        assert!(
+            result.get("errors").is_none(),
+            "errors: {:?}",
+            result.get("errors")
+        );
+        let inspect = &result["data"]["inspectTabs"];
+        assert_eq!(inspect["totals"]["tabs"], 1);
+        let entries = inspect["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        let signals = entries[0]["signals"].as_array().unwrap();
+        assert!(signals.iter().any(|s| s["name"] == "price"));
+    }
+
+    #[test]
+    fn query_read_tabs_basic() {
+        let result = exec(
+            r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId markdown chars truncated extracted error } } }"#,
+        );
+        assert!(
+            result.get("errors").is_none(),
+            "errors: {:?}",
+            result.get("errors")
+        );
+        assert_eq!(result["data"]["readTabs"]["totals"]["tabs"], 1);
+        let entries = result["data"]["readTabs"]["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["tabId"], 1);
+        assert_eq!(entries[0]["markdown"], "# Hello\n\nWorld.");
+        assert_eq!(entries[0]["chars"], 16);
+        assert!(entries[0]["error"].is_null());
+    }
+
+    #[test]
+    fn query_read_tabs_with_options() {
+        let result = exec(
+            r#"{ readTabs(windowId: 100, extract: false, maxChars: 5000, maxHtmlChars: 200000) { totals { tabs } entries { tabId extracted } } }"#,
+        );
+        assert!(
+            result.get("errors").is_none(),
+            "errors: {:?}",
+            result.get("errors")
+        );
+    }
+
+    #[test]
     fn query_report_tabs() {
         let result = exec(
             "{ reportTabs(windowId: 100) { generatedAt totals { tabs } entries { tabId description groupColor } } }",
@@ -2318,12 +2491,16 @@ mod tests {
         assert!(sdl.contains("type InspectResult"));
         assert!(sdl.contains("type ReportResult"));
         assert!(sdl.contains("type ScreenshotResult"));
+        assert!(sdl.contains("type ReadTabResult"));
+        assert!(sdl.contains("type ReadTabEntry"));
+        assert!(sdl.contains("readTabs"));
         assert!(sdl.contains("type PingResult"));
         assert!(sdl.contains("type HistoryEntry"));
         assert!(sdl.contains("type ReloadResult"));
         assert!(sdl.contains("type SkippedUrl"));
         assert!(sdl.contains("type OpenResult"));
         assert!(sdl.contains("input SelectorSpecInput"));
+        assert!(sdl.contains("styleProps"));
     }
 
     #[test]

--- a/rust/crates/graphql/src/types.rs
+++ b/rust/crates/graphql/src/types.rs
@@ -250,8 +250,17 @@ pub(crate) struct SelectorSpecInput {
     pub name: String,
     /// CSS selector to execute in the page.
     pub selector: String,
-    /// Attribute or extraction mode (e.g. text, href-url).
+    /// Extraction kind: text (default), attr name, href-url, src-url,
+    /// html, value, count, box, styles, visible, enabled, checked.
     pub attr: Option<String>,
+    /// When true, return all matching elements (as array). Ignored for count/box/styles/visible/enabled/checked.
+    pub all: Option<bool>,
+    /// Text filter: only include elements whose textContent contains/matches this string.
+    pub text: Option<String>,
+    /// Text filter mode: contains (default), exact, starts-with.
+    pub text_mode: Option<String>,
+    /// CSS property names to read for the 'styles' attr. Required when attr is 'styles'.
+    pub style_props: Option<Vec<String>>,
 }
 
 /// A named signal payload returned by inspectTabs.
@@ -408,6 +417,47 @@ pub(crate) struct ScreenshotResult {
     pub totals: ScreenshotTotals,
     /// Per-tab capture entries.
     pub entries: Vec<ScreenshotEntry>,
+}
+
+/// Markdown content read from a single tab.
+#[derive(Debug, Clone, GraphQLObject)]
+pub(crate) struct ReadTabEntry {
+    /// Tab identifier.
+    pub tab_id: i32,
+    /// Window identifier.
+    pub window_id: i32,
+    /// Tab URL.
+    pub url: String,
+    /// Tab title.
+    pub title: Option<String>,
+    /// Markdown rendering of the page content.
+    pub markdown: String,
+    /// Length of the markdown string in characters.
+    pub chars: i32,
+    /// Whether the markdown was truncated at maxChars.
+    pub truncated: bool,
+    /// Whether content extraction (strip nav/ads) was applied.
+    pub extracted: bool,
+    /// Error message if the tab could not be read, otherwise null.
+    pub error: Option<String>,
+}
+
+/// Summary counts for readTabs.
+#[derive(Debug, Clone, GraphQLObject)]
+pub(crate) struct ReadTabTotals {
+    /// Number of tabs attempted.
+    pub tabs: i32,
+    /// Number of page-markdown tasks executed.
+    pub tasks: i32,
+}
+
+/// Result of a readTabs query.
+#[derive(Debug, Clone, GraphQLObject)]
+pub(crate) struct ReadTabResult {
+    /// Summary counts.
+    pub totals: ReadTabTotals,
+    /// Per-tab markdown entries.
+    pub entries: Vec<ReadTabEntry>,
 }
 
 /// Result of a ping query.

--- a/rust/crates/host/src/host_impl/orchestrate/graphql_contracts.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/graphql_contracts.rs
@@ -14,6 +14,7 @@ use super::*;
 /// A CommandSender that returns pre-recorded responses for specific actions.
 struct ContractSender {
     responses: Mutex<Vec<(String, Value)>>,
+    requests: Mutex<Vec<(String, Value)>>,
     snapshot: Value,
 }
 
@@ -21,6 +22,7 @@ impl ContractSender {
     fn new(snapshot: Value) -> Self {
         Self {
             responses: Mutex::new(Vec::new()),
+            requests: Mutex::new(Vec::new()),
             snapshot,
         }
     }
@@ -31,10 +33,22 @@ impl ContractSender {
             .unwrap()
             .push((action.to_string(), response));
     }
+
+    fn request_params(&self, action: &str) -> Option<Value> {
+        self.requests
+            .lock()
+            .unwrap()
+            .iter()
+            .find_map(|(a, params)| (a == action).then(|| params.clone()))
+    }
 }
 
 impl tabctl_graphql::CommandSender for ContractSender {
-    fn send(&self, action: &str, _params: Value) -> Result<Value, String> {
+    fn send(&self, action: &str, params: Value) -> Result<Value, String> {
+        self.requests
+            .lock()
+            .unwrap()
+            .push((action.to_string(), params));
         let responses = self.responses.lock().unwrap();
         for (a, r) in responses.iter() {
             if a == action {
@@ -558,6 +572,94 @@ fn contract_inspect_tabs() {
         .as_array()
         .expect("signals should be an array");
     assert!(first_signals.iter().any(|s| s["name"] == "page-meta"));
+}
+
+#[test]
+fn contract_inspect_tabs_extended_selector() {
+    let snapshot = sample_snapshot();
+    let sender = Arc::new(ContractSender::new(snapshot.clone()));
+    sender.add_response(
+        "inspect",
+        serde_json::json!({
+            "totals": {"tabs": 1, "signals": 1, "tasks": 1},
+            "entries": [{
+                "tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A",
+                "signals": {"btn": {"values": [], "missing": [], "errors": {}, "hints": {}}}
+            }]
+        }),
+    );
+
+    let result = tabctl_graphql::execute(
+        r#"{ inspectTabs(windowId: 100, selectors: [
+            { name: "btn", selector: ".btn", attr: "styles", styleProps: ["color", "font-size"], all: true, text: "Click", textMode: "contains" }
+        ]) { totals { tasks } entries { tabId signals { name valueJson } } } }"#,
+        None,
+        snapshot,
+        sender.clone(),
+    )
+    .unwrap();
+
+    assert!(
+        result.get("errors").is_none(),
+        "errors: {:?}",
+        result.get("errors")
+    );
+    assert_eq!(result["data"]["inspectTabs"]["totals"]["tasks"], 1);
+
+    let params = sender
+        .request_params("inspect")
+        .expect("inspect params should be recorded");
+    assert_eq!(params["windowId"], 100);
+    assert_eq!(params["signals"], serde_json::json!(["selector"]));
+    assert_eq!(params["selectorSpecs"][0]["name"], "btn");
+    assert_eq!(params["selectorSpecs"][0]["selector"], ".btn");
+    assert_eq!(params["selectorSpecs"][0]["attr"], "styles");
+    assert_eq!(params["selectorSpecs"][0]["all"], true);
+    assert_eq!(params["selectorSpecs"][0]["text"], "Click");
+    assert_eq!(params["selectorSpecs"][0]["textMode"], "contains");
+    assert_eq!(
+        params["selectorSpecs"][0]["styleProps"],
+        serde_json::json!(["color", "font-size"])
+    );
+}
+
+#[test]
+fn contract_read_markdown_inspect() {
+    // Uses the real ReadMarkdownOrchestration wired through the GraphQL layer
+    let snapshot = sample_snapshot();
+    let sender = ContractSender::new(snapshot.clone());
+    sender.add_response(
+        "read-markdown",
+        serde_json::json!({
+            "totals": { "tabs": 1, "tasks": 1 },
+            "entries": [{
+                "tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A",
+                "markdown": "# A\n\nContent.", "chars": 13,
+                "truncated": false, "extracted": true, "error": null
+            }]
+        }),
+    );
+
+    let result = tabctl_graphql::execute(
+        r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId url markdown chars truncated extracted error } } }"#,
+        None,
+        snapshot,
+        std::sync::Arc::new(sender),
+    )
+    .unwrap();
+
+    assert!(
+        result.get("errors").is_none(),
+        "errors: {:?}",
+        result.get("errors")
+    );
+    let totals = &result["data"]["readTabs"]["totals"];
+    assert_eq!(totals["tabs"], 1);
+    assert_eq!(totals["tasks"], 1);
+    let entries = result["data"]["readTabs"]["entries"].as_array().unwrap();
+    assert_eq!(entries[0]["tabId"], 1);
+    assert_eq!(entries[0]["markdown"], "# A\n\nContent.");
+    assert!(entries[0]["error"].is_null());
 }
 
 // ── report ───────────────────────────────────────────────────────────────

--- a/rust/crates/host/src/host_impl/orchestrate/inspect.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/inspect.rs
@@ -41,6 +41,10 @@ struct Signal {
     name: String,
     selector: Option<String>,
     attr: Option<String>,
+    all: bool,
+    text: Option<String>,
+    text_mode: Option<String>,
+    style_props: Option<Vec<String>>,
     timeout_ms: Option<i64>,
 }
 
@@ -61,6 +65,16 @@ impl Signal {
             name,
             selector: v.get("selector").and_then(Value::as_str).map(String::from),
             attr: v.get("attr").and_then(Value::as_str).map(String::from),
+            all: v.get("all").and_then(Value::as_bool).unwrap_or(false),
+            text: v.get("text").and_then(Value::as_str).map(String::from),
+            text_mode: v.get("textMode").and_then(Value::as_str).map(String::from),
+            style_props: v.get("styleProps").and_then(Value::as_array).map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(String::from)
+                    .collect()
+            }),
             timeout_ms: None,
         })
     }
@@ -78,6 +92,22 @@ impl Signal {
                 .and_then(Value::as_str)
                 .map(String::from),
             attr: spec.get("attr").and_then(Value::as_str).map(String::from),
+            all: spec.get("all").and_then(Value::as_bool).unwrap_or(false),
+            text: spec.get("text").and_then(Value::as_str).map(String::from),
+            text_mode: spec
+                .get("textMode")
+                .and_then(Value::as_str)
+                .map(String::from),
+            style_props: spec
+                .get("styleProps")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .map(String::from)
+                        .collect()
+                }),
             timeout_ms: None,
         })
     }
@@ -88,6 +118,10 @@ impl Signal {
             name: "page-meta".to_string(),
             selector: None,
             attr: None,
+            all: false,
+            text: None,
+            text_mode: None,
+            style_props: None,
             timeout_ms: None,
         }
     }
@@ -95,11 +129,25 @@ impl Signal {
     fn to_execute_params(&self, tab_id: i64) -> Value {
         match self.signal_type.as_str() {
             "selector" => {
-                let selectors = vec![serde_json::json!({
+                let mut selector = serde_json::json!({
                     "name": self.name,
                     "selector": self.selector,
                     "attr": self.attr.as_deref().unwrap_or("text"),
-                })];
+                });
+                if self.all {
+                    selector["all"] = Value::Bool(true);
+                }
+                if let Some(text) = &self.text {
+                    selector["text"] = Value::String(text.clone());
+                }
+                if let Some(text_mode) = &self.text_mode {
+                    selector["textMode"] = Value::String(text_mode.clone());
+                }
+                if let Some(style_props) = &self.style_props {
+                    selector["styleProps"] =
+                        Value::Array(style_props.iter().cloned().map(Value::String).collect());
+                }
+                let selectors = vec![selector];
                 let mut params = serde_json::json!({
                     "tabId": tab_id,
                     "func": "extractSelectorSignal",
@@ -199,6 +247,10 @@ impl InspectOrchestration {
                                     name: id.clone(),
                                     selector: None,
                                     attr: None,
+                                    all: false,
+                                    text: None,
+                                    text_mode: None,
+                                    style_props: None,
                                     timeout_ms: None,
                                 });
                             }
@@ -525,5 +577,74 @@ mod tests {
         assert_eq!(action, "p:execute-script");
         // First task should be page-meta
         assert_eq!(params["func"], "extractPageMeta");
+    }
+
+    #[test]
+    fn inspect_selector_specs_pass_through_style_props() {
+        let params = serde_json::json!({
+            "signals": ["selector"],
+            "selectorSpecs": [
+                {
+                    "name": "ctaStyles",
+                    "selector": ".cta",
+                    "attr": "styles",
+                    "styleProps": ["display", "color"]
+                }
+            ],
+        });
+        let mut orch = InspectOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://example.com", "title": "Ex", "groupId": -1}),
+        ]);
+
+        let step = orch.step(snap);
+        let OrchStep::SendPrimitive { action, params } = &step else {
+            panic!("expected SendPrimitive, got {step:?}");
+        };
+        assert_eq!(action, "p:execute-script");
+        assert_eq!(params["func"], "extractSelectorSignal");
+        assert_eq!(
+            params["args"][0][0]["styleProps"],
+            serde_json::json!(["display", "color"])
+        );
+    }
+
+    #[test]
+    fn inspect_selector_specs_pass_through_filter_fields() {
+        let params = serde_json::json!({
+            "signals": ["selector"],
+            "selectorSpecs": [
+                {
+                    "name": "matches",
+                    "selector": ".item",
+                    "attr": "text",
+                    "all": true,
+                    "text": "Active",
+                    "textMode": "starts-with"
+                }
+            ],
+        });
+        let mut orch = InspectOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://example.com", "title": "Ex", "groupId": -1}),
+        ]);
+
+        let step = orch.step(snap);
+        let OrchStep::SendPrimitive { action, params } = &step else {
+            panic!("expected SendPrimitive, got {step:?}");
+        };
+        assert_eq!(action, "p:execute-script");
+        assert_eq!(params["func"], "extractSelectorSignal");
+        assert_eq!(params["args"][0][0]["all"], Value::Bool(true));
+        assert_eq!(
+            params["args"][0][0]["text"],
+            Value::String("Active".to_string())
+        );
+        assert_eq!(
+            params["args"][0][0]["textMode"],
+            Value::String("starts-with".to_string())
+        );
     }
 }

--- a/rust/crates/host/src/host_impl/orchestrate/mod.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/mod.rs
@@ -14,13 +14,13 @@ mod merge_window;
 mod move_group;
 mod move_tab;
 mod open;
+mod read_markdown;
 mod refresh;
 pub(super) mod report;
 pub(crate) mod resolve;
 pub(crate) mod scope;
 mod screenshot;
 mod undo;
-
 /// Multi-step orchestration of extension primitives for a single CLI request.
 ///
 /// Each implementation encodes a state machine: `start()` produces the first
@@ -100,6 +100,9 @@ pub(super) fn orchestration_for(action: &str, params: &Value) -> Option<Box<dyn 
         "undo" => Some(Box::new(undo::UndoOrchestration::new(params))),
         "analyze" => Some(Box::new(analyze::AnalyzeOrchestration::new(params))),
         "inspect" => Some(Box::new(inspect::InspectOrchestration::new(params))),
+        "read-markdown" => Some(Box::new(read_markdown::ReadMarkdownOrchestration::new(
+            params,
+        ))),
         "report" => Some(Box::new(report::ReportOrchestration::new(params))),
         "screenshot" => Some(Box::new(screenshot::ScreenshotOrchestration::new(params))),
         "snapshot" => Some(Box::new(list::SnapshotOrchestration)),

--- a/rust/crates/host/src/host_impl/orchestrate/read_markdown.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/read_markdown.rs
@@ -1,0 +1,324 @@
+use serde_json::{Map, Value};
+
+use super::report::is_non_scriptable;
+use super::scope::select_tabs_by_scope;
+use super::OrchStep;
+
+#[derive(Debug)]
+pub(crate) struct ReadMarkdownOrchestration {
+    params: Value,
+    state: Option<ReadMarkdownState>,
+}
+
+#[derive(Debug)]
+struct ReadMarkdownState {
+    tabs: Vec<ReadMarkdownTab>,
+    tab_index: usize,
+    results: Vec<Value>,
+    options: ReadMarkdownOptions,
+}
+
+#[derive(Debug, Clone)]
+struct ReadMarkdownTab {
+    tab_id: i64,
+    window_id: i64,
+    url: String,
+    title: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ReadMarkdownOptions {
+    extract: bool,
+    max_html_chars: Option<i64>,
+    max_chars: Option<i64>,
+    timeout_ms: Option<i64>,
+}
+
+impl ReadMarkdownOrchestration {
+    pub(crate) fn new(params: &Value) -> Self {
+        Self {
+            params: params.clone(),
+            state: None,
+        }
+    }
+}
+
+impl super::Orchestration for ReadMarkdownOrchestration {
+    fn start(&mut self) -> OrchStep {
+        OrchStep::SendPrimitive {
+            action: "p:snapshot".to_string(),
+            params: Value::Object(Map::new()),
+        }
+    }
+
+    fn step(&mut self, response: Value) -> OrchStep {
+        if self.state.is_none() {
+            return self.handle_snapshot(response);
+        }
+        self.handle_markdown(response)
+    }
+}
+
+impl ReadMarkdownOrchestration {
+    fn handle_snapshot(&mut self, snapshot: Value) -> OrchStep {
+        let scope_result = select_tabs_by_scope(&snapshot, &self.params);
+        if let Some(err) = scope_result.error {
+            return OrchStep::Error {
+                message: err,
+                hint: None,
+            };
+        }
+
+        let tabs: Vec<ReadMarkdownTab> = scope_result
+            .tabs
+            .iter()
+            .filter(|t| !is_non_scriptable(t.url.as_deref().unwrap_or("")))
+            .map(|t| ReadMarkdownTab {
+                tab_id: t.tab_id,
+                window_id: t.window_id,
+                url: t.url.clone().unwrap_or_default(),
+                title: t.title.clone(),
+            })
+            .collect();
+
+        if tabs.is_empty() {
+            return OrchStep::Complete {
+                response: serde_json::json!({
+                    "totals": { "tabs": 0, "tasks": 0 },
+                    "entries": [],
+                }),
+                undo: None,
+            };
+        }
+
+        let options = ReadMarkdownOptions {
+            extract: self
+                .params
+                .get("extract")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
+            max_html_chars: self.params.get("maxHtmlChars").and_then(Value::as_i64),
+            max_chars: self.params.get("maxChars").and_then(Value::as_i64),
+            timeout_ms: self.params.get("timeoutMs").and_then(Value::as_i64),
+        };
+
+        let first_params = build_page_markdown_params(&tabs[0], &options);
+        self.state = Some(ReadMarkdownState {
+            tabs,
+            tab_index: 0,
+            results: Vec::new(),
+            options,
+        });
+
+        OrchStep::SendPrimitive {
+            action: "p:page-markdown".to_string(),
+            params: first_params,
+        }
+    }
+
+    fn handle_markdown(&mut self, response: Value) -> OrchStep {
+        let state = self.state.as_mut().unwrap();
+        let tab = state.tabs[state.tab_index].clone();
+        state.results.push(build_result_entry(
+            &tab,
+            &state.options,
+            if response.get("markdown").is_some() {
+                Some(&response)
+            } else {
+                None
+            },
+        ));
+        state.tab_index += 1;
+
+        if state.tab_index >= state.tabs.len() {
+            return self.complete();
+        }
+
+        let next_tab = &state.tabs[state.tab_index];
+        OrchStep::SendPrimitive {
+            action: "p:page-markdown".to_string(),
+            params: build_page_markdown_params(next_tab, &state.options),
+        }
+    }
+
+    fn complete(&self) -> OrchStep {
+        let state = self.state.as_ref().unwrap();
+        OrchStep::Complete {
+            response: serde_json::json!({
+                "totals": { "tabs": state.tabs.len(), "tasks": state.tabs.len() },
+                "entries": state.results,
+            }),
+            undo: None,
+        }
+    }
+}
+
+fn build_page_markdown_params(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) -> Value {
+    let mut p = serde_json::json!({
+        "tabId": tab.tab_id,
+        "extract": options.extract,
+    });
+    if let Some(v) = options.max_html_chars {
+        p["maxHtmlChars"] = v.into();
+    }
+    if let Some(v) = options.max_chars {
+        p["maxChars"] = v.into();
+    }
+    if let Some(v) = options.timeout_ms {
+        p["timeoutMs"] = v.into();
+    }
+    p
+}
+
+fn build_result_entry(
+    tab: &ReadMarkdownTab,
+    options: &ReadMarkdownOptions,
+    response: Option<&Value>,
+) -> Value {
+    if let Some(response) = response {
+        serde_json::json!({
+            "tabId": tab.tab_id,
+            "windowId": tab.window_id,
+            "url": tab.url,
+            "title": tab.title,
+            "markdown": response.get("markdown").and_then(|v| v.as_str()).unwrap_or(""),
+            "chars": response.get("chars").and_then(|v| v.as_i64()).unwrap_or(0),
+            "truncated": response.get("truncated").and_then(|v| v.as_bool()).unwrap_or(false),
+            "extracted": response.get("extracted").and_then(|v| v.as_bool()).unwrap_or(true),
+            "error": Value::Null,
+        })
+    } else {
+        serde_json::json!({
+            "tabId": tab.tab_id,
+            "windowId": tab.window_id,
+            "url": tab.url,
+            "title": tab.title,
+            "markdown": "",
+            "chars": 0,
+            "truncated": false,
+            "extracted": options.extract,
+            "error": "failed to read page",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host_impl::orchestrate::Orchestration;
+
+    fn snapshot_with(tabs: Vec<Value>) -> Value {
+        serde_json::json!({
+            "windows": [{"windowId": 100, "focused": true, "tabs": tabs, "groups": []}]
+        })
+    }
+
+    #[test]
+    fn read_markdown_empty_scope() {
+        let params = serde_json::json!({"windowId": 999});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let step = orch.step(snapshot_with(vec![]));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"].as_array().unwrap().len(), 0);
+        assert_eq!(response["totals"]["tabs"], 0);
+    }
+
+    #[test]
+    fn read_markdown_single_tab() {
+        let params = serde_json::json!({"extract": true, "maxChars": 10000});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]);
+        let step = orch.step(snap);
+        let OrchStep::SendPrimitive { action, params } = &step else {
+            panic!("expected SendPrimitive, got {step:?}");
+        };
+        assert_eq!(action, "p:page-markdown");
+        assert_eq!(params["tabId"], 1);
+        assert_eq!(params["extract"], true);
+        assert_eq!(params["maxChars"], 10000);
+
+        let step = orch.step(
+            serde_json::json!({"markdown": "# Hello", "chars": 7, "truncated": false, "extracted": true}),
+        );
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entries = response["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["tabId"], 1);
+        assert_eq!(entries[0]["markdown"], "# Hello");
+        assert_eq!(entries[0]["chars"], 7);
+        assert_eq!(entries[0]["truncated"], false);
+    }
+
+    #[test]
+    fn read_markdown_multiple_tabs() {
+        let params = serde_json::json!({});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+            serde_json::json!({"tabId": 2, "windowId": 100, "url": "https://b.com", "title": "B", "groupId": -1}),
+        ]);
+        let step = orch.step(snap);
+        assert!(matches!(&step, OrchStep::SendPrimitive { action, params }
+            if action == "p:page-markdown" && params["tabId"] == 1));
+
+        let step = orch.step(
+            serde_json::json!({"markdown": "Tab1", "chars": 4, "truncated": false, "extracted": true}),
+        );
+        assert!(matches!(&step, OrchStep::SendPrimitive { action, params }
+            if action == "p:page-markdown" && params["tabId"] == 2));
+
+        let step = orch.step(
+            serde_json::json!({"markdown": "Tab2", "chars": 4, "truncated": false, "extracted": true}),
+        );
+        let OrchStep::Complete { response, undo } = step else {
+            panic!("expected Complete")
+        };
+        assert!(undo.is_none());
+        let entries = response["entries"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(response["totals"]["tasks"], 2);
+    }
+
+    #[test]
+    fn read_markdown_null_response_becomes_error_entry() {
+        let params = serde_json::json!({});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]);
+        let _ = orch.step(snap);
+        let step = orch.step(serde_json::Value::Null);
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["markdown"], "");
+        assert!(!entry["error"].is_null());
+    }
+
+    #[test]
+    fn read_markdown_skips_non_scriptable_tabs() {
+        let params = serde_json::json!({});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "chrome://settings", "title": "Settings", "groupId": -1}),
+            serde_json::json!({"tabId": 2, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]);
+        let step = orch.step(snap);
+        let OrchStep::SendPrimitive { params, .. } = &step else {
+            panic!("expected SendPrimitive")
+        };
+        assert_eq!(params["tabId"], 2);
+    }
+}

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -67,12 +67,20 @@ pub fn now_ms() -> u128 {
 
 static SANDBOX_COUNTER: AtomicU32 = AtomicU32::new(0);
 
+fn default_test_tmp_root() -> PathBuf {
+    if cfg!(windows) {
+        std::env::temp_dir().join("tctl-it")
+    } else {
+        PathBuf::from("/tmp/tctl-it")
+    }
+}
+
 /// Create an isolated sandbox directory for tests. Caller is responsible for cleanup.
 pub fn create_sandbox() -> PathBuf {
     let seq = SANDBOX_COUNTER.fetch_add(1, Ordering::Relaxed);
     let root = std::env::var("TABCTL_TEST_TMP_ROOT")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/tmp/tctl-it"));
+        .unwrap_or_else(|_| default_test_tmp_root());
     let sandbox = root.join(format!("l{}-{}-{}", now_ms(), std::process::id(), seq));
     fs::create_dir_all(&sandbox).expect("create test sandbox");
     sandbox
@@ -625,7 +633,7 @@ fn init_browser() -> SharedBrowser {
 
     let sandbox_root = std::env::var("TABCTL_TEST_TMP_ROOT")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/tmp/tctl-it"));
+        .unwrap_or_else(|_| default_test_tmp_root());
     let sandbox = sandbox_root.join(format!("s{}", now_ms()));
     fs::create_dir_all(&sandbox).expect("create test sandbox");
     // NOTE: TempDirGuard is intentionally NOT used — static values never Drop.

--- a/rust/crates/tabctl/tests/common/mod.rs
+++ b/rust/crates/tabctl/tests/common/mod.rs
@@ -70,12 +70,10 @@ static SANDBOX_COUNTER: AtomicU32 = AtomicU32::new(0);
 /// Create an isolated sandbox directory for tests. Caller is responsible for cleanup.
 pub fn create_sandbox() -> PathBuf {
     let seq = SANDBOX_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let sandbox = repo_root().join(".tabctl").join("it").join(format!(
-        "l{}-{}-{}",
-        now_ms(),
-        std::process::id(),
-        seq
-    ));
+    let root = std::env::var("TABCTL_TEST_TMP_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp/tctl-it"));
+    let sandbox = root.join(format!("l{}-{}-{}", now_ms(), std::process::id(), seq));
     fs::create_dir_all(&sandbox).expect("create test sandbox");
     sandbox
 }
@@ -625,10 +623,10 @@ fn init_browser() -> SharedBrowser {
         extension_dir.display()
     );
 
-    let sandbox = root
-        .join(".tabctl")
-        .join("it")
-        .join(format!("s{}", now_ms()));
+    let sandbox_root = std::env::var("TABCTL_TEST_TMP_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp/tctl-it"));
+    let sandbox = sandbox_root.join(format!("s{}", now_ms()));
     fs::create_dir_all(&sandbox).expect("create test sandbox");
     // NOTE: TempDirGuard is intentionally NOT used — static values never Drop.
     // The atexit handler cleans up the bootstrap process; the sandbox dir is

--- a/scripts/bundle-extension.js
+++ b/scripts/bundle-extension.js
@@ -2,18 +2,19 @@
  * Bundle the extension background script into a single file.
  *
  * Chrome service workers cannot use require() or ES module imports.
- * After tsc compiles the split TypeScript sources into CommonJS modules under
- * dist/extension/, this script bundles them into a self-contained background.js.
+ * We bundle directly from the TypeScript entrypoint so esbuild can resolve
+ * ESM-only runtime dependencies before writing dist/extension/background.js.
  */
 
 const { buildSync } = require("esbuild");
 const path = require("path");
 
-const dist = path.resolve(__dirname, "..", "dist");
+const root = path.resolve(__dirname, "..");
+const dist = path.join(root, "dist");
 
 // Extension bundle (IIFE for service worker)
 buildSync({
-  entryPoints: [path.join(dist, "extension", "background.js")],
+  entryPoints: [path.join(root, "src", "extension", "background.ts")],
   bundle: true,
   outfile: path.join(dist, "extension", "background.js"),
   allowOverwrite: true,

--- a/scripts/ci/integration-bootstrap.js
+++ b/scripts/ci/integration-bootstrap.js
@@ -12,12 +12,39 @@ function log(message) {
   process.stderr.write(`[integration-bootstrap] ${message}\n`);
 }
 
+function isNoisyChromeLine(line) {
+  return (
+    line.includes("chrome/updater/") ||
+    line.includes("EdgeUpdater") ||
+    line.includes("crash_reporter") ||
+    line.includes("crash_client") ||
+    line.includes("Crashpad") ||
+    line.includes("crashpad/") ||
+    line.includes("component_update_utils") ||
+    line.includes("registration_request.cc") ||
+    line.includes("event_history.cc") ||
+    line.includes("UPDATER_PROCESS") ||
+    line.includes("UpdaterMain") ||
+    line.includes("TensorFlow Lite XNNPACK delegate") ||
+    line.includes("Trying to load the allocator multiple times") ||
+    line.includes("Requested load of chrome://newtab/ for incorrect profile type") ||
+    line.includes("task_policy_set TASK_CATEGORY_POLICY") ||
+    line.includes("task_policy_set TASK_SUPPRESSION_POLICY") ||
+    line.includes("Device is MDM enrolled") ||
+    line.includes("No tenant ID in PSSO device cert") ||
+    line.includes("Microsoft Corp tenant not confirmed") ||
+    line.includes("IsInternalAadJoinedMac") ||
+    line.includes("Failed to write history event: logging not initialized") ||
+    line.includes("Shutdown: 0")
+  );
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function testScratchRoot() {
-  const root = process.env.TABCTL_BOOTSTRAP_TMP_ROOT || path.join(process.cwd(), ".tabctl", "it");
+  const root = process.env.TABCTL_BOOTSTRAP_TMP_ROOT || path.join("/tmp", "tctl-it");
   fs.mkdirSync(root, { recursive: true });
   return root;
 }
@@ -230,9 +257,17 @@ async function main() {
 
   chrome = launchChrome(chromePath, userDataDir);
   chrome.stdout?.resume();
+  let chromeStderrBuffer = "";
   chrome.stderr?.on("data", (chunk) => {
-    const text = chunk.toString("utf8").trim();
-    if (text) log(`chrome-stderr: ${text.slice(-300)}`);
+    chromeStderrBuffer += chunk.toString("utf8");
+    const lines = chromeStderrBuffer.split(/\r?\n/);
+    chromeStderrBuffer = lines.pop() || "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !isNoisyChromeLine(trimmed)) {
+        log(`chrome-stderr: ${trimmed}`);
+      }
+    }
   });
   chrome.on("exit", (code) => {
     if (!shuttingDown) {

--- a/scripts/ci/integration-bootstrap.js
+++ b/scripts/ci/integration-bootstrap.js
@@ -3,6 +3,7 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const os = require("node:os");
 const { spawn } = require("node:child_process");
 const { execFileSync } = require("node:child_process");
 
@@ -44,7 +45,8 @@ function sleep(ms) {
 }
 
 function testScratchRoot() {
-  const root = process.env.TABCTL_BOOTSTRAP_TMP_ROOT || path.join("/tmp", "tctl-it");
+  const root = process.env.TABCTL_BOOTSTRAP_TMP_ROOT ||
+    (process.platform === "win32" ? path.join(os.tmpdir(), "tctl-it") : path.join("/tmp", "tctl-it"));
   fs.mkdirSync(root, { recursive: true });
   return root;
 }

--- a/scripts/smoke-browser.js
+++ b/scripts/smoke-browser.js
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Launches an isolated Edge (or Chrome) instance for smoke testing.
+ *
+ * The browser uses a temp user-data-dir and loads the local extension build.
+ * tabctl setup runs first (writes native messaging manifest into the temp dir),
+ * then the browser is started so it finds the manifest on first native-messaging
+ * connection attempt.
+ *
+ * Emits one JSON line to stdout when the browser is connected and ready:
+ *   {"ok":true,"profile":"smoke-<ts>","pid":<n>,"tmpDir":"<path>","extensionDir":"<path>"}
+ *
+ * Stays alive until killed. On SIGINT/SIGTERM: removes the tabctl profile,
+ * kills the browser, and deletes the temp dir.
+ *
+ * Usage:
+ *   node scripts/smoke-browser.js [extension-dir]
+ *   TABCTL_BIN=./rust/target/debug/tabctl node scripts/smoke-browser.js dist/extension
+ *
+ * Environment variables:
+ *   TABCTL_BIN               Path to tabctl binary (default: rust/target/debug/tabctl → tabctl)
+ *   EDGE_PATH                Override browser binary path
+ *   TABCTL_EXTENSION_DIR     Alternative to argv[2] for extension dir
+ *   SMOKE_BROWSER_TIMEOUT_MS Ping timeout in ms (default: 30000)
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const { spawn, execFileSync } = require("node:child_process");
+
+function log(msg) {
+  process.stderr.write(`[smoke-browser] ${msg}\n`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function findBrowser() {
+  if (process.env.EDGE_PATH) {
+    return { bin: process.env.EDGE_PATH, name: "edge" };
+  }
+  const edgeCandidates =
+    process.platform === "darwin"
+      ? [
+          "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+          "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
+          "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
+        ]
+      : process.platform === "win32"
+        ? [
+            path.join(
+              process.env.PROGRAMFILES || "C:\\Program Files",
+              "Microsoft",
+              "Edge",
+              "Application",
+              "msedge.exe"
+            ),
+            path.join(
+              process.env["PROGRAMFILES(X86)"] || "C:\\Program Files (x86)",
+              "Microsoft",
+              "Edge",
+              "Application",
+              "msedge.exe"
+            ),
+          ]
+        : ["/usr/bin/microsoft-edge", "/usr/bin/microsoft-edge-stable"];
+
+  for (const c of edgeCandidates) {
+    if (c && fs.existsSync(c)) return { bin: c, name: "edge" };
+  }
+
+  const chromeCandidates =
+    process.platform === "darwin"
+      ? ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+      : process.platform === "win32"
+        ? [
+            path.join(
+              process.env.PROGRAMFILES || "C:\\Program Files",
+              "Google",
+              "Chrome",
+              "Application",
+              "chrome.exe"
+            ),
+          ]
+        : ["/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"];
+
+  for (const c of chromeCandidates) {
+    if (c && fs.existsSync(c)) return { bin: c, name: "chrome" };
+  }
+
+  throw new Error("Edge not found. Set EDGE_PATH to the browser binary.");
+}
+
+function findTabctl() {
+  if (process.env.TABCTL_BIN) return process.env.TABCTL_BIN;
+  const debugBin = path.join(process.cwd(), "rust", "target", "debug", "tabctl");
+  if (fs.existsSync(debugBin)) return debugBin;
+  return "tabctl";
+}
+
+let browserProc = null;
+let tmpDir = null;
+let profileName = null;
+let tabctlBin = null;
+let shuttingDown = false;
+
+async function shutdown(exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  if (browserProc && !browserProc.killed) {
+    log("Stopping browser...");
+    browserProc.kill("SIGTERM");
+    await sleep(800);
+    if (!browserProc.killed) {
+      try {
+        browserProc.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
+  }
+
+  if (profileName && tabctlBin) {
+    try {
+      execFileSync(tabctlBin, ["profile-remove", profileName], { stdio: "ignore" });
+      log(`Removed profile ${profileName}`);
+    } catch {
+      // best effort
+    }
+  }
+
+  if (tmpDir) {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      log(`Removed ${tmpDir}`);
+    } catch {
+      // best effort
+    }
+  }
+
+  process.exit(exitCode);
+}
+
+process.on("SIGINT", () => shutdown(0).catch(() => process.exit(0)));
+process.on("SIGTERM", () => shutdown(0).catch(() => process.exit(0)));
+
+async function main() {
+  const extensionDirInput =
+    process.argv[2] || process.env.TABCTL_EXTENSION_DIR || "dist/extension";
+
+  if (!fs.existsSync(path.join(extensionDirInput, "manifest.json"))) {
+    throw new Error(
+      `Extension not found at ${extensionDirInput}. Run 'npm run build' first.`
+    );
+  }
+
+  tabctlBin = findTabctl();
+  const { bin: browserBin, name: browserName } = findBrowser();
+  const ts = Date.now();
+  profileName = `smoke-${ts}`;
+
+  log(`tabctl:    ${tabctlBin}`);
+  log(`browser:   ${browserBin} (${browserName})`);
+  log(`extension: ${extensionDirInput}`);
+  log(`profile:   ${profileName}`);
+
+  // Create temp dir for isolated browser profile.
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tabctl-smoke-"));
+  const browserProfileDir = path.join(tmpDir, "browser-profile");
+  fs.mkdirSync(browserProfileDir, { recursive: true });
+
+  // Step 1: Run tabctl setup BEFORE launching the browser.
+  // This syncs the extension to the active dir, derives the extension ID from
+  // that active path, and writes the native messaging manifest into browserProfileDir.
+  // The browser will find the manifest there because it starts with --user-data-dir pointing at the same dir.
+  log("Running tabctl setup...");
+  let setupOutput;
+  try {
+    setupOutput = execFileSync(
+      tabctlBin,
+      [
+        "setup",
+        "--browser",
+        browserName,
+        "--extension-dir",
+        extensionDirInput,
+        "--user-data-dir",
+        browserProfileDir,
+        "--name",
+        profileName,
+        "--force",
+        "--json",
+        "--no-pretty",
+      ],
+      { encoding: "utf8" }
+    );
+  } catch (err) {
+    throw new Error(
+      `tabctl setup failed: ${err.stderr ? err.stderr.toString() : err.message}`
+    );
+  }
+
+  // Extract the active extension dir path from setup JSON output.
+  // tabctl setup syncs the local extension to the active dir and returns its path.
+  // We launch the browser with --load-extension pointing at the same path setup used
+  // to derive the extension ID, ensuring they match.
+  let activeExtDir;
+  try {
+    const setupJson = JSON.parse(setupOutput);
+    activeExtDir = setupJson?.data?.extensionSync?.activePath;
+  } catch {
+    // ignore parse errors; will fail below
+  }
+
+  if (!activeExtDir) {
+    throw new Error(
+      "tabctl setup did not return an active extension path (data.extensionSync.activePath)"
+    );
+  }
+  log(`Active extension: ${activeExtDir}`);
+
+  // Step 2: Launch the browser with the isolated profile and local extension.
+  const browserArgs = [
+    `--load-extension=${activeExtDir}`,
+    `--user-data-dir=${browserProfileDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-default-apps",
+    "--new-window",
+    "about:blank",
+  ];
+
+  log(`Launching browser...`);
+  browserProc = spawn(browserBin, browserArgs, {
+    stdio: ["ignore", "ignore", "pipe"],
+    detached: false,
+  });
+
+  browserProc.stderr.on("data", (chunk) => {
+    const text = chunk.toString("utf8").trim();
+    if (text) log(`browser: ${text.slice(-200)}`);
+  });
+
+  browserProc.on("exit", (code) => {
+    if (!shuttingDown) {
+      log(`Browser exited unexpectedly (code ${code})`);
+      shutdown(1).catch(() => process.exit(1));
+    }
+  });
+
+  // Step 3: Poll tabctl ping until the extension connects.
+  const timeoutMs = parseInt(process.env.SMOKE_BROWSER_TIMEOUT_MS || "30000", 10);
+  const deadline = Date.now() + timeoutMs;
+  log(`Waiting for ping (${timeoutMs}ms timeout)...`);
+
+  while (Date.now() < deadline) {
+    if (browserProc.exitCode !== null) {
+      throw new Error(`Browser exited early (code ${browserProc.exitCode})`);
+    }
+    try {
+      execFileSync(tabctlBin, ["ping", "--profile", profileName], {
+        stdio: "ignore",
+        timeout: 3000,
+      });
+      break;
+    } catch {
+      await sleep(1000);
+    }
+  }
+
+  if (Date.now() >= deadline && browserProc.exitCode === null) {
+    // One last attempt before giving up.
+    try {
+      execFileSync(tabctlBin, ["ping", "--profile", profileName], {
+        stdio: "ignore",
+        timeout: 3000,
+      });
+    } catch {
+      throw new Error(`Browser did not connect within ${timeoutMs}ms`);
+    }
+  }
+
+  // Step 4: Emit ready signal and keep alive.
+  const ready = {
+    ok: true,
+    profile: profileName,
+    pid: browserProc.pid,
+    tmpDir,
+    extensionDir: activeExtDir,
+  };
+  process.stdout.write(`${JSON.stringify(ready)}\n`);
+  log("Ready. Waiting for shutdown signal...");
+
+  await new Promise(() => {});
+}
+
+main().catch((err) => {
+  log(`FATAL: ${err instanceof Error ? err.message : String(err)}`);
+  shutdown(1).catch(() => process.exit(1));
+});

--- a/scripts/smoke-browser.js
+++ b/scripts/smoke-browser.js
@@ -35,6 +35,30 @@ function log(msg) {
   process.stderr.write(`[smoke-browser] ${msg}\n`);
 }
 
+function isNoisyBrowserLine(line) {
+  return (
+    line.includes("chrome/updater/") ||
+    line.includes("EdgeUpdater") ||
+    line.includes("crash_reporter") ||
+    line.includes("crash_client") ||
+    line.includes("Crashpad") ||
+    line.includes("crashpad/") ||
+    line.includes("component_update_utils") ||
+    line.includes("registration_request.cc") ||
+    line.includes("IsInternalAadJoinedMac") ||
+    line.includes("UPDATER_PROCESS") ||
+    line.includes("TensorFlow Lite XNNPACK delegate") ||
+    line.includes("Trying to load the allocator multiple times") ||
+    line.includes("Requested load of chrome://newtab/ for incorrect profile type") ||
+    line.includes("task_policy_set TASK_CATEGORY_POLICY") ||
+    line.includes("task_policy_set TASK_SUPPRESSION_POLICY") ||
+    line.includes("Device is MDM enrolled") ||
+    line.includes("No tenant ID in PSSO device cert") ||
+    line.includes("Microsoft Corp tenant not confirmed") ||
+    line.includes("returned 0")
+  );
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -241,9 +265,17 @@ async function main() {
     detached: false,
   });
 
+  let browserStderrBuffer = "";
   browserProc.stderr.on("data", (chunk) => {
-    const text = chunk.toString("utf8").trim();
-    if (text) log(`browser: ${text.slice(-200)}`);
+    browserStderrBuffer += chunk.toString("utf8");
+    const lines = browserStderrBuffer.split(/\r?\n/);
+    browserStderrBuffer = lines.pop() || "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !isNoisyBrowserLine(trimmed)) {
+        log(`browser: ${trimmed}`);
+      }
+    }
   });
 
   browserProc.on("exit", (code) => {

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawn } = require("node:child_process");
+const path = require("node:path");
+
+const tabctl = process.env.TABCTL_BIN || "./rust/target/debug/tabctl";
+const shortTmpRoot = process.env.TABCTL_TEST_TMP_ROOT || path.join("/tmp", "tctl-it");
+let smokeBrowser = null;
+let smokeProfile = null;
+let readTab = null;
+let testWindow = null;
+let testGroup = null;
+
+function log(message) {
+  const ts = new Date().toISOString();
+  process.stdout.write(`[smoke-test ${ts}] ${message}\n`);
+}
+
+function run(command, args, options = {}) {
+  const capture = options.capture === true;
+  const label = [command, ...args].join(" ");
+  log(`$ ${label}`);
+  return new Promise((resolve, reject) => {
+    const stdoutChunks = [];
+    let stderr = "";
+    const started = Date.now();
+    const heartbeat = setInterval(() => {
+      const seconds = Math.round((Date.now() - started) / 1000);
+      log(`Still running after ${seconds}s: ${label}`);
+    }, 15_000);
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        TABCTL_TEST_TMP_ROOT: shortTmpRoot,
+        TABCTL_BOOTSTRAP_TMP_ROOT: process.env.TABCTL_BOOTSTRAP_TMP_ROOT || shortTmpRoot,
+      },
+    });
+    let settled = false;
+
+    function finish(code, signal) {
+      if (settled) return;
+      settled = true;
+      clearInterval(heartbeat);
+      if (code === 0) {
+        const seconds = Math.round((Date.now() - started) / 1000);
+        log(`Completed in ${seconds}s: ${label}`);
+        resolve(stdoutChunks.join(""));
+      } else {
+        reject(
+          new Error(
+            `${command} exited with ${signal || code}${stderr ? `\n${stderr}` : ""}`
+          )
+        );
+      }
+    }
+
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString("utf8");
+      if (capture) stdoutChunks.push(text);
+      if (!capture) process.stdout.write(text);
+    });
+    child.stderr.on("data", (chunk) => {
+      const text = chunk.toString("utf8");
+      stderr += text;
+      process.stderr.write(text);
+    });
+
+    child.on("error", (err) => {
+      clearInterval(heartbeat);
+      reject(err);
+    });
+    child.on("exit", finish);
+    child.on("close", finish);
+  });
+}
+
+async function runJson(command, args) {
+  const output = await run(command, args, { capture: true });
+  const parsed = JSON.parse(output);
+  if (parsed.errors && parsed.errors.length > 0) {
+    throw new Error(JSON.stringify(parsed.errors, null, 2));
+  }
+  return parsed;
+}
+
+async function query(source) {
+  return runJson(tabctl, ["query", "--profile", smokeProfile, source]);
+}
+
+async function startSmokeBrowser() {
+  log("Starting isolated smoke browser");
+  smokeBrowser = spawn(process.execPath, ["scripts/smoke-browser.js"], {
+    stdio: ["ignore", "pipe", "inherit"],
+    env: process.env,
+  });
+
+  let stdout = "";
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("smoke browser did not report ready within 45s"));
+    }, 45_000);
+
+    smokeBrowser.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+      const lines = stdout.split(/\r?\n/);
+      stdout = lines.pop() || "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        process.stdout.write(`${line}\n`);
+        try {
+          const ready = JSON.parse(line);
+          if (ready.ok && ready.profile) {
+            clearTimeout(timeout);
+            smokeProfile = ready.profile;
+            log(`Smoke browser ready: profile=${ready.profile} pid=${ready.pid}`);
+            resolve(ready);
+          }
+        } catch {
+          // Non-JSON stdout is still useful progress output.
+        }
+      }
+    });
+
+    smokeBrowser.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    smokeBrowser.on("exit", (code, signal) => {
+      if (!smokeProfile) {
+        clearTimeout(timeout);
+        reject(new Error(`smoke browser exited before ready (${signal || code})`));
+      }
+    });
+  });
+}
+
+function expect(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function cleanupSmokeTabs() {
+  if (!smokeProfile) return;
+
+  if (readTab) {
+    log(`Cleaning up readTabs tab ${readTab}`);
+    try {
+      await query(`mutation { closeTabs(tabIds: [${readTab}], confirm: true) { txid closedTabs } }`);
+    } catch (err) {
+      log(`Cleanup warning for readTabs tab: ${err.message}`);
+    }
+  }
+
+  if (testGroup) {
+    log(`Cleaning up smoke group ${testGroup}`);
+    try {
+      const tabs = await query("query { tabs(limit: 200) { items { tabId groupTitle } } }");
+      const ids = tabs.data.tabs.items
+        .filter((tab) => tab.groupTitle === testGroup)
+        .map((tab) => tab.tabId);
+      if (ids.length > 0) {
+        await query(`mutation { closeTabs(tabIds: [${ids.join(",")}], confirm: true) { txid closedTabs } }`);
+      }
+    } catch (err) {
+      log(`Cleanup warning for smoke group: ${err.message}`);
+    }
+  }
+}
+
+async function stopSmokeBrowser() {
+  if (!smokeBrowser || smokeBrowser.exitCode !== null) return;
+  log("Stopping isolated smoke browser");
+  smokeBrowser.kill("SIGTERM");
+  await new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      if (smokeBrowser.exitCode === null) smokeBrowser.kill("SIGKILL");
+      resolve();
+    }, 3_000);
+    smokeBrowser.on("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+async function main() {
+  log("Step 1/8: build");
+  await run("npm", ["run", "build"]);
+
+  log("Step 2/8: Rust verify");
+  await run("npm", ["run", "rust:verify"]);
+
+  log("Step 3/8: integration tests");
+  await run("npm", ["run", "test:integration"]);
+
+  log("Step 4/8: start isolated browser");
+  await startSmokeBrowser();
+
+  log("Step 5/8: connectivity and read-only GraphQL checks");
+  await run(tabctl, ["ping", "--profile", smokeProfile]);
+  const ping = await query("query { ping { ok latencyMs } }");
+  expect(ping.data.ping.ok === true, "GraphQL ping did not return ok=true");
+  const tabs = await query("query { tabs(limit: 20) { total items { tabId windowId url title groupId groupTitle active } } }");
+  expect(tabs.data.tabs.total >= 0, "tabs query returned an invalid total");
+  const analyze = await query("query { analyze(staleDays: 30) { totalTabs staleTabs duplicateTabs } }");
+  expect(analyze.data.analyze.totalTabs >= 0, "analyze query returned an invalid total");
+  const report = await query("query { reportTabs { totals { tabs } entries { tabId windowId url title description } } }");
+  expect(report.data.reportTabs.totals.tabs >= 0, "reportTabs returned an invalid total");
+
+  log("Step 6/8: readTabs markdown extraction");
+  const readOpen = await query('mutation { openTabs(urls: ["https://example.com"], newWindow: true) { windowId tabs { tabId url title } } }');
+  readTab = readOpen.data.openTabs.tabs[0].tabId;
+  log(`Opened readTabs page: tab=${readTab}`);
+  await new Promise((resolve) => setTimeout(resolve, 2_000));
+  const read = await query(`query { readTabs(tabIds: [${readTab}], extract: true, maxChars: 50000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId url title chars truncated extracted markdown } } }`);
+  const readEntry = read.data.readTabs.entries[0];
+  expect(read.data.readTabs.totals.tabs === 1, "readTabs did not return exactly one tab");
+  expect(readEntry.chars > 0, "readTabs returned empty content");
+  expect(readEntry.markdown.length > 0, "readTabs returned empty markdown");
+  log(`readTabs extracted ${readEntry.chars} chars from ${readEntry.url}`);
+
+  log("Step 7/8: mutation, undo, screenshot, and inspect checks");
+  testGroup = `TEST-Smoke-${Date.now()}`;
+  const opened = await query(`mutation { openTabs(urls: ["https://example.com", "https://example.org", "https://example.net"], newWindow: true, group: "${testGroup}") { windowId groupId tabs { tabId windowId url title groupId groupTitle } } }`);
+  testWindow = opened.data.openTabs.windowId;
+  const firstTab = opened.data.openTabs.tabs[0].tabId;
+  log(`Opened smoke window: window=${testWindow} group=${testGroup} firstTab=${firstTab}`);
+  const windowCheck = await query(`query { window(id: ${testWindow}) { windowId tabs { tabId url groupTitle index } groups { groupId title color collapsed tabCount } } }`);
+  expect(windowCheck.data.window.windowId === testWindow, "smoke window was not found after openTabs");
+
+  const closed = await query(`mutation { closeTabs(tabIds: [${firstTab}], confirm: true) { txid closedTabs } }`);
+  expect(closed.data.closeTabs.closedTabs === 1, "closeTabs did not close exactly one tab");
+  const closeTxid = closed.data.closeTabs.txid;
+  log(`Closed one tab: txid=${closeTxid}`);
+  await query(`mutation { undoAction(txid: "${closeTxid}") { txid summary } }`);
+  log("Undo close succeeded");
+
+  const archived = await query(`mutation { archiveTabs(windowId: ${testWindow}) { txid archivedTabs } }`);
+  expect(archived.data.archiveTabs.archivedTabs > 0, "archiveTabs did not archive any tabs");
+  const archiveTxid = archived.data.archiveTabs.txid;
+  log(`Archived smoke window: txid=${archiveTxid}`);
+  await query(`mutation { undoAction(txid: "${archiveTxid}") { txid summary } }`);
+  log("Undo archive succeeded");
+
+  const restored = await query("query { tabs(limit: 200) { items { tabId windowId groupTitle } } }");
+  const restoredTabs = restored.data.tabs.items.filter((tab) => tab.groupTitle === testGroup);
+  expect(restoredTabs.length > 0, "undo archive did not restore any grouped smoke tabs");
+  testWindow = restoredTabs[0].windowId;
+  const restoredFirstTab = restoredTabs[0].tabId;
+  const screenshots = await query(`query { captureScreenshots(tabIds: [${restoredFirstTab}], mode: "viewport") { totals { tabs tiles } entries { tabId tiles { index width height } error { message } } } }`);
+  expect(screenshots.data.captureScreenshots.totals.tabs === 1, "captureScreenshots did not return one tab");
+  const inspected = await query(`query { inspectTabs(tabIds: [${restoredFirstTab}], signals: ["page-meta"], waitFor: "dom") { totals { tabs signals tasks } entries { tabId signals { name valueJson } } } }`);
+  expect(inspected.data.inspectTabs.totals.tabs === 1, "inspectTabs did not return one tab");
+
+  log("Step 8/8: cleanup");
+  await cleanupSmokeTabs();
+  readTab = null;
+  testWindow = null;
+  testGroup = null;
+  log("Smoke test completed successfully");
+}
+
+main()
+  .catch(async (err) => {
+    log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await cleanupSmokeTabs();
+    await stopSmokeBrowser();
+  });

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -3,9 +3,12 @@
 
 const { spawn } = require("node:child_process");
 const path = require("node:path");
+const os = require("node:os");
 
 const tabctl = process.env.TABCTL_BIN || "./rust/target/debug/tabctl";
-const shortTmpRoot = process.env.TABCTL_TEST_TMP_ROOT || path.join("/tmp", "tctl-it");
+const defaultTmpRoot =
+  process.platform === "win32" ? path.join(os.tmpdir(), "tctl-it") : path.join("/tmp", "tctl-it");
+const shortTmpRoot = process.env.TABCTL_TEST_TMP_ROOT || defaultTmpRoot;
 let smokeBrowser = null;
 let smokeProfile = null;
 let readTab = null;

--- a/skills/tabctl/SKILL.md
+++ b/skills/tabctl/SKILL.md
@@ -40,12 +40,27 @@ tabctl help query
 # Inspect page metadata
  tabctl query 'query { inspectTabs(tabIds: [456], signals: ["page-meta"]) { entries { tabId signals { name valueJson } } } }'
 
+# Inspect selectors with typed attrs and filters
+ tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true, text: "$", textMode: "contains" }, { name: "submit_visible", selector: "#submit", attr: "visible" }, { name: "submit_style", selector: "#submit", attr: "styles", styleProps: ["color", "background-color"] }, { name: "item_count", selector: ".item", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }, { name: "tos_checked", selector: "input[name=terms]", attr: "checked" }]) { entries { tabId url signals { name valueJson } } } }'
+
+# Read page content as Markdown
+ tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted error } } }'
+
 # Build reports
  tabctl query '{ reportTabs(windowId: 123) { entries { tabId title url description } } }'
 
 # Capture screenshots
  tabctl query 'query { captureScreenshots(tabIds: [456], mode: "viewport") { entries { tabId tiles { index width height } } } }'
 ```
+
+## Read-only extraction notes
+
+- `readTabs` converts main-frame HTML to Markdown. `extract: true` is a heuristic, best-effort readability pass; check `extracted` and `error` per tab.
+- `readTabs` v1 does not traverse cross-origin iframes or shadow DOM, and skips non-scriptable URLs automatically.
+- `inspectTabs` selector attrs now include `html`, `value`, `count`, `box`, `styles`, `visible`, `enabled`, and `checked`.
+- `visible` means rendered and not `display:none`, `visibility:hidden`, or `opacity:0`.
+- `enabled` means the element is not disabled and `aria-disabled != "true"`.
+- `checked` uses `input.checked` for form controls, otherwise `aria-checked == "true"`.
 
 ## Mutation examples
 

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -1,3 +1,5 @@
+import { convert } from "markdown-for-agents";
+
 const HOST_NAME = "com.erwinkroon.tabctl";
 const manifest = chrome.runtime.getManifest();
 const MANIFEST_VERSION = manifest.version || "0.0.0";
@@ -578,6 +580,31 @@ async function handleAction(action: string, params: Record<string, unknown>, req
         { mode, format: fmt, quality, tileMaxDim, maxBytes },
         { delay, executeWithTimeout },
       );
+    }
+
+    case "p:page-markdown": {
+      const targetTabId = requireFiniteId(params.tabId, "tabId");
+      const extract = params.extract !== false;
+      const maxHtmlChars = typeof params.maxHtmlChars === "number"
+        ? Math.max(1, Math.min(params.maxHtmlChars, 1_000_000))
+        : 500_000;
+      const maxChars = typeof params.maxChars === "number"
+        ? Math.max(1, Math.min(params.maxChars, 200_000))
+        : 50_000;
+      const timeoutMs = typeof params.timeoutMs === "number"
+        ? Math.max(1, params.timeoutMs)
+        : 15_000;
+
+      const html = await content.extractPageMarkdown(targetTabId, timeoutMs, maxHtmlChars);
+      if (!html) {
+        return { markdown: "", chars: 0, truncated: false, extracted: extract };
+      }
+
+      const fullMarkdown = convert(html, { extract }).markdown;
+      const truncated = fullMarkdown.length > maxChars;
+      const markdown = truncated ? fullMarkdown.slice(0, maxChars) : fullMarkdown;
+
+      return { markdown, chars: markdown.length, truncated, extracted: extract };
     }
 
     default:

--- a/src/extension/lib/content.ts
+++ b/src/extension/lib/content.ts
@@ -71,6 +71,15 @@ export async function extractPageMeta(tabId: number, timeoutMs: number, descript
   };
 }
 
+export async function extractPageMarkdown(tabId: number, timeoutMs: number, maxHtmlChars: number) {
+  const result = await executeWithTimeout(tabId, timeoutMs, (cap: number) => {
+    const raw = document.documentElement?.outerHTML || "";
+    return raw.length > cap ? raw.slice(0, cap) : raw;
+  }, [maxHtmlChars]);
+
+  return typeof result === "string" ? result : "";
+}
+
 export async function extractSelectorSignal(tabId: number, specs: Array<Record<string, unknown>>, timeoutMs: number, selectorValueMaxLength: number) {
   if (!specs.length) {
     return null;
@@ -81,6 +90,9 @@ export async function extractSelectorSignal(tabId: number, specs: Array<Record<s
     const missing: string[] = [];
     const errors: Record<string, string> = {};
     const hints: Record<string, string> = {};
+    const stringCap = typeof maxLen === "number" && maxLen > 0 ? maxLen : 500;
+    const htmlCap = typeof maxLen === "number" && maxLen > 0 ? maxLen : 4096;
+    const normalizeStringValue = (value: string, cap: number) => value.replace(/\s+/g, " ").trim().slice(0, cap);
 
     for (const raw of rawSpecs) {
       const selector = typeof raw.selector === "string" ? raw.selector : "";
@@ -94,6 +106,9 @@ export async function extractSelectorSignal(tabId: number, specs: Array<Record<s
       const textMode = typeof raw.textMode === "string" ? raw.textMode.trim().toLowerCase() : "";
       const normalizedTextMode = textMode === "includes" ? "contains" : textMode;
       const textModes = new Set(["", "contains", "exact", "starts-with"]);
+      const styleProps = Array.isArray(raw.styleProps)
+        ? raw.styleProps.filter((prop): prop is string => typeof prop === "string").map((prop) => prop.trim()).filter(Boolean)
+        : [];
       if (!textModes.has(normalizedTextMode)) {
         errors[name] = `Unsupported textMode: ${textMode || "unknown"}`;
         hints[name] = "Use textMode: contains | exact | starts-with";
@@ -102,16 +117,6 @@ export async function extractSelectorSignal(tabId: number, specs: Array<Record<s
 
       try {
         const elements = Array.from(document.querySelectorAll(selector));
-        if (!elements.length) {
-          missing.push(name);
-          if (selector.includes(":contains(")) {
-            hints[name] = "CSS :contains() is not supported; use selector text filters or a different selector.";
-          } else {
-            hints[name] = "No matches found; capture a screenshot for context or adjust the selector.";
-          }
-          continue;
-        }
-
         const matchesText = (el: Element) => {
           if (!text) {
             return true;
@@ -127,40 +132,106 @@ export async function extractSelectorSignal(tabId: number, specs: Array<Record<s
         };
 
         const filtered = text ? elements.filter(matchesText) : elements;
+        if (attr === "count") {
+          values[name] = filtered.length;
+          continue;
+        }
+
+        if (!elements.length) {
+          missing.push(name);
+          if (selector.includes(":contains(")) {
+            hints[name] = "CSS :contains() is not supported; use selector text filters or a different selector.";
+          } else {
+            hints[name] = "No matches found; capture a screenshot for context or adjust the selector.";
+          }
+          continue;
+        }
+
         if (!filtered.length) {
           missing.push(name);
           hints[name] = "Selector matched elements, but none matched the text filter; capture a screenshot for context or adjust text/textMode.";
           continue;
         }
 
-        const getValue = (el: Element) => {
-          let value = "";
+        const getValue = (el: Element): string | number | boolean | Record<string, unknown> | null => {
           if (attr === "text") {
-            value = el.textContent || "";
-          } else if (attr === "href-url" || attr === "src-url") {
+            return normalizeStringValue(el.textContent || "", stringCap);
+          }
+          if (attr === "html") {
+            return normalizeStringValue(el.outerHTML || "", htmlCap);
+          }
+          if (attr === "href-url" || attr === "src-url") {
             const rawValue = el.getAttribute(attr === "href-url" ? "href" : "src") || "";
             if (!rawValue) {
-              value = "";
-            } else {
-              try {
-                const resolved = new URL(rawValue, document.baseURI);
-                if (resolved.protocol === "http:" || resolved.protocol === "https:") {
-                  value = resolved.toString();
-                } else {
-                  value = "";
-                }
-              } catch {
-                value = "";
-              }
+              return "";
             }
-          } else {
-            value = el.getAttribute(attr) || "";
+            try {
+              const resolved = new URL(rawValue, document.baseURI);
+              if (resolved.protocol === "http:" || resolved.protocol === "https:") {
+                return normalizeStringValue(resolved.toString(), stringCap);
+              }
+              return "";
+            } catch {
+              return "";
+            }
           }
-          return value.replace(/\s+/g, " ").trim().slice(0, maxLen);
+          if (attr === "value") {
+            if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el instanceof HTMLSelectElement) {
+              return el.value;
+            }
+            return null;
+          }
+          if (attr === "box") {
+            const rect = el.getBoundingClientRect();
+            return {
+              x: rect.x,
+              y: rect.y,
+              width: rect.width,
+              height: rect.height,
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+              left: rect.left,
+            };
+          }
+          if (attr === "styles") {
+            if (!styleProps.length) {
+              return {};
+            }
+            const computed = window.getComputedStyle(el);
+            const selected: Record<string, unknown> = {};
+            for (const prop of styleProps) {
+              selected[prop] = computed.getPropertyValue(prop);
+            }
+            return selected;
+          }
+          if (attr === "visible") {
+            const computed = window.getComputedStyle(el);
+            const rect = el.getBoundingClientRect();
+            const styleVisible = computed.display !== "none" && computed.visibility !== "hidden" && computed.opacity !== "0";
+            const hasRenderedBox = rect.width > 0 || rect.height > 0;
+            return styleVisible && hasRenderedBox;
+          }
+          if (attr === "enabled") {
+            const candidate = el as Element & { disabled?: boolean };
+            return candidate.disabled !== true && el.getAttribute("aria-disabled") !== "true";
+          }
+          if (attr === "checked") {
+            if (el instanceof HTMLInputElement) {
+              return el.checked;
+            }
+            return el.getAttribute("aria-checked") === "true";
+          }
+          return normalizeStringValue(el.getAttribute(attr) || "", stringCap);
         };
 
+        if (attr === "box") {
+          values[name] = getValue(filtered[0]);
+          continue;
+        }
+
         if (all) {
-          values[name] = filtered.map(getValue).filter((val) => val.length > 0);
+          values[name] = filtered.map(getValue).filter((val) => typeof val !== "string" || val.length > 0);
         } else {
           values[name] = getValue(filtered[0]);
         }


### PR DESCRIPTION
## Summary
- add the readTabs GraphQL query and markdown extraction path
- extend inspectTabs selector kinds for richer read targeting
- add/update smoke-test and agent docs for the GraphQL-first workflow

## Testing
- pre-push hook ran and skipped heavy checks because it detected no Rust/build/hook-triggering changes