### PR TITLE
feat(read-tabs): convert page HTML to markdown in host

### DIFF
--- a/.github/skills/smoke-test/SKILL.md
+++ b/.github/skills/smoke-test/SKILL.md
@@ -168,18 +168,22 @@ query {
       chars
       truncated
       extracted
+      status
+      emptyReason
+      error
       markdown
     }
   }
 }")
 
 echo "$NOS_READ" | jq -r '.data.readTabs.entries[0] |
-  "url: \(.url)\ntitle: \(.title)\nchars: \(.chars)\ntruncated: \(.truncated)\nextracted: \(.extracted)\n\n--- MARKDOWN PREVIEW ---\n\(.markdown[:1200])"'
+  "url: \(.url)\ntitle: \(.title)\nstatus: \(.status)\nemptyReason: \(.emptyReason)\nerror: \(.error)\nchars: \(.chars)\ntruncated: \(.truncated)\nextracted: \(.extracted)\n\n--- MARKDOWN PREVIEW ---\n\(.markdown[:1200])"'
 ```
 
 Success criteria:
 
 - `readTabs.totals.tabs` is `1`.
+- `entries[0].status` is `READ`.
 - `entries[0].chars` is greater than `0`.
 - `entries[0].markdown` contains readable Markdown, not raw empty HTML.
 - `entries[0].truncated` is acceptable only if `maxChars` was intentionally low.

--- a/CLI.md
+++ b/CLI.md
@@ -71,7 +71,7 @@ Use `tabctl schema` when you need field discovery, then use `tabctl query` for b
  tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true }, { name: "checkout_visible", selector: "#checkout", attr: "visible" }, { name: "checkout_style", selector: "#checkout", attr: "styles", styleProps: ["color", "background-color"] }, { name: "item_count", selector: ".line-item", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }]) { totals { tabs tasks } entries { tabId url signals { name valueJson } } } }'
 
 # Read page content as Markdown
- tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 50000) { totals { tabs tasks } entries { tabId title url markdown chars truncated extracted error } } }'
+ tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 50000) { totals { tabs tasks } entries { tabId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
 
 # Generate a report with descriptions
  tabctl query '{ reportTabs(windowId: 123) { totals { tabs } entries { tabId title url description } } }'
@@ -123,20 +123,21 @@ tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", s
 
 Arguments:
 - scope via one of `windowId`, `groupId`, `groupTitle`, `tabIds`, or `ungrouped`
-- `extract` — best-effort content extraction before Markdown conversion; defaults to `true`
+- `extract` — enables Kreuzberg standard preprocessing before Markdown conversion; defaults to `true`
 - `maxChars` — maximum Markdown characters per tab; defaults to `50000`, max `200000`
-- `maxHtmlChars` — maximum raw HTML characters read per tab; defaults to `500000`, max `1000000`
+- `maxHtmlChars` — maximum raw HTML characters read per tab; defaults to `500000`, max `650000`
 - `timeoutMs` — per-tab timeout in milliseconds; defaults to `15000`
 
 Caveats:
-- Extraction is heuristic; check `extracted` in the response to see whether it was applied.
+- Markdown conversion uses the Kreuzberg `html-to-markdown` converter in the native host.
+- Check `status`, `emptyReason`, `diagnostics`, and `error` per tab; empty Markdown is not reported as a clean success.
 - v1 reads the main frame only; cross-origin iframes and shadow DOM are not traversed.
-- Non-scriptable URLs such as `chrome://` and `about:` are skipped automatically.
+- Non-scriptable URLs such as `chrome://` and `about:` are returned with `status: UNSUPPORTED_URL`.
 
 Example:
 
 ```bash
-tabctl query 'query { readTabs(groupTitle: "Research", extract: true, maxChars: 30000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId windowId title url markdown chars truncated extracted error } } }'
+tabctl query 'query { readTabs(groupTitle: "Research", extract: true, maxChars: 30000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId windowId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
 ```
 
 ### Mutation examples

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ tabctl schema
 
 Read-only browser features include:
 - `inspectTabs` for page metadata and selector-based reads
-- `readTabs` for page HTML → Markdown conversion with best-effort extraction
+- `readTabs` for page HTML → Markdown conversion with Kreuzberg preprocessing and per-tab diagnostics
 - `reportTabs`, `captureScreenshots`, and browser-state history queries for summaries and context
 
 See [CLI.md](CLI.md) for the full command reference, options, and examples.
@@ -169,8 +169,8 @@ tabctl query 'query { inspectTabs(tabIds: [456], signals: ["page-meta"]) { entri
 # Inspect selectors with typed attrs and filters
 tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true }, { name: "buy_now_visible", selector: "button.buy-now", attr: "visible" }, { name: "buy_now_style", selector: "button.buy-now", attr: "styles", styleProps: ["color", "background-color"] }, { name: "review_count", selector: ".review", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }]) { entries { tabId url signals { name valueJson } } } }'
 
-# Read tab content as Markdown (best-effort extraction by default)
-tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted error } } }'
+# Read tab content as Markdown (Kreuzberg preprocessing by default)
+tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
 
 # Generate reports
 tabctl query '{ reportTabs(windowId: 123) { entries { tabId title url description } } }'
@@ -427,7 +427,7 @@ Notes:
 - Browser reads and mutations now go through GraphQL via `tabctl query`.
 - Reports include short descriptions from page metadata and a fallback snippet.
 - `inspectTabs` supports `page-meta` plus selector reads with `all`, `text`, `textMode`, `styleProps`, and attrs such as `html`, `value`, `count`, `box`, `styles`, `visible`, `enabled`, and `checked`.
