### PR TITLE
fix(release): sync rc7 platform package lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -569,7 +569,17 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "optional": true
+      "version": "0.6.0-rc.7",
+      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.7.tgz",
+      "integrity": "sha512-iA6LUjzrVZKkSyCzhb9bq7mjBeCUPjWwIHsN/1E8FrGxzj2a424CZIB/y712q59LFXoeCgj9WaWQ+Nxuh4a7mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/typescript": {
       "version": "5.9.3",


### PR DESCRIPTION
## Summary
- restore the tabctl-win32-x64 package metadata in package-lock.json for v0.6.0-rc.7
- fix the WSL npm ci failure on main after the release bump

## Validation
- npm ci --ignore-scripts