### PR TITLE
chore(release): v0.6.0-rc.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.6",
+  "version": "0.6.0-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.6",
+      "version": "0.6.0-rc.7",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"
@@ -24,7 +24,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.6"
+        "tabctl-win32-x64": "0.6.0-rc.7"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -569,17 +569,7 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "version": "0.6.0-rc.6",
-      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.6.tgz",
-      "integrity": "sha512-csiQUkxgyoh+sigffxIMNMJVybGFIQNwU7AiGndIPErG5hjzUrMVvgSAfTPWBNtdwzTcHWjIiGYybUqTnuFkKQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.6",
+  "version": "0.6.0-rc.7",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -53,7 +53,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.6"
+    "tabctl-win32-x64": "0.6.0-rc.7"
   },
   "dependencies": {
     "normalize-url": "^8.1.1"

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.6",
+  "version": "0.6.0-rc.7",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 dependencies = [
  "clap",
  "dirs",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 dependencies = [
  "indexmap",
  "juniper",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 dependencies = [
  "getrandom",
  "html-to-markdown-rs",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.6"
+version = "0.6.0-rc.7"


### PR DESCRIPTION
## Release preparation

- Current version: `0.6.0-rc.6`
- Next version: `0.6.0-rc.7`
- Bump type: `rc`
- Recommendation: current version is a release candidate

This PR continues the release branch created by the **Prepare Release** workflow after GitHub Actions was not permitted to create the PR.
After it merges, the **Tag Release** workflow should create `v0.6.0-rc.7` and dispatch the **Release** workflow.