-- `readTabs` converts main-frame page HTML to Markdown, with best-effort content extraction enabled by default and status surfaced through `extracted`/`error` fields.
+- `readTabs` converts main-frame page HTML to Markdown with Kreuzberg `html-to-markdown`; per-tab `status`, `emptyReason`, `diagnostics`, and `error` distinguish empty pages, unsupported URLs, injection failures, conversion failures, and timeouts.
 - `captureScreenshots` returns tile metadata and image data from GraphQL.
 - `undoAction` accepts either an explicit `txid` or `latest: true`.
 - `tabctl history --json` returns a top-level JSON array.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.6.0-rc.6",
       "license": "MIT",
       "dependencies": {
-        "markdown-for-agents": "^1.3.4",
         "normalize-url": "^8.1.1"
       },
       "bin": {
@@ -515,85 +514,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -634,38 +554,6 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
-      }
-    },
-    "node_modules/htmlparser2": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
-      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "entities": "^7.0.1"
-      }
-    },
-    "node_modules/markdown-for-agents": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/markdown-for-agents/-/markdown-for-agents-1.3.4.tgz",
-      "integrity": "sha512-kyXaAd/A+6SrZdaEbzeKL1wyJck5lckIXeTa1w04SCqxpzV0vxAQDT7FlJfXsYdm426L/TB39p7HKMpM4uFVsA==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "^5.0.3",
-        "htmlparser2": "^10.1.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/normalize-url": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "tabctl-win32-x64": "0.6.0-rc.6"
   },
   "dependencies": {
-    "markdown-for-agents": "^1.3.4",
     "normalize-url": "^8.1.1"
   }
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +96,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tl"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90933ffb0f97e2fc2e0de21da9d3f20597b804012d199843a6fe7c2810d28f3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +132,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -183,6 +226,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +268,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -305,6 +374,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +406,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -439,7 +520,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -447,6 +528,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -455,6 +541,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
+name = "html-to-markdown-rs"
+version = "3.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbbfb183e8634cb956309c6bbd781d9ddae068d376fb9eb1451ac49cf4cbba7"
+dependencies = [
+ "ahash",
+ "astral-tl",
+ "base64",
+ "html-escape",
+ "html5ever",
+ "lru",
+ "memchr",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -648,10 +773,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
 
 [[package]]
 name = "memchr"
@@ -670,6 +824,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,10 +848,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -709,6 +937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +979,35 @@ dependencies = [
  "libredox",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rusqlite"
@@ -750,6 +1022,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -818,6 +1096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +1135,30 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -910,6 +1218,7 @@ name = "tabctl-host"
 version = "0.6.0-rc.6"
 dependencies = [
  "getrandom",
+ "html-to-markdown-rs",
  "rusqlite",
  "serde",
  "serde_json",
@@ -927,6 +1236,16 @@ dependencies = [
  "serde_json",
  "sha2",
  "url-normalize",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -967,6 +1286,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1013,6 +1341,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1387,18 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
 
 [[package]]
 name = "windows-link"
@@ -1239,6 +1591,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/crates/graphql/src/schema.rs
+++ b/rust/crates/graphql/src/schema.rs
@@ -455,7 +455,9 @@ impl Query {
         #[graphql(description = "Restrict to these specific tab IDs.")] tab_ids: Option<Vec<i32>>,
         #[graphql(description = "Enable content extraction (strip nav/ads). Default: true.")]
         extract: Option<bool>,
-        #[graphql(description = "Maximum raw HTML characters to read per tab. Default: 500000.")]
+        #[graphql(
+            description = "Maximum raw HTML characters to read per tab. Default: 500000, max: 650000."
+        )]
         max_html_chars: Option<i32>,
         #[graphql(description = "Maximum Markdown characters per tab. Default: 50000.")]
         max_chars: Option<i32>,
@@ -912,6 +914,12 @@ fn parse_read_result(response: &serde_json::Value) -> ReadTabResult {
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false),
                         extracted: e.get("extracted").and_then(|v| v.as_bool()).unwrap_or(true),
+                        status: parse_read_status(e.get("status").and_then(|v| v.as_str())),
+                        empty_reason: e
+                            .get("emptyReason")
+                            .and_then(|v| v.as_str())
+                            .map(String::from),
+                        diagnostics: parse_read_diagnostics(e.get("diagnostics")),
                         error: e.get("error").and_then(|v| v.as_str()).map(String::from),
                     })
                 })
