### PR TITLE
fix(release): checkout tag before creating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,10 @@ jobs:
     if: ${{ always() && needs.validate.result == 'success' && needs.build.result == 'success' && needs.extension.result == 'success' && (needs.npm_publish.result == 'success' || needs.npm_publish.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -681,7 +681,17 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "optional": true
+      "version": "0.6.0-rc.6",
+      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.6.tgz",
+      "integrity": "sha512-csiQUkxgyoh+sigffxIMNMJVybGFIQNwU7AiGndIPErG5hjzUrMVvgSAfTPWBNtdwzTcHWjIiGYybUqTnuFkKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/typescript": {
       "version": "5.9.3",


### PR DESCRIPTION
## Summary\n- check out the release tag in the create-release job before invoking `gh release create --generate-notes`\n- fixes the final release step failing with `failed to run git: fatal: not a git repository`\n\n## Validation\n- pre-push hook passed: rust:verify, build, integration\n- parsed .github/workflows/release.yml as YAML\n- git diff --check