@@ -920,6 +928,40 @@ fn parse_read_result(response: &serde_json::Value) -> ReadTabResult {
         .unwrap_or_default();
 
     ReadTabResult { totals, entries }
+}
+
+fn parse_read_status(value: Option<&str>) -> ReadTabStatus {
+    match value {
+        Some("EMPTY") => ReadTabStatus::Empty,
+        Some("UNSUPPORTED_URL") => ReadTabStatus::UnsupportedUrl,
+        Some("PROTECTED") => ReadTabStatus::Protected,
+        Some("NOT_LOADED") => ReadTabStatus::NotLoaded,
+        Some("INJECTION_FAILED") => ReadTabStatus::InjectionFailed,
+        Some("EXTRACTION_FAILED") => ReadTabStatus::ExtractionFailed,
+        Some("TIMED_OUT") => ReadTabStatus::TimedOut,
+        _ => ReadTabStatus::Read,
+    }
+}
+
+fn parse_read_diagnostics(value: Option<&serde_json::Value>) -> ReadTabDiagnostics {
+    let get_i32 = |name: &str| {
+        value
+            .and_then(|v| v.get(name))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32
+    };
+    ReadTabDiagnostics {
+        source_html_chars: get_i32("sourceHtmlChars"),
+        source_text_chars: get_i32("sourceTextChars"),
+        document_ready_state: value
+            .and_then(|v| v.get("documentReadyState"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        truncated_html: value
+            .and_then(|v| v.get("truncatedHtml"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    }
 }
 
 fn parse_report_result(response: &serde_json::Value) -> ReportResult {
@@ -2317,7 +2359,7 @@ mod tests {
     #[test]
     fn query_read_tabs_basic() {
         let result = exec(
-            r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId markdown chars truncated extracted error } } }"#,
+            r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }"#,
         );
         assert!(
             result.get("errors").is_none(),
@@ -2330,6 +2372,7 @@ mod tests {
         assert_eq!(entries[0]["tabId"], 1);
         assert_eq!(entries[0]["markdown"], "# Hello\n\nWorld.");
         assert_eq!(entries[0]["chars"], 16);
+        assert_eq!(entries[0]["status"], "READ");
         assert!(entries[0]["error"].is_null());
     }
 

--- a/rust/crates/graphql/src/types.rs
+++ b/rust/crates/graphql/src/types.rs
@@ -1,4 +1,4 @@
-use juniper::{GraphQLInputObject, GraphQLObject};
+use juniper::{GraphQLEnum, GraphQLInputObject, GraphQLObject};
 
 /// A browser tab.
 #[derive(Debug, Clone, GraphQLObject)]
@@ -419,6 +419,40 @@ pub(crate) struct ScreenshotResult {
     pub entries: Vec<ScreenshotEntry>,
 }
 
+/// Status for a tab Markdown read attempt.
+#[derive(Debug, Clone, Copy, GraphQLEnum)]
+pub(crate) enum ReadTabStatus {
+    /// Markdown was produced.
+    Read,
+    /// The page was reachable but contained no convertible content.
+    Empty,
+    /// The URL cannot be accessed by browser content scripts.
+    UnsupportedUrl,
+    /// Browser policy or permissions blocked access to the page.
+    Protected,
+    /// The page had not finished loading when it was read.
+    NotLoaded,
+    /// Content-script injection failed.
+    InjectionFailed,
+    /// Page extraction or Markdown conversion failed.
+    ExtractionFailed,
+    /// Page extraction exceeded the timeout.
+    TimedOut,
+}
+
+/// Diagnostics captured while reading tab Markdown.
+#[derive(Debug, Clone, GraphQLObject)]
+pub(crate) struct ReadTabDiagnostics {
+    /// Raw HTML characters observed before applying maxHtmlChars.
+    pub source_html_chars: i32,
+    /// Visible text characters observed in the document body.
+    pub source_text_chars: i32,
+    /// Browser document.readyState at extraction time.
+    pub document_ready_state: Option<String>,
+    /// Whether the raw HTML was truncated before conversion.
+    pub truncated_html: bool,
+}
+
 /// Markdown content read from a single tab.
 #[derive(Debug, Clone, GraphQLObject)]
 pub(crate) struct ReadTabEntry {
@@ -436,8 +470,14 @@ pub(crate) struct ReadTabEntry {
     pub chars: i32,
     /// Whether the markdown was truncated at maxChars.
     pub truncated: bool,
-    /// Whether content extraction (strip nav/ads) was applied.
+    /// Whether Kreuzberg preprocessing was applied before conversion.
     pub extracted: bool,
+    /// Structured read status for this tab.
+    pub status: ReadTabStatus,
+    /// Machine-readable reason when Markdown is empty or unavailable.
+    pub empty_reason: Option<String>,
+    /// Extraction and conversion diagnostics.
+    pub diagnostics: ReadTabDiagnostics,
     /// Error message if the tab could not be read, otherwise null.
     pub error: Option<String>,
 }

--- a/rust/crates/host/Cargo.toml
+++ b/rust/crates/host/Cargo.toml
@@ -8,6 +8,7 @@ path = "src/lib.rs"
 
 [dependencies]
 getrandom = "0.2"
+html-to-markdown-rs = "3.5.7"
 rusqlite = { version = "0.33", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/crates/host/src/host_impl/orchestrate/graphql_contracts.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/graphql_contracts.rs
@@ -635,13 +635,20 @@ fn contract_read_markdown_inspect() {
             "entries": [{
                 "tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A",
                 "markdown": "# A\n\nContent.", "chars": 13,
-                "truncated": false, "extracted": true, "error": null
+                "truncated": false, "extracted": true, "status": "READ", "emptyReason": null,
+                "diagnostics": {
+                    "sourceHtmlChars": 120,
+                    "sourceTextChars": 10,
+                    "documentReadyState": "complete",
+                    "truncatedHtml": false
+                },
+                "error": null
             }]
         }),
     );
 
     let result = tabctl_graphql::execute(
-        r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId url markdown chars truncated extracted error } } }"#,
+        r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }"#,
         None,
         snapshot,
         std::sync::Arc::new(sender),
@@ -659,6 +666,8 @@ fn contract_read_markdown_inspect() {
     let entries = result["data"]["readTabs"]["entries"].as_array().unwrap();
     assert_eq!(entries[0]["tabId"], 1);
     assert_eq!(entries[0]["markdown"], "# A\n\nContent.");
+    assert_eq!(entries[0]["status"], "READ");
+    assert_eq!(entries[0]["diagnostics"]["documentReadyState"], "complete");
     assert!(entries[0]["error"].is_null());
 }
 

--- a/rust/crates/host/src/host_impl/orchestrate/read_markdown.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/read_markdown.rs
@@ -1,8 +1,18 @@
+use html_to_markdown_rs::{convert, ConversionOptions, PreprocessingOptions};
 use serde_json::{Map, Value};
 
 use super::report::is_non_scriptable;
 use super::scope::select_tabs_by_scope;
 use super::OrchStep;
+
+const STATUS_READ: &str = "READ";
+const STATUS_EMPTY: &str = "EMPTY";
+const STATUS_UNSUPPORTED_URL: &str = "UNSUPPORTED_URL";
+const STATUS_NOT_LOADED: &str = "NOT_LOADED";
+const STATUS_INJECTION_FAILED: &str = "INJECTION_FAILED";
+const STATUS_EXTRACTION_FAILED: &str = "EXTRACTION_FAILED";
+const STATUS_TIMED_OUT: &str = "TIMED_OUT";
+const STATUS_PROTECTED: &str = "PROTECTED";
 
 #[derive(Debug)]
 pub(crate) struct ReadMarkdownOrchestration {
@@ -14,6 +24,8 @@ pub(crate) struct ReadMarkdownOrchestration {
 struct ReadMarkdownState {
     tabs: Vec<ReadMarkdownTab>,
     tab_index: usize,
+    in_flight_index: Option<usize>,
+    tasks: usize,
     results: Vec<Value>,
     options: ReadMarkdownOptions,
 }
@@ -55,7 +67,7 @@ impl super::Orchestration for ReadMarkdownOrchestration {
         if self.state.is_none() {
             return self.handle_snapshot(response);
         }
-        self.handle_markdown(response)
+        self.handle_html(response)
     }
 }
 
@@ -72,7 +84,6 @@ impl ReadMarkdownOrchestration {
         let tabs: Vec<ReadMarkdownTab> = scope_result
             .tabs
             .iter()
-            .filter(|t| !is_non_scriptable(t.url.as_deref().unwrap_or("")))
             .map(|t| ReadMarkdownTab {
                 tab_id: t.tab_id,
                 window_id: t.window_id,
@@ -102,42 +113,57 @@ impl ReadMarkdownOrchestration {
             timeout_ms: self.params.get("timeoutMs").and_then(Value::as_i64),
         };
 
-        let first_params = build_page_markdown_params(&tabs[0], &options);
         self.state = Some(ReadMarkdownState {
             tabs,
             tab_index: 0,
+            in_flight_index: None,
+            tasks: 0,
             results: Vec::new(),
             options,
         });
 
-        OrchStep::SendPrimitive {
-            action: "p:page-markdown".to_string(),
-            params: first_params,
-        }
+        self.next_step()
     }
 
-    fn handle_markdown(&mut self, response: Value) -> OrchStep {
+    fn handle_html(&mut self, response: Value) -> OrchStep {
         let state = self.state.as_mut().unwrap();
-        let tab = state.tabs[state.tab_index].clone();
-        state.results.push(build_result_entry(
-            &tab,
-            &state.options,
-            if response.get("markdown").is_some() {
-                Some(&response)
-            } else {
-                None
-            },
-        ));
-        state.tab_index += 1;
+        let Some(in_flight_index) = state.in_flight_index.take() else {
+            return OrchStep::Error {
+                message: "readTabs received page HTML without an in-flight tab".to_string(),
+                hint: None,
+            };
+        };
+        let tab = state.tabs[in_flight_index].clone();
+        state
+            .results
+            .push(build_result_entry(&tab, &state.options, Some(&response)));
+        self.next_step()
+    }
 
-        if state.tab_index >= state.tabs.len() {
-            return self.complete();
-        }
+    fn next_step(&mut self) -> OrchStep {
+        loop {
+            let state = self.state.as_mut().unwrap();
+            if state.tab_index >= state.tabs.len() {
+                return self.complete();
+            }
 
-        let next_tab = &state.tabs[state.tab_index];
-        OrchStep::SendPrimitive {
-            action: "p:page-markdown".to_string(),
-            params: build_page_markdown_params(next_tab, &state.options),
+            let tab = state.tabs[state.tab_index].clone();
+            if is_non_scriptable(&tab.url) {
+                state
+                    .results
+                    .push(build_unsupported_entry(&tab, &state.options));
+                state.tab_index += 1;
+                continue;
+            }
+
+            let params = build_page_html_params(&tab, &state.options);
+            state.in_flight_index = Some(state.tab_index);
+            state.tab_index += 1;
+            state.tasks += 1;
+            return OrchStep::SendPrimitive {
+                action: "p:page-html".to_string(),
+                params,
+            };
         }
     }
 
@@ -145,7 +171,7 @@ impl ReadMarkdownOrchestration {
         let state = self.state.as_ref().unwrap();
         OrchStep::Complete {
             response: serde_json::json!({
-                "totals": { "tabs": state.tabs.len(), "tasks": state.tabs.len() },
+                "totals": { "tabs": state.tabs.len(), "tasks": state.tasks },
                 "entries": state.results,
             }),
             undo: None,
@@ -153,16 +179,12 @@ impl ReadMarkdownOrchestration {
     }
 }
 
-fn build_page_markdown_params(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) -> Value {
+fn build_page_html_params(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) -> Value {
     let mut p = serde_json::json!({
         "tabId": tab.tab_id,
-        "extract": options.extract,
     });
     if let Some(v) = options.max_html_chars {
         p["maxHtmlChars"] = v.into();
-    }
-    if let Some(v) = options.max_chars {
-        p["maxChars"] = v.into();
     }
     if let Some(v) = options.timeout_ms {
         p["timeoutMs"] = v.into();
@@ -170,36 +192,261 @@ fn build_page_markdown_params(tab: &ReadMarkdownTab, options: &ReadMarkdownOptio
     p
 }
 
+fn build_unsupported_entry(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) -> Value {
+    base_entry(
+        tab,
+        options,
+        STATUS_UNSUPPORTED_URL,
+        "",
+        0,
+        false,
+        Some("unsupported URL for content-script extraction"),
+        Some("unsupported_url"),
+        diagnostics(0, 0, None, false),
+    )
+}
+
 fn build_result_entry(
     tab: &ReadMarkdownTab,
     options: &ReadMarkdownOptions,
     response: Option<&Value>,
 ) -> Value {
-    if let Some(response) = response {
-        serde_json::json!({
-            "tabId": tab.tab_id,
-            "windowId": tab.window_id,
-            "url": tab.url,
-            "title": tab.title,
-            "markdown": response.get("markdown").and_then(|v| v.as_str()).unwrap_or(""),
-            "chars": response.get("chars").and_then(|v| v.as_i64()).unwrap_or(0),
-            "truncated": response.get("truncated").and_then(|v| v.as_bool()).unwrap_or(false),
-            "extracted": response.get("extracted").and_then(|v| v.as_bool()).unwrap_or(true),
-            "error": Value::Null,
-        })
-    } else {
-        serde_json::json!({
-            "tabId": tab.tab_id,
-            "windowId": tab.window_id,
-            "url": tab.url,
-            "title": tab.title,
-            "markdown": "",
-            "chars": 0,
-            "truncated": false,
-            "extracted": options.extract,
-            "error": "failed to read page",
-        })
+    let Some(response) = response else {
+        return base_entry(
+            tab,
+            options,
+            STATUS_EXTRACTION_FAILED,
+            "",
+            0,
+            false,
+            Some("failed to read page"),
+            Some("missing_response"),
+            diagnostics(0, 0, None, false),
+        );
+    };
+
+    let source_html_chars = response
+        .get("sourceHtmlChars")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let source_text_chars = response
+        .get("sourceTextChars")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let document_ready_state = response
+        .get("documentReadyState")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let truncated_html = response
+        .get("truncatedHtml")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let diag = diagnostics(
+        source_html_chars,
+        source_text_chars,
+        document_ready_state.as_deref(),
+        truncated_html,
+    );
+
+    let response_status = response
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or(STATUS_EXTRACTION_FAILED);
+    if response_status != STATUS_READ {
+        let status = normalize_status(response_status);
+        let error = response
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| default_error(status));
+        return base_entry(
+            tab,
+            options,
+            status,
+            "",
+            0,
+            false,
+            Some(error),
+            Some(empty_reason_for_status(status)),
+            diag,
+        );
     }
+
+    let html = response.get("html").and_then(Value::as_str).unwrap_or("");
+    if html.is_empty() {
+        let status = if document_ready_state.as_deref() == Some("loading") {
+            STATUS_NOT_LOADED
+        } else {
+            STATUS_EMPTY
+        };
+        return base_entry(
+            tab,
+            options,
+            status,
+            "",
+            0,
+            false,
+            Some(default_error(status)),
+            Some(empty_reason_for_status(status)),
+            diag,
+        );
+    }
+
+    let conversion = convert(html, Some(conversion_options(options.extract)));
+    let full_markdown = match conversion {
+        Ok(result) => result.content.unwrap_or_default(),
+        Err(err) => {
+            let message = format!("Markdown conversion failed: {err}");
+            return base_entry(
+                tab,
+                options,
+                STATUS_EXTRACTION_FAILED,
+                "",
+                0,
+                false,
+                Some(&message),
+                Some("conversion_failed"),
+                diag,
+            );
+        }
+    };
+    let (markdown, chars, truncated) = truncate_markdown(&full_markdown, options.max_chars);
+
+    if markdown.trim().is_empty() {
+        let status = if source_text_chars > 0 {
+            STATUS_EXTRACTION_FAILED
+        } else {
+            STATUS_EMPTY
+        };
+        return base_entry(
+            tab,
+            options,
+            status,
+            "",
+            0,
+            false,
+            Some(default_error(status)),
+            Some(if source_text_chars > 0 {
+                "conversion_produced_empty_markdown"
+            } else {
+                "page_text_empty"
+            }),
+            diag,
+        );
+    }
+
+    base_entry(
+        tab,
+        options,
+        STATUS_READ,
+        &markdown,
+        chars,
+        truncated,
+        None,
+        None,
+        diag,
+    )
+}
+
+fn conversion_options(extract: bool) -> ConversionOptions {
+    ConversionOptions {
+        preprocessing: PreprocessingOptions {
+            enabled: extract,
+            ..PreprocessingOptions::default()
+        },
+        ..ConversionOptions::default()
+    }
+}
+
+fn truncate_markdown(markdown: &str, max_chars: Option<i64>) -> (String, i64, bool) {
+    let max_chars = max_chars.unwrap_or(50_000).clamp(1, 200_000) as usize;
+    let total_chars = markdown.chars().count();
+    if total_chars > max_chars {
+        (
+            markdown.chars().take(max_chars).collect(),
+            max_chars as i64,
+            true,
+        )
+    } else {
+        (markdown.to_string(), total_chars as i64, false)
+    }
+}
+
+fn normalize_status(status: &str) -> &'static str {
+    match status {
+        STATUS_TIMED_OUT => STATUS_TIMED_OUT,
+        STATUS_PROTECTED => STATUS_PROTECTED,
+        STATUS_NOT_LOADED => STATUS_NOT_LOADED,
+        STATUS_INJECTION_FAILED => STATUS_INJECTION_FAILED,
+        STATUS_UNSUPPORTED_URL => STATUS_UNSUPPORTED_URL,
+        STATUS_EMPTY => STATUS_EMPTY,
+        _ => STATUS_EXTRACTION_FAILED,
+    }
+}
+
+fn default_error(status: &str) -> &'static str {
+    match status {
+        STATUS_EMPTY => "page produced empty Markdown",
+        STATUS_UNSUPPORTED_URL => "unsupported URL for content-script extraction",
+        STATUS_PROTECTED => "browser blocked access to this tab",
+        STATUS_NOT_LOADED => "page was still loading",
+        STATUS_INJECTION_FAILED => "content-script injection failed",
+        STATUS_TIMED_OUT => "page extraction timed out",
+        _ => "page extraction failed",
+    }
+}
+
+fn empty_reason_for_status(status: &str) -> &'static str {
+    match status {
+        STATUS_EMPTY => "page_text_empty",
+        STATUS_UNSUPPORTED_URL => "unsupported_url",
+        STATUS_PROTECTED => "protected_page",
+        STATUS_NOT_LOADED => "document_not_loaded",
+        STATUS_INJECTION_FAILED => "injection_failed",
+        STATUS_TIMED_OUT => "timed_out",
+        _ => "extraction_failed",
+    }
+}
+
+fn diagnostics(
+    source_html_chars: i64,
+    source_text_chars: i64,
+    document_ready_state: Option<&str>,
+    truncated_html: bool,
+) -> Value {
+    serde_json::json!({
+        "sourceHtmlChars": source_html_chars,
+        "sourceTextChars": source_text_chars,
+        "documentReadyState": document_ready_state,
+        "truncatedHtml": truncated_html,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn base_entry(
+    tab: &ReadMarkdownTab,
+    options: &ReadMarkdownOptions,
+    status: &str,
+    markdown: &str,
+    chars: i64,
+    truncated: bool,
+    error: Option<&str>,
+    empty_reason: Option<&str>,
+    diagnostics: Value,
+) -> Value {
+    serde_json::json!({
+        "tabId": tab.tab_id,
+        "windowId": tab.window_id,
+        "url": tab.url,
+        "title": tab.title,
+        "markdown": markdown,
+        "chars": chars,
+        "truncated": truncated,
+        "extracted": options.extract,
+        "status": status,
+        "emptyReason": empty_reason,
+        "diagnostics": diagnostics,
+        "error": error,
+    })
 }
 
 #[cfg(test)]
@@ -210,6 +457,18 @@ mod tests {
     fn snapshot_with(tabs: Vec<Value>) -> Value {
         serde_json::json!({
             "windows": [{"windowId": 100, "focused": true, "tabs": tabs, "groups": []}]
+        })
+    }
+
+    fn html_response(html: &str, source_text_chars: i64) -> Value {
+        serde_json::json!({
+            "status": "READ",
+            "html": html,
+            "sourceHtmlChars": html.chars().count(),
+            "sourceTextChars": source_text_chars,
+            "documentReadyState": "complete",
+            "truncatedHtml": false,
+            "error": null
         })
     }
 
@@ -238,27 +497,24 @@ mod tests {
         let OrchStep::SendPrimitive { action, params } = &step else {
             panic!("expected SendPrimitive, got {step:?}");
         };
-        assert_eq!(action, "p:page-markdown");
+        assert_eq!(action, "p:page-html");
         assert_eq!(params["tabId"], 1);
-        assert_eq!(params["extract"], true);
-        assert_eq!(params["maxChars"], 10000);
+        assert_eq!(params["maxChars"], Value::Null);
 
-        let step = orch.step(
-            serde_json::json!({"markdown": "# Hello", "chars": 7, "truncated": false, "extracted": true}),
-        );
+        let step = orch.step(html_response("<h1>Hello</h1><p>World.</p>", 12));
         let OrchStep::Complete { response, .. } = step else {
             panic!("expected Complete")
         };
         let entries = response["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["tabId"], 1);
-        assert_eq!(entries[0]["markdown"], "# Hello");
-        assert_eq!(entries[0]["chars"], 7);
+        assert_eq!(entries[0]["status"], STATUS_READ);
+        assert!(entries[0]["markdown"].as_str().unwrap().contains("Hello"));
         assert_eq!(entries[0]["truncated"], false);
     }
 
     #[test]
-    fn read_markdown_multiple_tabs() {
+    fn read_markdown_multiple_tabs_preserves_order() {
         let params = serde_json::json!({});
         let mut orch = ReadMarkdownOrchestration::new(&params);
         let _ = orch.start();
@@ -268,23 +524,21 @@ mod tests {
         ]);
         let step = orch.step(snap);
         assert!(matches!(&step, OrchStep::SendPrimitive { action, params }
-            if action == "p:page-markdown" && params["tabId"] == 1));
+            if action == "p:page-html" && params["tabId"] == 1));
 
-        let step = orch.step(
-            serde_json::json!({"markdown": "Tab1", "chars": 4, "truncated": false, "extracted": true}),
-        );
+        let step = orch.step(html_response("<p>Tab1</p>", 4));
         assert!(matches!(&step, OrchStep::SendPrimitive { action, params }
-            if action == "p:page-markdown" && params["tabId"] == 2));
+            if action == "p:page-html" && params["tabId"] == 2));
 
-        let step = orch.step(
-            serde_json::json!({"markdown": "Tab2", "chars": 4, "truncated": false, "extracted": true}),
-        );
+        let step = orch.step(html_response("<p>Tab2</p>", 4));
         let OrchStep::Complete { response, undo } = step else {
             panic!("expected Complete")
         };
         assert!(undo.is_none());
         let entries = response["entries"].as_array().unwrap();
         assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["tabId"], 1);
+        assert_eq!(entries[1]["tabId"], 2);
         assert_eq!(response["totals"]["tasks"], 2);
     }
 
@@ -303,11 +557,12 @@ mod tests {
         };
         let entry = &response["entries"][0];
         assert_eq!(entry["markdown"], "");
+        assert_eq!(entry["status"], STATUS_EXTRACTION_FAILED);
         assert!(!entry["error"].is_null());
     }
 
     #[test]
-    fn read_markdown_skips_non_scriptable_tabs() {
+    fn read_markdown_keeps_non_scriptable_tabs_as_unsupported_entries() {
         let params = serde_json::json!({});
         let mut orch = ReadMarkdownOrchestration::new(&params);
         let _ = orch.start();
@@ -320,5 +575,69 @@ mod tests {
             panic!("expected SendPrimitive")
         };
         assert_eq!(params["tabId"], 2);
+
+        let step = orch.step(html_response("<p>A</p>", 1));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["totals"]["tabs"], 2);
+        assert_eq!(response["totals"]["tasks"], 1);
+        assert_eq!(response["entries"][0]["status"], STATUS_UNSUPPORTED_URL);
+        assert_eq!(response["entries"][1]["status"], STATUS_READ);
+    }
+
+    #[test]
+    fn read_markdown_empty_conversion_is_not_success() {
+        let params = serde_json::json!({});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]);
+        let _ = orch.step(snap);
+        let step = orch.step(html_response(
+            "<html><body><script>1</script></body></html>",
+            42,
+        ));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["status"], STATUS_EXTRACTION_FAILED);
+        assert!(!entry["error"].is_null());
+        assert_eq!(entry["diagnostics"]["sourceTextChars"], 42);
+    }
+
+    #[test]
+    fn read_markdown_timeout_status_is_preserved() {
+        let params = serde_json::json!({});
+        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]);
+        let _ = orch.step(snap);
+        let step = orch.step(serde_json::json!({
+            "status": "TIMED_OUT",
+            "error": "Timed out after 10ms",
+            "sourceHtmlChars": 0,
+            "sourceTextChars": 0,
+            "documentReadyState": null,
+            "truncatedHtml": false
+        }));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["status"], STATUS_TIMED_OUT);
+        assert_eq!(entry["emptyReason"], "timed_out");
+    }
+
+    #[test]
+    fn truncate_markdown_uses_character_boundaries() {
+        let (markdown, chars, truncated) = truncate_markdown("aé🙂b", Some(3));
+        assert_eq!(markdown, "aé🙂");
+        assert_eq!(chars, 3);
+        assert!(truncated);
     }
 }

--- a/rust/crates/tabctl/tests/browser_integration.rs
+++ b/rust/crates/tabctl/tests/browser_integration.rs
@@ -6,8 +6,46 @@
 mod common;
 
 use common::*;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::thread::sleep;
 use std::time::Duration;
+
+fn known_markdown_fixture_url() -> String {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind known markdown fixture");
+    let addr = listener.local_addr().expect("read fixture address");
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buffer = [0_u8; 1024];
+            let _ = stream.read(&mut request_buffer);
+            let body = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Known Markdown Fixture</title>
+  </head>
+  <body>
+    <main>
+      <h1>Known Markdown Heading</h1>
+      <p>This deterministic integration paragraph proves readTabs converted fixture HTML.</p>
+      <ul>
+        <li>First known list item</li>
+        <li>Second known list item</li>
+      </ul>
+      <a href="https://example.test/fixture-link">Fixture Link</a>
+    </main>
+  </body>
+</html>"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+    format!("http://{addr}/known-markdown")
+}
 
 #[test]
 #[ignore = "requires built dist artifacts and Chrome"]
@@ -128,6 +166,85 @@ fn real_browser_integration_harness_passes() {
                     && entry["action"].as_str() == Some("close")
             })),
         "expected closeTabs txid in history results: {history}"
+    );
+
+    b.close_test_window(window_id);
+}
+
+#[test]
+#[ignore = "requires built dist artifacts and Chrome"]
+fn read_tabs_returns_markdown_for_known_page() {
+    let b = shared_browser();
+    let fixture_url = known_markdown_fixture_url();
+    let (window_id, tab_ids) = b.create_test_window(&[fixture_url.as_str()], None);
+    let tab_id = tab_ids[0];
+    sleep(Duration::from_secs(1));
+
+    let read = b.run_query(&format!(
+        r#"query {{ readTabs(tabIds: [{tab_id}], extract: true, maxChars: 50000, timeoutMs: 15000) {{ totals {{ tabs tasks }} entries {{ tabId url title chars truncated extracted status emptyReason diagnostics {{ sourceHtmlChars sourceTextChars documentReadyState truncatedHtml }} error markdown }} }} }}"#
+    ));
+    assert_ok("readTabs known markdown page", &read);
+    let data = &response_data(&read)["readTabs"];
+    assert_eq!(
+        data["totals"]["tabs"].as_i64(),
+        Some(1),
+        "readTabs should return one tab: {read}"
+    );
+    assert_eq!(
+        data["totals"]["tasks"].as_i64(),
+        Some(1),
+        "readTabs should run extraction for the known http page: {read}"
+    );
+
+    let entry = &data["entries"][0];
+    assert_eq!(entry["tabId"].as_i64(), Some(tab_id));
+    assert_eq!(entry["status"].as_str(), Some("READ"), "{read}");
+    assert_eq!(entry["emptyReason"], serde_json::Value::Null);
+    assert_eq!(entry["error"], serde_json::Value::Null);
+    assert_eq!(entry["extracted"].as_bool(), Some(true));
+    assert_eq!(entry["truncated"].as_bool(), Some(false));
+    assert!(
+        entry["chars"].as_i64().unwrap_or(0) > 0,
+        "readTabs should report Markdown characters: {read}"
+    );
+    assert!(
+        entry["diagnostics"]["sourceHtmlChars"]
+            .as_i64()
+            .unwrap_or(0)
+            > 0,
+        "readTabs should report source HTML diagnostics: {read}"
+    );
+    assert!(
+        entry["diagnostics"]["sourceTextChars"]
+            .as_i64()
+            .unwrap_or(0)
+            > 0,
+        "readTabs should report source text diagnostics: {read}"
+    );
+    assert_eq!(
+        entry["diagnostics"]["documentReadyState"].as_str(),
+        Some("complete")
+    );
+    assert_eq!(entry["diagnostics"]["truncatedHtml"].as_bool(), Some(false));
+
+    let markdown = entry["markdown"]
+        .as_str()
+        .expect("readTabs should return Markdown text");
+    assert!(
+        markdown.contains("Known Markdown Heading"),
+        "expected known heading in Markdown: {markdown}"
+    );
+    assert!(
+        markdown.contains("deterministic integration paragraph"),
+        "expected known paragraph in Markdown: {markdown}"
+    );
+    assert!(
+        markdown.contains("First known list item"),
+        "expected known list item in Markdown: {markdown}"
+    );
+    assert!(
+        markdown.contains("Fixture Link") && markdown.contains("https://example.test/fixture-link"),
+        "expected known link in Markdown: {markdown}"
     );
 
     b.close_test_window(window_id);

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -216,9 +216,10 @@ async function main() {
   readTab = readOpen.data.openTabs.tabs[0].tabId;
   log(`Opened readTabs page: tab=${readTab}`);
   await new Promise((resolve) => setTimeout(resolve, 2_000));
-  const read = await query(`query { readTabs(tabIds: [${readTab}], extract: true, maxChars: 50000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId url title chars truncated extracted markdown } } }`);
+  const read = await query(`query { readTabs(tabIds: [${readTab}], extract: true, maxChars: 50000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId url title chars truncated extracted status emptyReason error markdown } } }`);
   const readEntry = read.data.readTabs.entries[0];
   expect(read.data.readTabs.totals.tabs === 1, "readTabs did not return exactly one tab");
+  expect(readEntry.status === "READ", `readTabs status was ${readEntry.status}: ${readEntry.error || readEntry.emptyReason || "no detail"}`);
   expect(readEntry.chars > 0, "readTabs returned empty content");
   expect(readEntry.markdown.length > 0, "readTabs returned empty markdown");
   log(`readTabs extracted ${readEntry.chars} chars from ${readEntry.url}`);

--- a/skills/tabctl/SKILL.md
+++ b/skills/tabctl/SKILL.md
@@ -44,7 +44,7 @@ tabctl help query
  tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true, text: "$", textMode: "contains" }, { name: "submit_visible", selector: "#submit", attr: "visible" }, { name: "submit_style", selector: "#submit", attr: "styles", styleProps: ["color", "background-color"] }, { name: "item_count", selector: ".item", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }, { name: "tos_checked", selector: "input[name=terms]", attr: "checked" }]) { entries { tabId url signals { name valueJson } } } }'
 
 # Read page content as Markdown
- tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted error } } }'
+ tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
 
 # Build reports
  tabctl query '{ reportTabs(windowId: 123) { entries { tabId title url description } } }'
@@ -55,8 +55,8 @@ tabctl help query
 
 ## Read-only extraction notes
 
-- `readTabs` converts main-frame HTML to Markdown. `extract: true` is a heuristic, best-effort readability pass; check `extracted` and `error` per tab.
-- `readTabs` v1 does not traverse cross-origin iframes or shadow DOM, and skips non-scriptable URLs automatically.
+- `readTabs` converts main-frame HTML to Markdown with Kreuzberg preprocessing. Check `status`, `emptyReason`, `diagnostics`, and `error` per tab.
+- `readTabs` v1 does not traverse cross-origin iframes or shadow DOM; non-scriptable URLs are returned with `status: UNSUPPORTED_URL`.
 - `inspectTabs` selector attrs now include `html`, `value`, `count`, `box`, `styles`, `visible`, `enabled`, and `checked`.
 - `visible` means rendered and not `display:none`, `visibility:hidden`, or `opacity:0`.
 - `enabled` means the element is not disabled and `aria-disabled != "true"`.

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -1,5 +1,3 @@
-import { convert } from "markdown-for-agents";
-
 const HOST_NAME = "com.erwinkroon.tabctl";
 const manifest = chrome.runtime.getManifest();
 const MANIFEST_VERSION = manifest.version || "0.0.0";
@@ -582,29 +580,16 @@ async function handleAction(action: string, params: Record<string, unknown>, req
       );
     }
 
-    case "p:page-markdown": {
+    case "p:page-html": {
       const targetTabId = requireFiniteId(params.tabId, "tabId");
-      const extract = params.extract !== false;
       const maxHtmlChars = typeof params.maxHtmlChars === "number"
-        ? Math.max(1, Math.min(params.maxHtmlChars, 1_000_000))
+        ? Math.max(1, Math.min(params.maxHtmlChars, 650_000))
         : 500_000;
-      const maxChars = typeof params.maxChars === "number"
-        ? Math.max(1, Math.min(params.maxChars, 200_000))
-        : 50_000;
       const timeoutMs = typeof params.timeoutMs === "number"
         ? Math.max(1, params.timeoutMs)
         : 15_000;
 
-      const html = await content.extractPageMarkdown(targetTabId, timeoutMs, maxHtmlChars);
-      if (!html) {
-        return { markdown: "", chars: 0, truncated: false, extracted: extract };
-      }
-
-      const fullMarkdown = convert(html, { extract }).markdown;
-      const truncated = fullMarkdown.length > maxChars;
-      const markdown = truncated ? fullMarkdown.slice(0, maxChars) : fullMarkdown;
-
-      return { markdown, chars: markdown.length, truncated, extracted: extract };
+      return await content.extractPageHtml(targetTabId, timeoutMs, maxHtmlChars);
     }
 
     default:

--- a/src/extension/lib/content.ts
+++ b/src/extension/lib/content.ts
@@ -35,6 +35,42 @@ export async function executeWithTimeout<T>(
   }
 }
 
+export type ScriptExecutionResult<T> =
+  | { kind: "ok"; value: T | null }
+  | { kind: "timeout" }
+  | { kind: "error"; message: string };
+
+export async function executeWithTimeoutDetailed<T>(
+  tabId: number,
+  timeoutMs: number,
+  func: (...args: Array<any>) => T,
+  args: Array<unknown> = [],
+): Promise<ScriptExecutionResult<T>> {
+  const execPromise: Promise<ScriptExecutionResult<T>> = chrome.scripting.executeScript({
+    target: { tabId },
+    func,
+    args,
+  }).then((result): ScriptExecutionResult<T> => {
+    if (!result || !Array.isArray(result)) {
+      return { kind: "ok", value: null };
+    }
+    const [{ result: value }] = result as Array<{ result?: T | null }>;
+    return { kind: "ok", value: value ?? null };
+  }).catch((err: unknown) => ({
+    kind: "error",
+    message: err instanceof Error ? err.message : String(err),
+  }));
+
+  const timeoutPromise = new Promise<ScriptExecutionResult<T>>((resolve) => {
+    const handle = setTimeout(() => {
+      clearTimeout(handle);
+      resolve({ kind: "timeout" });
+    }, timeoutMs);
+  });
+
+  return Promise.race([execPromise, timeoutPromise]);
+}
+
 export async function extractPageMeta(tabId: number, timeoutMs: number, descriptionMaxLength: number) {
   const result = await executeWithTimeout(tabId, timeoutMs, () => {
     const pickContent = (selector: string) => {
@@ -78,6 +114,79 @@ export async function extractPageMarkdown(tabId: number, timeoutMs: number, maxH
   }, [maxHtmlChars]);
 
   return typeof result === "string" ? result : "";
+}
+
+type PageHtmlPayload = {
+  html: string;
+  sourceHtmlChars: number;
+  sourceTextChars: number;
+  documentReadyState: string;
+  truncatedHtml: boolean;
+};
+
+function injectionStatus(message: string) {
+  const lower = message.toLowerCase();
+  if (lower.includes("cannot access") || lower.includes("permission") || lower.includes("extensions gallery")) {
+    return "PROTECTED";
+  }
+  return "INJECTION_FAILED";
+}
+
+export async function extractPageHtml(tabId: number, timeoutMs: number, maxHtmlChars: number) {
+  const result = await executeWithTimeoutDetailed<PageHtmlPayload>(tabId, timeoutMs, (cap: number) => {
+    const raw = document.documentElement?.outerHTML || "";
+    const text = document.body?.innerText || document.documentElement?.textContent || "";
+    return {
+      html: raw.length > cap ? raw.slice(0, cap) : raw,
+      sourceHtmlChars: raw.length,
+      sourceTextChars: text.length,
+      documentReadyState: document.readyState,
+      truncatedHtml: raw.length > cap,
+    };
+  }, [maxHtmlChars]);
+
+  if (result.kind === "timeout") {
+    return {
+      status: "TIMED_OUT",
+      html: "",
+      sourceHtmlChars: 0,
+      sourceTextChars: 0,
+      documentReadyState: null,
+      truncatedHtml: false,
+      error: `Timed out after ${timeoutMs}ms`,
+    };
+  }
+
+  if (result.kind === "error") {
+    return {
+      status: injectionStatus(result.message),
+      html: "",
+      sourceHtmlChars: 0,
+      sourceTextChars: 0,
+      documentReadyState: null,
+      truncatedHtml: false,
+      error: result.message,
+    };
+  }
+
+  if (!result.value) {
+    return {
+      status: "EXTRACTION_FAILED",
+      html: "",
+      sourceHtmlChars: 0,
+      sourceTextChars: 0,
+      documentReadyState: null,
+      truncatedHtml: false,
+      error: "Content script returned no page HTML payload",
+    };
+  }
+
+  const status = result.value.documentReadyState === "loading" ? "NOT_LOADED" : "READ";
+  return {
+    status,
+    ...result.value,
+    error: null,
+  };
 }
 
 export async function extractSelectorSignal(tabId: number, specs: Array<Record<string, unknown>>, timeoutMs: number, selectorValueMaxLength: number) {


### PR DESCRIPTION
## Summary
- move readTabs Markdown conversion into the Rust host using page HTML from the extension
- expose readTabs status and diagnostics through GraphQL
- add deterministic browser integration coverage for known-page Markdown output
- keep smoke testing to a lightweight Markdown health signal

## Validation
- npm test
- npm run test:integration
- npm run test:smoke