### PR TITLE
feat: add readTabs page cache and tab badge

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -71,7 +71,7 @@ Use `tabctl schema` when you need field discovery, then use `tabctl query` for b
  tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true }, { name: "checkout_visible", selector: "#checkout", attr: "visible" }, { name: "checkout_style", selector: "#checkout", attr: "styles", styleProps: ["color", "background-color"] }, { name: "item_count", selector: ".line-item", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }]) { totals { tabs tasks } entries { tabId url signals { name valueJson } } } }'
 
 # Read page content as Markdown
- tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 50000) { totals { tabs tasks } entries { tabId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
+ tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 50000) { totals { tabs tasks } entries { tabId title url markdown chars truncated extracted cached status emptyReason diagnostics { source sourceHtmlChars sourceTextChars documentReadyState truncatedHtml cachedAt cacheAgeMs } error } } }'
 
 # Generate a report with descriptions
  tabctl query '{ reportTabs(windowId: 123) { totals { tabs } entries { tabId title url description } } }'
@@ -125,19 +125,20 @@ Arguments:
 - scope via one of `windowId`, `groupId`, `groupTitle`, `tabIds`, or `ungrouped`
 - `extract` — enables Kreuzberg standard preprocessing before Markdown conversion; defaults to `true`
 - `maxChars` — maximum Markdown characters per tab; defaults to `50000`, max `200000`
-- `maxHtmlChars` — maximum raw HTML characters read per tab; defaults to `500000`, max `650000`
+- `maxHtmlChars` — maximum raw HTML characters read per tab; defaults to `500000`, max `1500000`
 - `timeoutMs` — per-tab timeout in milliseconds; defaults to `15000`
 
 Caveats:
 - Markdown conversion uses the Kreuzberg `html-to-markdown` converter in the native host.
 - Check `status`, `emptyReason`, `diagnostics`, and `error` per tab; empty Markdown is not reported as a clean success.
+- The host keeps a bounded profile-local cache of active/open-tab HTML from successful `readTabs` reads and active-tab refreshes; if a later live read fails for the same open tab, exact URL, duplicate exact URL, or canonical URL without fragment, `readTabs` may return cached Markdown with `status: CACHED`, `cached: true`, and cache provenance in `diagnostics.source`, `cachedAt`, `cacheAgeMs`, and `cacheMatch`.
 - v1 reads the main frame only; cross-origin iframes and shadow DOM are not traversed.
 - Non-scriptable URLs such as `chrome://` and `about:` are returned with `status: UNSUPPORTED_URL`.
 
 Example:
 
 ```bash
-tabctl query 'query { readTabs(groupTitle: "Research", extract: true, maxChars: 30000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId windowId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
+tabctl query 'query { readTabs(groupTitle: "Research", extract: true, maxChars: 30000, timeoutMs: 15000) { totals { tabs tasks } entries { tabId windowId title url markdown chars truncated extracted cached status emptyReason diagnostics { source sourceHtmlChars sourceTextChars documentReadyState truncatedHtml cachedAt cacheAgeMs } error } } }'
 ```
 
 ### Mutation examples

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ tabctl query 'query { inspectTabs(tabIds: [456], signals: ["page-meta"]) { entri
 tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true }, { name: "buy_now_visible", selector: "button.buy-now", attr: "visible" }, { name: "buy_now_style", selector: "button.buy-now", attr: "styles", styleProps: ["color", "background-color"] }, { name: "review_count", selector: ".review", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }]) { entries { tabId url signals { name valueJson } } } }'
 
 # Read tab content as Markdown (Kreuzberg preprocessing by default)
-tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
+tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted cached status emptyReason diagnostics { source sourceHtmlChars sourceTextChars documentReadyState truncatedHtml cachedAt cacheAgeMs } error } } }'
 
 # Generate reports
 tabctl query '{ reportTabs(windowId: 123) { entries { tabId title url description } } }'
@@ -427,7 +427,8 @@ Notes:
 - Browser reads and mutations now go through GraphQL via `tabctl query`.
 - Reports include short descriptions from page metadata and a fallback snippet.
 - `inspectTabs` supports `page-meta` plus selector reads with `all`, `text`, `textMode`, `styleProps`, and attrs such as `html`, `value`, `count`, `box`, `styles`, `visible`, `enabled`, and `checked`.
-- `readTabs` converts main-frame page HTML to Markdown with Kreuzberg `html-to-markdown`; per-tab `status`, `emptyReason`, `diagnostics`, and `error` distinguish empty pages, unsupported URLs, injection failures, conversion failures, and timeouts.
+- `readTabs` converts main-frame page HTML to Markdown with Kreuzberg `html-to-markdown`; per-tab `status`, `emptyReason`, `diagnostics`, and `error` distinguish empty pages, unsupported URLs, injection failures, conversion failures, timeouts, and cached fallbacks (`status: CACHED`, `cached: true`, `diagnostics.source: "cache"`).
+- Cached fallbacks use a bounded profile-local open-tab HTML cache refreshed after successful reads, active tab switches, and quiescent active pages; diagnostics include cache age and match mode when cached content is used.
 - `captureScreenshots` returns tile metadata and image data from GraphQL.
 - `undoAction` accepts either an explicit `txid` or `latest: true`.
 - `tabctl history --json` returns a top-level JSON array.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.8",
+      "version": "0.6.0-rc.9",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"
@@ -24,7 +24,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.8"
+        "tabctl-win32-x64": "0.6.0-rc.9"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.7",
+  "version": "0.6.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.7",
+      "version": "0.6.0-rc.8",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"
@@ -24,7 +24,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.7"
+        "tabctl-win32-x64": "0.6.0-rc.8"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -569,17 +569,7 @@
       }
     },
     "node_modules/tabctl-win32-x64": {
-      "version": "0.6.0-rc.7",
-      "resolved": "https://registry.npmjs.org/tabctl-win32-x64/-/tabctl-win32-x64-0.6.0-rc.7.tgz",
-      "integrity": "sha512-iA6LUjzrVZKkSyCzhb9bq7mjBeCUPjWwIHsN/1E8FrGxzj2a424CZIB/y712q59LFXoeCgj9WaWQ+Nxuh4a7mQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0-rc.9",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -53,7 +53,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.8"
+    "tabctl-win32-x64": "0.6.0-rc.9"
   },
   "dependencies": {
     "normalize-url": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.7",
+  "version": "0.6.0-rc.8",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -53,7 +53,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.7"
+    "tabctl-win32-x64": "0.6.0-rc.8"
   },
   "dependencies": {
     "normalize-url": "^8.1.1"

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.7",
+  "version": "0.6.0-rc.8",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.8",
+  "version": "0.6.0-rc.9",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 dependencies = [
  "clap",
  "dirs",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 dependencies = [
  "indexmap",
  "juniper",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 dependencies = [
  "getrandom",
  "html-to-markdown-rs",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "clap",
  "dirs",
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "indexmap",
  "juniper",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "getrandom",
  "html-to-markdown-rs",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.8"
+version = "0.6.0-rc.9"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.7"
+version = "0.6.0-rc.8"

--- a/rust/crates/graphql/src/schema.rs
+++ b/rust/crates/graphql/src/schema.rs
@@ -456,7 +456,7 @@ impl Query {
         #[graphql(description = "Enable content extraction (strip nav/ads). Default: true.")]
         extract: Option<bool>,
         #[graphql(
-            description = "Maximum raw HTML characters to read per tab. Default: 500000, max: 650000."
+            description = "Maximum raw HTML characters to read per tab. Default: 500000, max: 1500000."
         )]
         max_html_chars: Option<i32>,
         #[graphql(description = "Maximum Markdown characters per tab. Default: 50000.")]
@@ -914,6 +914,7 @@ fn parse_read_result(response: &serde_json::Value) -> ReadTabResult {
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false),
                         extracted: e.get("extracted").and_then(|v| v.as_bool()).unwrap_or(true),
+                        cached: e.get("cached").and_then(|v| v.as_bool()).unwrap_or(false),
                         status: parse_read_status(e.get("status").and_then(|v| v.as_str())),
                         empty_reason: e
                             .get("emptyReason")
@@ -932,6 +933,7 @@ fn parse_read_result(response: &serde_json::Value) -> ReadTabResult {
 
 fn parse_read_status(value: Option<&str>) -> ReadTabStatus {
     match value {
+        Some("CACHED") => ReadTabStatus::Cached,
         Some("EMPTY") => ReadTabStatus::Empty,
         Some("UNSUPPORTED_URL") => ReadTabStatus::UnsupportedUrl,
         Some("PROTECTED") => ReadTabStatus::Protected,
@@ -951,6 +953,20 @@ fn parse_read_diagnostics(value: Option<&serde_json::Value>) -> ReadTabDiagnosti
             .unwrap_or(0) as i32
     };
     ReadTabDiagnostics {
+        source: value
+            .and_then(|v| v.get("source"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        cached_at: value
+            .and_then(|v| v.get("cachedAt"))
+            .and_then(|v| v.as_f64()),
+        cache_age_ms: value
+            .and_then(|v| v.get("cacheAgeMs"))
+            .and_then(|v| v.as_f64()),
+        cache_match: value
+            .and_then(|v| v.get("cacheMatch"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
         source_html_chars: get_i32("sourceHtmlChars"),
         source_text_chars: get_i32("sourceTextChars"),
         document_ready_state: value
@@ -2359,7 +2375,7 @@ mod tests {
     #[test]
     fn query_read_tabs_basic() {
         let result = exec(
-            r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }"#,
+            r#"{ readTabs(windowId: 100) { totals { tabs tasks } entries { tabId markdown chars truncated extracted cached status emptyReason diagnostics { source cachedAt cacheAgeMs cacheMatch sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }"#,
         );
         assert!(
             result.get("errors").is_none(),
@@ -2372,8 +2388,88 @@ mod tests {
         assert_eq!(entries[0]["tabId"], 1);
         assert_eq!(entries[0]["markdown"], "# Hello\n\nWorld.");
         assert_eq!(entries[0]["chars"], 16);
+        assert_eq!(entries[0]["cached"], false);
         assert_eq!(entries[0]["status"], "READ");
+        assert!(entries[0]["diagnostics"]["source"].is_null());
+        assert!(entries[0]["diagnostics"]["cachedAt"].is_null());
+        assert!(entries[0]["diagnostics"]["cacheAgeMs"].is_null());
+        assert!(entries[0]["diagnostics"]["cacheMatch"].is_null());
         assert!(entries[0]["error"].is_null());
+    }
+
+    #[test]
+    fn parse_read_tabs_cached_contract() {
+        let parsed = super::parse_read_result(&serde_json::json!({
+            "totals": { "tabs": 1, "tasks": 0 },
+            "entries": [{
+                "tabId": 7,
+                "windowId": 100,
+                "url": "https://cached.example/",
+                "title": "Cached",
+                "markdown": "# Cached",
+                "chars": 8,
+                "truncated": false,
+                "extracted": true,
+                "cached": true,
+                "status": "CACHED",
+                "diagnostics": {
+                    "source": "cache",
+                    "cachedAt": 1700000000000.0,
+                    "cacheAgeMs": 2500.0,
+                    "cacheMatch": "canonical",
+                    "sourceHtmlChars": 1234,
+                    "sourceTextChars": 56,
+                    "documentReadyState": "complete",
+                    "truncatedHtml": false
+                },
+                "error": null
+            }]
+        }));
+
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert!(entry.cached);
+        assert!(matches!(entry.status, super::ReadTabStatus::Cached));
+        assert_eq!(entry.diagnostics.source.as_deref(), Some("cache"));
+        assert_eq!(entry.diagnostics.cached_at, Some(1700000000000.0));
+        assert_eq!(entry.diagnostics.cache_age_ms, Some(2500.0));
+        assert_eq!(entry.diagnostics.cache_match.as_deref(), Some("canonical"));
+    }
+
+    #[test]
+    fn parse_read_tabs_older_cache_diagnostics_default_cache_match() {
+        let parsed = super::parse_read_result(&serde_json::json!({
+            "totals": { "tabs": 1, "tasks": 0 },
+            "entries": [{
+                "tabId": 7,
+                "windowId": 100,
+                "url": "https://cached.example/",
+                "title": "Cached",
+                "markdown": "# Cached",
+                "chars": 8,
+                "truncated": false,
+                "extracted": true,
+                "cached": true,
+                "status": "CACHED",
+                "diagnostics": {
+                    "source": "cache",
+                    "cachedAt": 1700000000000.0,
+                    "cacheAgeMs": 2500.0,
+                    "sourceHtmlChars": 1234,
+                    "sourceTextChars": 56,
+                    "documentReadyState": "complete",
+                    "truncatedHtml": false
+                },
+                "error": null
+            }]
+        }));
+
+        assert_eq!(parsed.entries.len(), 1);
+        let entry = &parsed.entries[0];
+        assert!(entry.cached);
+        assert!(matches!(entry.status, super::ReadTabStatus::Cached));
+        assert_eq!(entry.diagnostics.source.as_deref(), Some("cache"));
+        assert_eq!(entry.diagnostics.cache_match, None);
     }
 
     #[test]

--- a/rust/crates/graphql/src/types.rs
+++ b/rust/crates/graphql/src/types.rs
@@ -424,6 +424,8 @@ pub(crate) struct ScreenshotResult {
 pub(crate) enum ReadTabStatus {
     /// Markdown was produced.
     Read,
+    /// Markdown was served from the readTabs page cache.
+    Cached,
     /// The page was reachable but contained no convertible content.
     Empty,
     /// The URL cannot be accessed by browser content scripts.
@@ -443,6 +445,14 @@ pub(crate) enum ReadTabStatus {
 /// Diagnostics captured while reading tab Markdown.
 #[derive(Debug, Clone, GraphQLObject)]
 pub(crate) struct ReadTabDiagnostics {
+    /// Provenance for the returned content, e.g. "live" or "cache".
+    pub source: Option<String>,
+    /// Cache capture timestamp in milliseconds since the Unix epoch.
+    pub cached_at: Option<f64>,
+    /// Age of the cached content when returned, in milliseconds.
+    pub cache_age_ms: Option<f64>,
+    /// Cache lookup strategy that produced cached content.
+    pub cache_match: Option<String>,
     /// Raw HTML characters observed before applying maxHtmlChars.
     pub source_html_chars: i32,
     /// Visible text characters observed in the document body.
@@ -472,6 +482,8 @@ pub(crate) struct ReadTabEntry {
     pub truncated: bool,
     /// Whether Kreuzberg preprocessing was applied before conversion.
     pub extracted: bool,
+    /// Whether the markdown came from the readTabs page cache.
+    pub cached: bool,
     /// Structured read status for this tab.
     pub status: ReadTabStatus,
     /// Machine-readable reason when Markdown is empty or unavailable.

--- a/rust/crates/host/src/host_impl.rs
+++ b/rust/crates/host/src/host_impl.rs
@@ -2,6 +2,7 @@ mod browser_state;
 mod dispatch;
 mod focus_store;
 mod orchestrate;
+mod page_cache;
 mod protocol;
 mod runtime;
 mod state;

--- a/rust/crates/host/src/host_impl/orchestrate/mod.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/mod.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::path::PathBuf;
 
 mod analyze;
 mod archive;
@@ -26,6 +27,12 @@ mod undo;
 /// Each implementation encodes a state machine: `start()` produces the first
 /// primitive call, and `step(response)` advances the machine until it reaches
 /// `Complete` or `Error`.
+#[derive(Clone, Debug, Default)]
+pub(super) struct OrchestrationContext {
+    pub(super) page_cache_path: Option<PathBuf>,
+    pub(super) profile_name: Option<String>,
+}
+
 pub(super) trait Orchestration: Send + std::fmt::Debug {
     /// Produce the first primitive action to send to the extension.
     fn start(&mut self) -> OrchStep;
@@ -63,7 +70,11 @@ pub(super) enum OrchStep {
 ///
 /// Commands are registered here as they migrate from thick extension handlers
 /// to host-side orchestration.
-pub(super) fn orchestration_for(action: &str, params: &Value) -> Option<Box<dyn Orchestration>> {
+pub(super) fn orchestration_for(
+    action: &str,
+    params: &Value,
+    context: &OrchestrationContext,
+) -> Option<Box<dyn Orchestration>> {
     match action {
         "list" => Some(Box::new(list::ListOrchestration::new(params))),
         "group-list" => Some(Box::new(list::GroupListOrchestration::new(params))),
@@ -102,6 +113,7 @@ pub(super) fn orchestration_for(action: &str, params: &Value) -> Option<Box<dyn 
         "inspect" => Some(Box::new(inspect::InspectOrchestration::new(params))),
         "read-markdown" => Some(Box::new(read_markdown::ReadMarkdownOrchestration::new(
             params,
+            context.clone(),
         ))),
         "report" => Some(Box::new(report::ReportOrchestration::new(params))),
         "screenshot" => Some(Box::new(screenshot::ScreenshotOrchestration::new(params))),

--- a/rust/crates/host/src/host_impl/orchestrate/read_markdown.rs
+++ b/rust/crates/host/src/host_impl/orchestrate/read_markdown.rs
@@ -1,11 +1,15 @@
 use html_to_markdown_rs::{convert, ConversionOptions, PreprocessingOptions};
 use serde_json::{Map, Value};
 
+use crate::host_impl::page_cache::{OpenTabCacheKey, PageCache, PageCacheEntry, PageCacheLookup};
+use crate::host_impl::protocol::{log_line, now_ms};
+
 use super::report::is_non_scriptable;
 use super::scope::select_tabs_by_scope;
-use super::OrchStep;
+use super::{OrchStep, OrchestrationContext};
 
 const STATUS_READ: &str = "READ";
+const STATUS_CACHED: &str = "CACHED";
 const STATUS_EMPTY: &str = "EMPTY";
 const STATUS_UNSUPPORTED_URL: &str = "UNSUPPORTED_URL";
 const STATUS_NOT_LOADED: &str = "NOT_LOADED";
@@ -13,11 +17,13 @@ const STATUS_INJECTION_FAILED: &str = "INJECTION_FAILED";
 const STATUS_EXTRACTION_FAILED: &str = "EXTRACTION_FAILED";
 const STATUS_TIMED_OUT: &str = "TIMED_OUT";
 const STATUS_PROTECTED: &str = "PROTECTED";
+const MAX_HTML_CHARS_PER_READ: i64 = 1_500_000;
 
 #[derive(Debug)]
 pub(crate) struct ReadMarkdownOrchestration {
     params: Value,
     state: Option<ReadMarkdownState>,
+    context: OrchestrationContext,
 }
 
 #[derive(Debug)]
@@ -28,6 +34,7 @@ struct ReadMarkdownState {
     tasks: usize,
     results: Vec<Value>,
     options: ReadMarkdownOptions,
+    cache: Option<PageCache>,
 }
 
 #[derive(Debug, Clone)]
@@ -36,6 +43,7 @@ struct ReadMarkdownTab {
     window_id: i64,
     url: String,
     title: Option<String>,
+    incognito: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -47,10 +55,11 @@ struct ReadMarkdownOptions {
 }
 
 impl ReadMarkdownOrchestration {
-    pub(crate) fn new(params: &Value) -> Self {
+    pub(crate) fn new(params: &Value, context: OrchestrationContext) -> Self {
         Self {
             params: params.clone(),
             state: None,
+            context,
         }
     }
 }
@@ -89,10 +98,18 @@ impl ReadMarkdownOrchestration {
                 window_id: t.window_id,
                 url: t.url.clone().unwrap_or_default(),
                 title: t.title.clone(),
+                incognito: t.incognito,
             })
             .collect();
 
+        let mut cache = self.context.page_cache_path.as_deref().map(PageCache::load);
+        if let Some(cache) = cache.as_mut() {
+            let open_tabs = open_cache_keys_from_snapshot(&snapshot);
+            cache.prune_to_open_tabs(self.context.profile_name.as_deref(), &open_tabs);
+        }
+
         if tabs.is_empty() {
+            self.save_cache_if_dirty(cache.as_mut());
             return OrchStep::Complete {
                 response: serde_json::json!({
                     "totals": { "tabs": 0, "tasks": 0 },
@@ -120,6 +137,7 @@ impl ReadMarkdownOrchestration {
             tasks: 0,
             results: Vec::new(),
             options,
+            cache,
         });
 
         self.next_step()
@@ -134,9 +152,31 @@ impl ReadMarkdownOrchestration {
             };
         };
         let tab = state.tabs[in_flight_index].clone();
-        state
-            .results
-            .push(build_result_entry(&tab, &state.options, Some(&response)));
+        let entry = build_result_entry(&tab, &state.options, Some(&response));
+        if entry["status"] == STATUS_READ {
+            maybe_store_success(
+                state.cache.as_mut(),
+                self.context.profile_name.as_deref(),
+                &tab,
+                &response,
+            );
+            state.results.push(entry);
+        } else if let Some(cached) = eligible_cache_fallback(
+            &tab,
+            &response,
+            state.cache.as_ref(),
+            self.context.profile_name.as_deref(),
+        ) {
+            state.results.push(build_cached_entry(
+                &tab,
+                &state.options,
+                &cached.entry,
+                cached.match_mode.as_str(),
+                now_ms() as i64,
+            ));
+        } else {
+            state.results.push(entry);
+        }
         self.next_step()
     }
 
@@ -167,14 +207,31 @@ impl ReadMarkdownOrchestration {
         }
     }
 
-    fn complete(&self) -> OrchStep {
-        let state = self.state.as_ref().unwrap();
+    fn complete(&mut self) -> OrchStep {
+        let (tabs_len, tasks, results, mut cache) = {
+            let state = self.state.as_mut().unwrap();
+            (
+                state.tabs.len(),
+                state.tasks,
+                state.results.clone(),
+                state.cache.take(),
+            )
+        };
+        self.save_cache_if_dirty(cache.as_mut());
         OrchStep::Complete {
             response: serde_json::json!({
-                "totals": { "tabs": state.tabs.len(), "tasks": state.tasks },
-                "entries": state.results,
+                "totals": { "tabs": tabs_len, "tasks": tasks },
+                "entries": results,
             }),
             undo: None,
+        }
+    }
+
+    fn save_cache_if_dirty(&self, cache: Option<&mut PageCache>) {
+        if let (Some(path), Some(cache)) = (&self.context.page_cache_path, cache) {
+            if let Err(err) = cache.save_if_dirty(path) {
+                log_line(&format!("readTabs page cache save failed: {err}"));
+            }
         }
     }
 }
@@ -182,6 +239,7 @@ impl ReadMarkdownOrchestration {
 fn build_page_html_params(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) -> Value {
     let mut p = serde_json::json!({
         "tabId": tab.tab_id,
+        "expectedUrl": tab.url,
     });
     if let Some(v) = options.max_html_chars {
         p["maxHtmlChars"] = v.into();
@@ -190,6 +248,40 @@ fn build_page_html_params(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) 
         p["timeoutMs"] = v.into();
     }
     p
+}
+
+fn open_cache_keys_from_snapshot(snapshot: &Value) -> Vec<OpenTabCacheKey> {
+    let mut keys = Vec::new();
+    for window in snapshot
+        .get("windows")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let window_incognito = window
+            .get("incognito")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        for tab in window
+            .get("tabs")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let tab_id = tab.get("tabId").and_then(Value::as_i64);
+            let url = tab.get("url").and_then(Value::as_str);
+            let incognito = tab
+                .get("incognito")
+                .and_then(Value::as_bool)
+                .unwrap_or(window_incognito);
+            if let (Some(tab_id), Some(url)) = (tab_id, url) {
+                if !incognito && !url.is_empty() && !is_non_scriptable(url) {
+                    keys.push(OpenTabCacheKey::new(tab_id, url));
+                }
+            }
+        }
+    }
+    keys
 }
 
 fn build_unsupported_entry(tab: &ReadMarkdownTab, options: &ReadMarkdownOptions) -> Value {
@@ -418,6 +510,27 @@ fn diagnostics(
         "sourceTextChars": source_text_chars,
         "documentReadyState": document_ready_state,
         "truncatedHtml": truncated_html,
+        "source": "live",
+        "cachedAt": null,
+        "cacheAgeMs": null,
+    })
+}
+
+fn cache_diagnostics_with_truncation(
+    entry: &PageCacheEntry,
+    cache_match: &str,
+    now: i64,
+    truncated_html: bool,
+) -> Value {
+    serde_json::json!({
+        "sourceHtmlChars": entry.source_html_chars,
+        "sourceTextChars": entry.source_text_chars,
+        "documentReadyState": entry.document_ready_state,
+        "truncatedHtml": truncated_html,
+        "source": "cache",
+        "cachedAt": entry.captured_at,
+        "cacheAgeMs": now.saturating_sub(entry.captured_at),
+        "cacheMatch": cache_match,
     })
 }
 
@@ -443,16 +556,144 @@ fn base_entry(
         "truncated": truncated,
         "extracted": options.extract,
         "status": status,
+        "cached": status == STATUS_CACHED,
         "emptyReason": empty_reason,
         "diagnostics": diagnostics,
         "error": error,
     })
 }
 
+fn maybe_store_success(
+    cache: Option<&mut PageCache>,
+    profile: Option<&str>,
+    tab: &ReadMarkdownTab,
+    response: &Value,
+) {
+    let Some(cache) = cache else {
+        return;
+    };
+    let html = response.get("html").and_then(Value::as_str).unwrap_or("");
+    let source_html_chars = response
+        .get("sourceHtmlChars")
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| html.chars().count() as i64);
+    let source_text_chars = response
+        .get("sourceTextChars")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let document_ready_state = response.get("documentReadyState").and_then(Value::as_str);
+    let truncated_html = response
+        .get("truncatedHtml")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    cache.store_success(
+        profile,
+        tab.tab_id,
+        &tab.url,
+        tab.title.as_deref(),
+        html,
+        source_html_chars,
+        source_text_chars,
+        document_ready_state,
+        truncated_html,
+        tab.incognito,
+        now_ms() as i64,
+    );
+}
+
+fn eligible_cache_fallback(
+    tab: &ReadMarkdownTab,
+    response: &Value,
+    cache: Option<&PageCache>,
+    profile: Option<&str>,
+) -> Option<PageCacheLookup> {
+    if tab.incognito || is_non_scriptable(&tab.url) {
+        return None;
+    }
+    let status = response.get("status").and_then(Value::as_str)?;
+    if !matches!(
+        status,
+        STATUS_PROTECTED
+            | STATUS_TIMED_OUT
+            | STATUS_NOT_LOADED
+            | STATUS_INJECTION_FAILED
+            | STATUS_EXTRACTION_FAILED
+    ) {
+        return None;
+    }
+    cache?.lookup_open_tab(profile, tab.tab_id, &tab.url)
+}
+
+fn build_cached_entry(
+    tab: &ReadMarkdownTab,
+    options: &ReadMarkdownOptions,
+    cached: &PageCacheEntry,
+    cache_match: &str,
+    now: i64,
+) -> Value {
+    let (html, truncated_html_for_request) =
+        truncate_cached_html_for_request(&cached.html, options.max_html_chars);
+    let conversion = convert(&html, Some(conversion_options(options.extract)));
+    let full_markdown = match conversion {
+        Ok(result) => result.content.unwrap_or_default(),
+        Err(_) => return build_result_entry(tab, options, None),
+    };
+    let (markdown, chars, truncated) = truncate_markdown(&full_markdown, options.max_chars);
+    if markdown.trim().is_empty() {
+        return build_result_entry(tab, options, None);
+    }
+    base_entry(
+        tab,
+        options,
+        STATUS_CACHED,
+        &markdown,
+        chars,
+        truncated,
+        None,
+        None,
+        cache_diagnostics_with_truncation(cached, cache_match, now, truncated_html_for_request),
+    )
+}
+
+fn truncate_cached_html_for_request(html: &str, max_html_chars: Option<i64>) -> (String, bool) {
+    let Some(max_html_chars) = max_html_chars else {
+        return (html.to_string(), false);
+    };
+    let max_html_chars = max_html_chars.clamp(1, MAX_HTML_CHARS_PER_READ) as usize;
+    let total_chars = html.chars().count();
+    if total_chars > max_html_chars {
+        (html.chars().take(max_html_chars).collect(), true)
+    } else {
+        (html.to_string(), false)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::host_impl::orchestrate::Orchestration;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn cache_path(name: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("read-markdown-cache-tests")
+            .join(format!("{}-{}-{}", name, std::process::id(), id));
+        let _ = std::fs::remove_dir_all(&path);
+        path
+    }
+
+    fn context_with_cache(path: PathBuf) -> OrchestrationContext {
+        OrchestrationContext {
+            page_cache_path: Some(path),
+            profile_name: Some("test-profile".to_string()),
+        }
+    }
 
     fn snapshot_with(tabs: Vec<Value>) -> Value {
         serde_json::json!({
@@ -472,10 +713,21 @@ mod tests {
         })
     }
 
+    fn status_response(status: &str) -> Value {
+        serde_json::json!({
+            "status": status,
+            "error": null,
+            "sourceHtmlChars": 0,
+            "sourceTextChars": 0,
+            "documentReadyState": null,
+            "truncatedHtml": false
+        })
+    }
+
     #[test]
     fn read_markdown_empty_scope() {
         let params = serde_json::json!({"windowId": 999});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let step = orch.step(snapshot_with(vec![]));
         let OrchStep::Complete { response, .. } = step else {
@@ -486,9 +738,46 @@ mod tests {
     }
 
     #[test]
+    fn empty_scope_still_prunes_cache_to_snapshot() {
+        let path = cache_path("empty-scope-prunes");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://closed.example",
+            None,
+            "<p>Closed</p>",
+            13,
+            6,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch = ReadMarkdownOrchestration::new(
+            &serde_json::json!({"windowId": 999}),
+            context_with_cache(path.clone()),
+        );
+        let _ = orch.start();
+        let step = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 2, "windowId": 100, "url": "https://open.example", "title": "Open", "groupId": -1}),
+        ]));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["totals"]["tabs"], 0);
+        let cache = PageCache::load(&path);
+        assert!(cache
+            .lookup_open_tab(Some("test-profile"), 1, "https://closed.example")
+            .is_none());
+    }
+
+    #[test]
     fn read_markdown_single_tab() {
         let params = serde_json::json!({"extract": true, "maxChars": 10000});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let snap = snapshot_with(vec![
             serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
@@ -499,6 +788,7 @@ mod tests {
         };
         assert_eq!(action, "p:page-html");
         assert_eq!(params["tabId"], 1);
+        assert_eq!(params["expectedUrl"], "https://a.com");
         assert_eq!(params["maxChars"], Value::Null);
 
         let step = orch.step(html_response("<h1>Hello</h1><p>World.</p>", 12));
@@ -509,14 +799,501 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["tabId"], 1);
         assert_eq!(entries[0]["status"], STATUS_READ);
+        assert_eq!(entries[0]["cached"], false);
+        assert_eq!(entries[0]["diagnostics"]["source"], "live");
         assert!(entries[0]["markdown"].as_str().unwrap().contains("Hello"));
         assert_eq!(entries[0]["truncated"], false);
     }
 
     #[test]
+    fn live_read_writes_cache_and_live_provenance() {
+        let path = cache_path("live-write");
+        let params = serde_json::json!({});
+        let mut orch = ReadMarkdownOrchestration::new(&params, context_with_cache(path.clone()));
+        let _ = orch.start();
+        let snap = snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com/page#frag", "title": "A", "groupId": -1}),
+        ]);
+        let _ = orch.step(snap);
+        let step = orch.step(html_response("<h1>Cached</h1>", 6));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_READ);
+        assert_eq!(response["entries"][0]["cached"], false);
+        assert_eq!(response["entries"][0]["diagnostics"]["source"], "live");
+        assert!(path.exists());
+
+        let cache = PageCache::load(&path);
+        assert!(cache
+            .lookup_open_tab(Some("test-profile"), 1, "https://a.com/page#frag")
+            .is_some());
+    }
+
+    #[test]
+    fn protected_failure_falls_back_to_cache() {
+        let path = cache_path("protected-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com",
+            Some("A"),
+            "<h1>Cached body</h1>",
+            20,
+            11,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_PROTECTED));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["status"], STATUS_CACHED);
+        assert_eq!(entry["cached"], true);
+        assert_eq!(entry["error"], Value::Null);
+        assert_eq!(entry["emptyReason"], Value::Null);
+        assert_eq!(entry["diagnostics"]["source"], "cache");
+        assert_eq!(entry["diagnostics"]["cacheMatch"], "exact");
+        assert_eq!(entry["diagnostics"]["cachedAt"], 1000);
+        assert_eq!(entry["diagnostics"]["sourceHtmlChars"], 20);
+    }
+
+    #[test]
+    fn cached_fallback_reports_duplicate_exact_match() {
+        let path = cache_path("duplicate-exact-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com/page?q=1#frag",
+            Some("A"),
+            "<h1>Cached duplicate</h1>",
+            25,
+            16,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 2, "windowId": 100, "url": "https://a.com/page?q=1#frag", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_PROTECTED));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["status"], STATUS_CACHED);
+        assert_eq!(entry["diagnostics"]["cacheMatch"], "duplicateExact");
+    }
+
+    #[test]
+    fn cached_fallback_reports_canonical_match() {
+        let path = cache_path("canonical-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com/page?q=1#old",
+            Some("A"),
+            "<h1>Cached canonical</h1>",
+            25,
+            16,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com/page?q=1#new", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_PROTECTED));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["status"], STATUS_CACHED);
+        assert_eq!(entry["diagnostics"]["cacheMatch"], "canonical");
+    }
+
+    #[test]
+    fn cached_fallback_respects_current_max_html_chars() {
+        let path = cache_path("cached-max-html");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com",
+            Some("A"),
+            "<h1>First</h1><p>Second</p>",
+            27,
+            11,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch = ReadMarkdownOrchestration::new(
+            &serde_json::json!({"maxHtmlChars": 14}),
+            context_with_cache(path),
+        );
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_PROTECTED));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        let entry = &response["entries"][0];
+        assert_eq!(entry["status"], STATUS_CACHED);
+        assert_eq!(entry["diagnostics"]["truncatedHtml"], true);
+        let markdown = entry["markdown"].as_str().unwrap();
+        assert!(markdown.contains("First"));
+        assert!(!markdown.contains("Second"));
+    }
+
+    #[test]
+    fn timed_out_failure_falls_back_to_cache() {
+        let path = cache_path("timeout-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com",
+            None,
+            "<p>Stale ok</p>",
+            15,
+            8,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_TIMED_OUT));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_CACHED);
+    }
+
+    #[test]
+    fn no_fallback_without_cache() {
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), OrchestrationContext::default());
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_PROTECTED));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_PROTECTED);
+        assert_eq!(response["entries"][0]["cached"], false);
+    }
+
+    #[test]
+    fn url_mismatch_does_not_fallback_to_cache() {
+        let path = cache_path("url-mismatch-no-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com",
+            None,
+            "<p>Cached</p>",
+            13,
+            6,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response("URL_MISMATCH"));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_EXTRACTION_FAILED);
+        assert_eq!(response["entries"][0]["cached"], false);
+    }
+
+    #[test]
+    fn unsupported_url_does_not_fallback() {
+        let path = cache_path("unsupported-no-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "chrome://settings",
+            None,
+            "<p>Never</p>",
+            12,
+            5,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let step = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "chrome://settings", "title": "Settings", "groupId": -1}),
+        ]));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_UNSUPPORTED_URL);
+        assert_eq!(response["entries"][0]["cached"], false);
+        assert_eq!(response["totals"]["tasks"], 0);
+    }
+
+    #[test]
+    fn incognito_neither_reads_nor_writes_cache() {
+        let path = cache_path("incognito-no-write");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com",
+            None,
+            "<h1>Cached secret</h1>",
+            22,
+            13,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch = ReadMarkdownOrchestration::new(
+            &serde_json::json!({}),
+            context_with_cache(path.clone()),
+        );
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "incognito": true, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(html_response("<h1>Secret</h1>", 6));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_READ);
+        assert_eq!(response["entries"][0]["cached"], false);
+        let cache = PageCache::load(&path);
+        assert!(cache
+            .lookup_open_tab(Some("test-profile"), 1, "https://a.com")
+            .is_none());
+    }
+
+    #[test]
+    fn incognito_failure_does_not_fallback_to_cache() {
+        let path = cache_path("incognito-no-fallback");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com",
+            None,
+            "<h1>Cached secret</h1>",
+            22,
+            13,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "incognito": true, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let step = orch.step(status_response(STATUS_PROTECTED));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_PROTECTED);
+        assert_eq!(response["entries"][0]["cached"], false);
+    }
+
+    #[test]
+    fn truncated_html_is_not_cached() {
+        let path = cache_path("truncated-no-cache");
+        let mut response = html_response("<h1>Cut</h1>", 3);
+        response["truncatedHtml"] = true.into();
+        let mut orch = ReadMarkdownOrchestration::new(
+            &serde_json::json!({}),
+            context_with_cache(path.clone()),
+        );
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+        let _ = orch.step(response);
+        let cache = PageCache::load(&path);
+        assert!(cache
+            .lookup_open_tab(Some("test-profile"), 1, "https://a.com")
+            .is_none());
+    }
+
+    #[test]
+    fn cache_is_pruned_to_open_current_urls() {
+        let path = cache_path("prune-open");
+        let mut cache = PageCache::default();
+        cache.store_success(
+            Some("test-profile"),
+            1,
+            "https://a.com/old",
+            None,
+            "<p>Old</p>",
+            10,
+            3,
+            Some("complete"),
+            false,
+            false,
+            1000,
+        );
+        cache.store_success(
+            Some("test-profile"),
+            2,
+            "https://b.com",
+            None,
+            "<p>Keep</p>",
+            11,
+            4,
+            Some("complete"),
+            false,
+            false,
+            1001,
+        );
+        cache.save_if_dirty(&path).unwrap();
+
+        let mut orch = ReadMarkdownOrchestration::new(
+            &serde_json::json!({"tabIds": [2]}),
+            context_with_cache(path.clone()),
+        );
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com/new", "title": "A", "groupId": -1}),
+            serde_json::json!({"tabId": 2, "windowId": 100, "url": "https://b.com", "title": "B", "groupId": -1}),
+        ]));
+        let _ = orch.step(status_response(STATUS_TIMED_OUT));
+
+        let cache = PageCache::load(&path);
+        assert!(cache
+            .lookup_open_tab(Some("test-profile"), 1, "https://a.com/old")
+            .is_none());
+        assert!(cache
+            .lookup_open_tab(Some("test-profile"), 2, "https://b.com")
+            .is_some());
+    }
+
+    #[test]
+    fn cache_is_saved_only_when_dirty_read_completes() {
+        let path = cache_path("save-on-complete");
+        let mut orch = ReadMarkdownOrchestration::new(
+            &serde_json::json!({}),
+            context_with_cache(path.clone()),
+        );
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+            serde_json::json!({"tabId": 2, "windowId": 100, "url": "https://b.com", "title": "B", "groupId": -1}),
+        ]));
+
+        let step = orch.step(html_response("<p>A</p>", 1));
+        assert!(matches!(step, OrchStep::SendPrimitive { .. }));
+        assert!(
+            !path.exists(),
+            "cache should not be persisted until all readTabs work completes"
+        );
+
+        let step = orch.step(html_response("<p>B</p>", 1));
+        assert!(matches!(step, OrchStep::Complete { .. }));
+        assert!(
+            path.exists(),
+            "dirty cache should be persisted on completion"
+        );
+        assert!(PageCache::load(&path)
+            .lookup_open_tab(Some("test-profile"), 1, "https://a.com")
+            .is_some());
+        assert!(PageCache::load(&path)
+            .lookup_open_tab(Some("test-profile"), 2, "https://b.com")
+            .is_some());
+    }
+
+    #[test]
+    fn cache_save_failure_does_not_fail_live_read() {
+        let path = cache_path("save-failure-nonfatal");
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, b"not-a-directory").unwrap();
+        let mut orch =
+            ReadMarkdownOrchestration::new(&serde_json::json!({}), context_with_cache(path));
+        let _ = orch.start();
+        let _ = orch.step(snapshot_with(vec![
+            serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
+        ]));
+
+        let step = orch.step(html_response("<h1>Hello</h1>", 5));
+        let OrchStep::Complete { response, .. } = step else {
+            panic!("expected Complete despite cache save failure")
+        };
+        assert_eq!(response["entries"][0]["status"], STATUS_READ);
+        assert_eq!(response["entries"][0]["cached"], false);
+    }
+
+    #[test]
     fn read_markdown_multiple_tabs_preserves_order() {
         let params = serde_json::json!({});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let snap = snapshot_with(vec![
             serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
@@ -545,7 +1322,7 @@ mod tests {
     #[test]
     fn read_markdown_null_response_becomes_error_entry() {
         let params = serde_json::json!({});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let snap = snapshot_with(vec![
             serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
@@ -564,7 +1341,7 @@ mod tests {
     #[test]
     fn read_markdown_keeps_non_scriptable_tabs_as_unsupported_entries() {
         let params = serde_json::json!({});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let snap = snapshot_with(vec![
             serde_json::json!({"tabId": 1, "windowId": 100, "url": "chrome://settings", "title": "Settings", "groupId": -1}),
@@ -589,7 +1366,7 @@ mod tests {
     #[test]
     fn read_markdown_empty_conversion_is_not_success() {
         let params = serde_json::json!({});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let snap = snapshot_with(vec![
             serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),
@@ -611,7 +1388,7 @@ mod tests {
     #[test]
     fn read_markdown_timeout_status_is_preserved() {
         let params = serde_json::json!({});
-        let mut orch = ReadMarkdownOrchestration::new(&params);
+        let mut orch = ReadMarkdownOrchestration::new(&params, OrchestrationContext::default());
         let _ = orch.start();
         let snap = snapshot_with(vec![
             serde_json::json!({"tabId": 1, "windowId": 100, "url": "https://a.com", "title": "A", "groupId": -1}),

--- a/rust/crates/host/src/host_impl/page_cache.rs
+++ b/rust/crates/host/src/host_impl/page_cache.rs
@@ -179,6 +179,14 @@ impl PageCache {
             })
     }
 
+    pub(crate) fn has_exact_open_tab(&self, profile: Option<&str>, tab_id: i64, url: &str) -> bool {
+        self.entries.contains_key(&CacheKey {
+            profile: profile_key(profile),
+            tab_id,
+            url_key: url_key(url),
+        })
+    }
+
     #[cfg(test)]
     fn lookup_exact_open_tab(
         &self,

--- a/rust/crates/host/src/host_impl/page_cache.rs
+++ b/rust/crates/host/src/host_impl/page_cache.rs
@@ -1,0 +1,1013 @@
+//! Per-tab HTML snapshot cache.
+//!
+//! The cache is strictly profile-isolated and stores successful, non-incognito,
+//! non-truncated HTML snapshots as one private file per `(profile, tab_id, url)`
+//! entry under the active profile data directory. Full URLs, including fragments,
+//! are the exact cache key; each entry also records a canonical URL with only the
+//! fragment stripped. Lookups prefer the exact tab and URL, then the latest
+//! duplicate/restored tab for the exact URL, then the latest canonical URL match.
+//! Callers prune after each browser snapshot, and corrupted cache files are ignored.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+const MAX_HTML_CHARS_PER_ENTRY: usize = 1_500_000;
+const MAX_ENTRIES: usize = 250;
+const MAX_TOTAL_HTML_BYTES: usize = 128 * 1024 * 1024;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    profile: String,
+    tab_id: i64,
+    url_key: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct OpenTabCacheKey {
+    pub(crate) tab_id: i64,
+    pub(crate) url: String,
+}
+
+impl OpenTabCacheKey {
+    pub(crate) fn new(tab_id: i64, url: impl Into<String>) -> Self {
+        Self {
+            tab_id,
+            url: url.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PageCacheEntry {
+    pub(crate) profile: String,
+    pub(crate) tab_id: i64,
+    pub(crate) url_key: String,
+    #[serde(default)]
+    pub(crate) canonical_url_key: String,
+    pub(crate) title: Option<String>,
+    pub(crate) html: String,
+    pub(crate) source_html_chars: i64,
+    pub(crate) source_text_chars: i64,
+    pub(crate) document_ready_state: Option<String>,
+    pub(crate) captured_at: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PageCacheMatchMode {
+    Exact,
+    DuplicateExact,
+    Canonical,
+}
+
+impl PageCacheMatchMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::DuplicateExact => "duplicateExact",
+            Self::Canonical => "canonical",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PageCacheLookup {
+    pub(crate) entry: PageCacheEntry,
+    pub(crate) match_mode: PageCacheMatchMode,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PageCache {
+    entries: HashMap<CacheKey, PageCacheEntry>,
+    dirty: bool,
+    stale_files: HashSet<PathBuf>,
+}
+
+impl PageCache {
+    pub(crate) fn load(path: &Path) -> Self {
+        let Ok(entries) = fs::read_dir(path) else {
+            return Self::default();
+        };
+
+        let mut cache = Self::default();
+        for dir_entry in entries.filter_map(Result::ok) {
+            let file_path = dir_entry.path();
+            if file_path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let Ok(bytes) = fs::read(&file_path) else {
+                cache.stale_files.insert(file_path);
+                cache.dirty = true;
+                continue;
+            };
+            let Ok(mut entry) = serde_json::from_slice::<PageCacheEntry>(&bytes) else {
+                cache.stale_files.insert(file_path);
+                cache.dirty = true;
+                continue;
+            };
+            if entry.html.is_empty() || entry.html.chars().count() > MAX_HTML_CHARS_PER_ENTRY {
+                cache.stale_files.insert(file_path);
+                cache.dirty = true;
+                continue;
+            };
+            let canonical_url_key = canonical_url_key(&entry.url_key);
+            if entry.canonical_url_key != canonical_url_key {
+                entry.canonical_url_key = canonical_url_key;
+                cache.dirty = true;
+            }
+            cache.entries.insert(
+                CacheKey {
+                    profile: entry.profile.clone(),
+                    tab_id: entry.tab_id,
+                    url_key: entry.url_key.clone(),
+                },
+                entry,
+            );
+        }
+        cache.enforce_caps();
+        cache
+    }
+
+    pub(crate) fn lookup_open_tab(
+        &self,
+        profile: Option<&str>,
+        tab_id: i64,
+        url: &str,
+    ) -> Option<PageCacheLookup> {
+        let profile = profile_key(profile);
+        let url_key = url_key(url);
+        if let Some(entry) = self.entries.get(&CacheKey {
+            profile: profile.clone(),
+            tab_id,
+            url_key: url_key.clone(),
+        }) {
+            return Some(PageCacheLookup {
+                entry: entry.clone(),
+                match_mode: PageCacheMatchMode::Exact,
+            });
+        }
+
+        if let Some(entry) = self
+            .entries
+            .values()
+            .filter(|entry| entry.profile == profile && entry.url_key == url_key)
+            .max_by_key(|entry| entry.captured_at)
+        {
+            return Some(PageCacheLookup {
+                entry: entry.clone(),
+                match_mode: PageCacheMatchMode::DuplicateExact,
+            });
+        }
+
+        let canonical_url_key = canonical_url_key(url);
+        self.entries
+            .values()
+            .filter(|entry| {
+                entry.profile == profile && entry.canonical_url_key == canonical_url_key
+            })
+            .max_by_key(|entry| entry.captured_at)
+            .map(|entry| PageCacheLookup {
+                entry: entry.clone(),
+                match_mode: PageCacheMatchMode::Canonical,
+            })
+    }
+
+    #[cfg(test)]
+    fn lookup_exact_open_tab(
+        &self,
+        profile: Option<&str>,
+        tab_id: i64,
+        url: &str,
+    ) -> Option<PageCacheEntry> {
+        self.entries
+            .get(&CacheKey {
+                profile: profile_key(profile),
+                tab_id,
+                url_key: url_key(url),
+            })
+            .cloned()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn store_success(
+        &mut self,
+        profile: Option<&str>,
+        tab_id: i64,
+        url: &str,
+        title: Option<&str>,
+        html: &str,
+        source_html_chars: i64,
+        source_text_chars: i64,
+        document_ready_state: Option<&str>,
+        truncated_html: bool,
+        incognito: bool,
+        captured_at: i64,
+    ) {
+        if incognito
+            || truncated_html
+            || html.is_empty()
+            || html.chars().count() > MAX_HTML_CHARS_PER_ENTRY
+        {
+            return;
+        }
+
+        let profile = profile_key(profile);
+        let url_key = url_key(url);
+        let canonical_url_key = canonical_url_key(url);
+        let key = CacheKey {
+            profile: profile.clone(),
+            tab_id,
+            url_key: url_key.clone(),
+        };
+        self.entries.insert(
+            key,
+            PageCacheEntry {
+                profile,
+                tab_id,
+                url_key,
+                canonical_url_key,
+                title: title.map(str::to_string),
+                html: html.to_string(),
+                source_html_chars,
+                source_text_chars,
+                document_ready_state: document_ready_state.map(str::to_string),
+                captured_at,
+            },
+        );
+        self.dirty = true;
+        self.enforce_caps();
+    }
+
+    pub(crate) fn prune_to_open_tabs(
+        &mut self,
+        profile: Option<&str>,
+        open_tabs: &[OpenTabCacheKey],
+    ) {
+        let profile = profile_key(profile);
+        let open_exact_urls: HashSet<String> =
+            open_tabs.iter().map(|tab| url_key(&tab.url)).collect();
+        let open_canonical_urls: HashSet<String> = open_tabs
+            .iter()
+            .map(|tab| canonical_url_key(&tab.url))
+            .collect();
+        let before = self.entries.len();
+        self.entries.retain(|key, entry| {
+            key.profile != profile
+                || open_exact_urls.contains(&entry.url_key)
+                || open_canonical_urls.contains(&entry.canonical_url_key)
+        });
+        if self.entries.len() != before {
+            self.dirty = true;
+        }
+    }
+
+    pub(crate) fn save_if_dirty(&mut self, path: &Path) -> Result<(), String> {
+        if !self.dirty {
+            return Ok(());
+        }
+        fs::create_dir_all(path).map_err(|err| format!("create page cache directory: {err}"))?;
+        set_private_dir_permissions(path)?;
+
+        for stale_file in self.stale_files.drain() {
+            let _ = fs::remove_file(stale_file);
+        }
+
+        let expected_files: HashSet<PathBuf> = self
+            .entries
+            .values()
+            .map(|entry| cache_file_path(path, entry))
+            .collect();
+        if let Ok(existing) = fs::read_dir(path) {
+            for file_path in existing
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+            {
+                if !expected_files.contains(&file_path) {
+                    let _ = fs::remove_file(file_path);
+                }
+            }
+        }
+
+        let mut entries: Vec<_> = self.entries.values().cloned().collect();
+        entries.sort_by_key(|entry| (entry.captured_at, entry.profile.clone(), entry.tab_id));
+        for entry in entries {
+            let file_path = cache_file_path(path, &entry);
+            let tmp_path = file_path.with_extension(format!(
+                "json.tmp.{}.{}",
+                std::process::id(),
+                crate::host_impl::protocol::now_ms()
+            ));
+            let bytes = serde_json::to_vec_pretty(&entry)
+                .map_err(|err| format!("serialize page cache: {err}"))?;
+            write_private_file(&tmp_path, &bytes).map_err(|err| {
+                let _ = fs::remove_file(&tmp_path);
+                err
+            })?;
+            fs::rename(&tmp_path, &file_path).map_err(|err| {
+                let _ = fs::remove_file(&tmp_path);
+                format!("replace page cache: {err}")
+            })?;
+            set_private_file_permissions(&file_path)?;
+        }
+        self.dirty = false;
+        Ok(())
+    }
+
+    fn enforce_caps(&mut self) {
+        let mut entries: Vec<_> = self.entries.values().cloned().collect();
+        entries.sort_by_key(|entry| entry.captured_at);
+
+        let mut keep = HashSet::new();
+        let mut total_bytes = 0usize;
+        for entry in entries.into_iter().rev() {
+            let html_bytes = entry.html.len();
+            if keep.len() >= MAX_ENTRIES
+                || total_bytes.saturating_add(html_bytes) > MAX_TOTAL_HTML_BYTES
+            {
+                self.dirty = true;
+                continue;
+            }
+
+            total_bytes += html_bytes;
+            keep.insert(CacheKey {
+                profile: entry.profile,
+                tab_id: entry.tab_id,
+                url_key: entry.url_key,
+            });
+        }
+        let before = self.entries.len();
+        self.entries.retain(|key, _| keep.contains(key));
+        if self.entries.len() != before {
+            self.dirty = true;
+        }
+    }
+}
+
+fn cache_file_path(dir: &Path, entry: &PageCacheEntry) -> PathBuf {
+    dir.join(format!(
+        "tab-{}-{}.json",
+        entry.tab_id,
+        cache_file_hash(&entry.profile, entry.tab_id, &entry.url_key)
+    ))
+}
+
+fn cache_file_hash(profile: &str, tab_id: i64, url_key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(profile.as_bytes());
+    hasher.update([0]);
+    hasher.update(tab_id.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(url_key.as_bytes());
+    let digest = hasher.finalize();
+    digest[..12]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn profile_key(profile: Option<&str>) -> String {
+    profile.unwrap_or_default().to_string()
+}
+
+fn url_key(url: &str) -> String {
+    url.to_string()
+}
+
+fn canonical_url_key(url: &str) -> String {
+    url.split_once('#')
+        .map(|(without_fragment, _)| without_fragment)
+        .unwrap_or(url)
+        .to_string()
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    #[cfg(unix)]
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|err| format!("create private page cache temp file: {err}"))?;
+
+    #[cfg(not(unix))]
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|err| format!("create page cache temp file: {err}"))?;
+
+    file.write_all(bytes)
+        .map_err(|err| format!("write page cache: {err}"))?;
+    file.sync_all()
+        .map_err(|err| format!("sync page cache: {err}"))
+}
+
+fn set_private_dir_permissions(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|err| format!("set page cache directory permissions: {err}"))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+fn set_private_file_permissions(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|err| format!("set page cache file permissions: {err}"))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn cache_path(name: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("page-cache-tests")
+            .join(format!("{}-{}-{}", name, std::process::id(), id));
+        let _ = fs::remove_dir_all(&path);
+        path
+    }
+
+    fn store(
+        cache: &mut PageCache,
+        profile: Option<&str>,
+        tab_id: i64,
+        url: &str,
+        html: &str,
+        captured_at: i64,
+    ) {
+        cache.store_success(
+            profile,
+            tab_id,
+            url,
+            Some("title"),
+            html,
+            html.chars().count() as i64,
+            4,
+            Some("complete"),
+            false,
+            false,
+            captured_at,
+        );
+    }
+
+    #[test]
+    fn write_read_same_profile_tab_url() {
+        let path = cache_path("roundtrip");
+        let mut cache = PageCache::load(&path);
+        store(
+            &mut cache,
+            Some("work"),
+            7,
+            "https://example.com/a?x=1",
+            "<html>ok</html>",
+            10,
+        );
+        cache.save_if_dirty(&path).expect("save cache");
+
+        let loaded = PageCache::load(&path);
+        let entry = loaded
+            .lookup_open_tab(Some("work"), 7, "https://example.com/a?x=1")
+            .expect("cached entry");
+        assert_eq!(entry.match_mode, PageCacheMatchMode::Exact);
+        assert_eq!(entry.entry.html, "<html>ok</html>");
+        assert_eq!(entry.entry.title.as_deref(), Some("title"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn saved_cache_file_and_directory_are_private() {
+        let path = cache_path("permissions");
+        let mut cache = PageCache::default();
+        store(&mut cache, Some("work"), 1, "https://example.com", "ok", 1);
+        cache.save_if_dirty(&path).expect("save cache");
+
+        let files: Vec<_> = fs::read_dir(&path)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .collect();
+        assert_eq!(files.len(), 1);
+        let file_mode = fs::metadata(&files[0]).unwrap().permissions().mode() & 0o777;
+        let dir_mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(file_mode, 0o600);
+        assert_eq!(dir_mode, 0o700);
+    }
+
+    #[test]
+    fn saved_cache_uses_one_bounded_private_file_per_entry() {
+        let path = cache_path("file-layout");
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work-secret"),
+            7,
+            "https://example.com/private/path?token=secret#one",
+            "one",
+            1,
+        );
+        store(
+            &mut cache,
+            Some("work-secret"),
+            7,
+            "https://example.com/private/path?token=secret#two",
+            "two",
+            2,
+        );
+        cache.save_if_dirty(&path).expect("save cache");
+
+        let mut file_names: Vec<_> = fs::read_dir(&path)
+            .expect("read cache dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        file_names.sort();
+
+        assert_eq!(file_names.len(), 2);
+        for name in file_names {
+            assert!(name.starts_with("tab-7-"), "{name}");
+            assert!(name.ends_with(".json"), "{name}");
+            assert!(name.len() <= 40, "{name}");
+            assert!(!name.contains("work-secret"), "{name}");
+            assert!(!name.contains("example.com"), "{name}");
+            assert!(!name.contains("secret"), "{name}");
+            assert!(!name.contains("private"), "{name}");
+        }
+    }
+
+    #[test]
+    fn profile_isolation() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work"),
+            1,
+            "https://example.com",
+            "work",
+            1,
+        );
+        store(
+            &mut cache,
+            Some("home"),
+            1,
+            "https://example.com",
+            "home",
+            2,
+        );
+        assert_eq!(
+            cache
+                .lookup_open_tab(Some("work"), 1, "https://example.com")
+                .unwrap()
+                .entry
+                .html,
+            "work"
+        );
+        assert_eq!(
+            cache
+                .lookup_open_tab(Some("home"), 1, "https://example.com")
+                .unwrap()
+                .entry
+                .html,
+            "home"
+        );
+        assert!(cache
+            .lookup_open_tab(None, 1, "https://example.com")
+            .is_none());
+    }
+
+    #[test]
+    fn query_string_separation() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            None,
+            1,
+            "https://example.com/item?id=1",
+            "one",
+            1,
+        );
+        store(
+            &mut cache,
+            None,
+            1,
+            "https://example.com/item?id=2",
+            "two",
+            2,
+        );
+        assert_eq!(
+            cache
+                .lookup_open_tab(None, 1, "https://example.com/item?id=1")
+                .unwrap()
+                .entry
+                .html,
+            "one"
+        );
+        assert_eq!(
+            cache
+                .lookup_open_tab(None, 1, "https://example.com/item?id=2")
+                .unwrap()
+                .entry
+                .html,
+            "two"
+        );
+        assert!(cache
+            .lookup_open_tab(None, 99, "https://example.com/item?id=3#other")
+            .is_none());
+    }
+
+    #[test]
+    fn exact_match_wins_over_canonical_match() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            None,
+            1,
+            "https://example.com/page?q=1#a",
+            "a",
+            1,
+        );
+        store(
+            &mut cache,
+            None,
+            1,
+            "https://example.com/page?q=1#b",
+            "b",
+            2,
+        );
+        let lookup = cache
+            .lookup_open_tab(None, 1, "https://example.com/page?q=1#a")
+            .unwrap();
+        assert_eq!(lookup.match_mode, PageCacheMatchMode::Exact);
+        assert_eq!(lookup.entry.html, "a");
+    }
+
+    #[test]
+    fn exact_match_wins_over_newer_duplicate_exact_match() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work"),
+            1,
+            "https://example.com/page?q=1",
+            "exact",
+            10,
+        );
+        store(
+            &mut cache,
+            Some("work"),
+            2,
+            "https://example.com/page?q=1",
+            "newer duplicate",
+            20,
+        );
+
+        let lookup = cache
+            .lookup_open_tab(Some("work"), 1, "https://example.com/page?q=1")
+            .unwrap();
+        assert_eq!(lookup.match_mode, PageCacheMatchMode::Exact);
+        assert_eq!(lookup.entry.tab_id, 1);
+        assert_eq!(lookup.entry.html, "exact");
+    }
+
+    #[test]
+    fn canonical_fallback_matches_fragment_drift() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            None,
+            1,
+            "https://example.com/page?q=1#a",
+            "a",
+            1,
+        );
+        let lookup = cache
+            .lookup_open_tab(None, 1, "https://example.com/page?q=1#b")
+            .unwrap();
+        assert_eq!(lookup.match_mode, PageCacheMatchMode::Canonical);
+        assert_eq!(lookup.entry.html, "a");
+        assert_eq!(
+            cache
+                .lookup_open_tab(None, 1, "https://example.com/page?q=1#a")
+                .unwrap()
+                .entry
+                .html,
+            "a"
+        );
+    }
+
+    #[test]
+    fn duplicate_urls_use_latest_matching_url_cache() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work"),
+            1,
+            "https://example.com/page?q=1",
+            "old",
+            10,
+        );
+        store(
+            &mut cache,
+            Some("work"),
+            2,
+            "https://example.com/page?q=1",
+            "new",
+            20,
+        );
+
+        let lookup = cache
+            .lookup_open_tab(Some("work"), 99, "https://example.com/page?q=1")
+            .expect("latest URL cache should survive tab id changes");
+        assert_eq!(lookup.match_mode, PageCacheMatchMode::DuplicateExact);
+        assert_eq!(lookup.entry.tab_id, 2);
+        assert_eq!(lookup.entry.html, "new");
+    }
+
+    #[test]
+    fn rejects_disallowed_writes() {
+        let mut cache = PageCache::default();
+        cache.store_success(
+            None,
+            1,
+            "https://a",
+            None,
+            "secret",
+            6,
+            1,
+            None,
+            false,
+            true,
+            1,
+        );
+        cache.store_success(None, 2, "https://a", None, "", 0, 0, None, false, false, 1);
+        cache.store_success(
+            None,
+            3,
+            "https://a",
+            None,
+            "abc",
+            3,
+            1,
+            None,
+            true,
+            false,
+            1,
+        );
+        let oversized = "x".repeat(MAX_HTML_CHARS_PER_ENTRY + 1);
+        cache.store_success(
+            None,
+            4,
+            "https://a",
+            None,
+            &oversized,
+            oversized.len() as i64,
+            1,
+            None,
+            false,
+            false,
+            1,
+        );
+        assert!(cache.entries.is_empty());
+    }
+
+    #[test]
+    fn prune_closed_tabs_and_url_changed_tabs() {
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("p"),
+            1,
+            "https://example.com/a?x=1",
+            "keep",
+            1,
+        );
+        store(
+            &mut cache,
+            Some("p"),
+            2,
+            "https://example.com/b",
+            "closed",
+            2,
+        );
+        store(
+            &mut cache,
+            Some("p"),
+            3,
+            "https://example.com/old",
+            "changed",
+            3,
+        );
+        store(
+            &mut cache,
+            Some("p"),
+            4,
+            "https://example.com/fragment#old",
+            "canonical",
+            4,
+        );
+        store(
+            &mut cache,
+            Some("p"),
+            5,
+            "https://example.com/unrelated#old",
+            "unrelated",
+            5,
+        );
+        store(
+            &mut cache,
+            Some("other"),
+            2,
+            "https://example.com/b",
+            "other",
+            4,
+        );
+
+        cache.prune_to_open_tabs(
+            Some("p"),
+            &[
+                OpenTabCacheKey::new(1, "https://example.com/a?x=1"),
+                OpenTabCacheKey::new(3, "https://example.com/new"),
+                OpenTabCacheKey::new(4, "https://example.com/fragment#new"),
+            ],
+        );
+
+        assert!(cache
+            .lookup_open_tab(Some("p"), 1, "https://example.com/a?x=1")
+            .is_some());
+        assert!(cache
+            .lookup_open_tab(Some("p"), 2, "https://example.com/b")
+            .is_none());
+        assert!(cache
+            .lookup_exact_open_tab(Some("p"), 3, "https://example.com/old")
+            .is_none());
+        assert!(cache
+            .lookup_exact_open_tab(Some("p"), 4, "https://example.com/fragment#old")
+            .is_some());
+        assert!(cache
+            .lookup_exact_open_tab(Some("p"), 5, "https://example.com/unrelated#old")
+            .is_none());
+        assert!(cache
+            .lookup_open_tab(Some("other"), 2, "https://example.com/b")
+            .is_some());
+    }
+
+    #[test]
+    fn evicts_oldest_for_max_entries_and_total_bytes() {
+        let mut cache = PageCache::default();
+        for i in 0..260 {
+            store(
+                &mut cache,
+                None,
+                i,
+                &format!("https://example.com/{i}"),
+                "x",
+                i,
+            );
+        }
+        assert_eq!(cache.entries.len(), MAX_ENTRIES);
+        assert!(cache
+            .lookup_open_tab(None, 0, "https://example.com/0")
+            .is_none());
+        assert!(cache
+            .lookup_open_tab(None, 259, "https://example.com/259")
+            .is_some());
+
+        let mut byte_cache = PageCache::default();
+        let html = "x".repeat(600_000);
+        for i in 0..230 {
+            store(
+                &mut byte_cache,
+                None,
+                i,
+                &format!("https://bytes.example/{i}"),
+                &html,
+                i,
+            );
+        }
+        let total: usize = byte_cache
+            .entries
+            .values()
+            .map(|entry| entry.html.len())
+            .sum();
+        assert!(total <= MAX_TOTAL_HTML_BYTES);
+        assert!(byte_cache
+            .lookup_open_tab(None, 0, "https://bytes.example/0")
+            .is_none());
+        assert!(byte_cache
+            .lookup_open_tab(None, 229, "https://bytes.example/229")
+            .is_some());
+    }
+
+    #[test]
+    fn corrupted_cache_load_degrades_gracefully() {
+        let path = cache_path("corrupt");
+        fs::create_dir_all(&path).expect("create dir");
+        fs::write(path.join("bad.json"), b"not-json").expect("write corrupt cache");
+        let cache = PageCache::load(&path);
+        assert!(cache.entries.is_empty());
+        assert!(cache.dirty);
+    }
+
+    #[test]
+    fn load_drops_invalid_entries_and_marks_dirty() {
+        let path = cache_path("invalid-load");
+        fs::create_dir_all(&path).expect("create dir");
+        fs::write(
+            path.join("entries.json"),
+            serde_json::json!({
+                "profile": "p",
+                "tabId": 1,
+                "urlKey": "https://example.com/empty",
+                "title": null,
+                "html": "",
+                "sourceHtmlChars": 0,
+                "sourceTextChars": 0,
+                "documentReadyState": null,
+                "capturedAt": 1
+            })
+            .to_string(),
+        )
+        .expect("write cache");
+        fs::write(
+            path.join("ok.json"),
+            serde_json::json!({
+                "profile": "p",
+                "tabId": 2,
+                "urlKey": "https://example.com/ok",
+                "title": "Ok",
+                "html": "<p>ok</p>",
+                "sourceHtmlChars": 9,
+                "sourceTextChars": 2,
+                "documentReadyState": "complete",
+                "capturedAt": 2
+            })
+            .to_string(),
+        )
+        .expect("write cache");
+
+        let cache = PageCache::load(&path);
+        assert!(cache.dirty);
+        assert!(cache
+            .lookup_open_tab(Some("p"), 1, "https://example.com/empty")
+            .is_none());
+        assert!(cache
+            .lookup_open_tab(Some("p"), 2, "https://example.com/ok")
+            .is_some());
+    }
+
+    #[test]
+    fn atomic_save_creates_parent_dir_and_loads_again() {
+        let path = cache_path("atomic");
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            None,
+            42,
+            "https://example.com/save",
+            "saved",
+            42,
+        );
+        cache.save_if_dirty(&path).expect("save");
+        assert!(path.exists());
+        assert_eq!(
+            PageCache::load(&path)
+                .lookup_open_tab(None, 42, "https://example.com/save")
+                .unwrap()
+                .entry
+                .html,
+            "saved"
+        );
+        let files: Vec<_> = fs::read_dir(&path)
+            .expect("read cache dir")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .collect();
+        assert_eq!(files.len(), 1);
+    }
+}

--- a/rust/crates/host/src/host_impl/runtime.rs
+++ b/rust/crates/host/src/host_impl/runtime.rs
@@ -205,12 +205,15 @@ fn run_unix() -> io::Result<()> {
     let _ = fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600));
 
     let native_channel_available = !io::stdin().is_terminal() && !io::stdout().is_terminal();
-    let state = Arc::new(Mutex::new(HostState::new_with_native_channel(
-        PathBuf::from(&config.undo_log),
-        PathBuf::from(&config.base_data_dir).join("focus.db"),
-        config.active_profile_name.clone(),
-        native_channel_available,
-    )));
+    let state = Arc::new(Mutex::new(
+        HostState::new_with_native_channel_and_page_cache(
+            PathBuf::from(&config.undo_log),
+            PathBuf::from(&config.base_data_dir).join("focus.db"),
+            PathBuf::from(&config.data_dir).join("page-cache"),
+            config.active_profile_name.clone(),
+            native_channel_available,
+        ),
+    ));
     let clients: Clients = Arc::new(Mutex::new(std::collections::HashMap::new()));
     let native_out: NativeWriter = Arc::new(Mutex::new(Box::new(io::stdout())));
 
@@ -472,12 +475,15 @@ fn run_windows() -> io::Result<()> {
     let pipe_file = write_pipe_endpoint_file(&data_dir, &pipe_path)?;
 
     let native_channel_available = !io::stdin().is_terminal() && !io::stdout().is_terminal();
-    let state = Arc::new(Mutex::new(HostState::new_with_native_channel(
-        PathBuf::from(&config.undo_log),
-        PathBuf::from(&config.base_data_dir).join("focus.db"),
-        config.active_profile_name.clone(),
-        native_channel_available,
-    )));
+    let state = Arc::new(Mutex::new(
+        HostState::new_with_native_channel_and_page_cache(
+            PathBuf::from(&config.undo_log),
+            PathBuf::from(&config.base_data_dir).join("focus.db"),
+            PathBuf::from(&config.data_dir).join("page-cache"),
+            config.active_profile_name.clone(),
+            native_channel_available,
+        ),
+    ));
     let clients: Clients = Arc::new(Mutex::new(std::collections::HashMap::new()));
     let native_out: NativeWriter = Arc::new(Mutex::new(Box::new(io::stdout())));
     start_native_reader(state.clone(), clients.clone(), native_out.clone());

--- a/rust/crates/host/src/host_impl/state.rs
+++ b/rust/crates/host/src/host_impl/state.rs
@@ -6,7 +6,8 @@ use tabctl_shared::{ClientInfo, NativeMessage, ProtocolError, RequestEnvelope, R
 
 use super::browser_state;
 use super::focus_store;
-use super::orchestrate::{orchestration_for, OrchStep, Orchestration};
+use super::orchestrate::{orchestration_for, OrchStep, Orchestration, OrchestrationContext};
+use super::page_cache::{OpenTabCacheKey, PageCache};
 use super::protocol::{
     add_host_metadata, add_ping_metadata, base_response, create_id, host_ping_data, host_version,
     local_actions, log_line, now_ms, trace_line, undo_actions, value_object, version_info_value,
@@ -41,6 +42,7 @@ pub(super) struct HostState {
     undo_log: PathBuf,
     state_db_path: PathBuf,
     focus_db_path: PathBuf,
+    page_cache_path: PathBuf,
     profile_name: Option<String>,
     native_channel_available: bool,
 }
@@ -87,6 +89,91 @@ impl HostState {
         }
     }
 
+    fn ingest_page_cache_capture(&self, payload: Value) {
+        if let Err(err) = self.try_ingest_page_cache_capture(&payload) {
+            log_line(&format!("page-cache capture ingest failed: {err}"));
+        }
+    }
+
+    fn try_ingest_page_cache_capture(&self, payload: &Value) -> Result<(), String> {
+        let Some(root) = payload.as_object() else {
+            return Ok(());
+        };
+        let Some(tab) = root.get("tab").and_then(Value::as_object) else {
+            return Ok(());
+        };
+        let Some(extraction) = root.get("extraction").and_then(Value::as_object) else {
+            return Ok(());
+        };
+
+        if extraction.get("status").and_then(Value::as_str) != Some("READ") {
+            return Ok(());
+        }
+
+        let Some(html) = extraction.get("html").and_then(Value::as_str) else {
+            return Ok(());
+        };
+        if html.is_empty() {
+            return Ok(());
+        }
+
+        let Some(tab_id) = tab.get("tabId").and_then(Value::as_i64) else {
+            return Ok(());
+        };
+        let Some(url) = tab.get("url").and_then(Value::as_str) else {
+            return Ok(());
+        };
+        if url.is_empty() {
+            return Ok(());
+        }
+
+        let incognito = tab
+            .get("incognito")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let truncated_html = extraction
+            .get("truncatedHtml")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if incognito || truncated_html {
+            return Ok(());
+        }
+
+        let source_html_chars = extraction
+            .get("sourceHtmlChars")
+            .and_then(Value::as_i64)
+            .unwrap_or_else(|| html.chars().count() as i64);
+        let source_text_chars = extraction
+            .get("sourceTextChars")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+        let document_ready_state = extraction.get("documentReadyState").and_then(Value::as_str);
+        let captured_at = root
+            .get("capturedAt")
+            .and_then(Value::as_i64)
+            .unwrap_or_else(|| now_ms() as i64);
+        let title = tab.get("title").and_then(Value::as_str);
+
+        let mut cache = PageCache::load(&self.page_cache_path);
+        if let Some(open_tabs) = page_cache_open_tabs_from_payload(root) {
+            cache.prune_to_open_tabs(self.profile_name.as_deref(), &open_tabs);
+        }
+        cache.store_success(
+            self.profile_name.as_deref(),
+            tab_id,
+            url,
+            title,
+            html,
+            source_html_chars,
+            source_text_chars,
+            document_ready_state,
+            truncated_html,
+            incognito,
+            captured_at,
+        );
+        cache.save_if_dirty(&self.page_cache_path)
+    }
+
     #[cfg_attr(not(test), allow(dead_code))]
     pub(super) fn new(
         undo_log: PathBuf,
@@ -102,6 +189,26 @@ impl HostState {
         profile_name: Option<String>,
         native_channel_available: bool,
     ) -> Self {
+        let page_cache_path = undo_log
+            .parent()
+            .map(|parent| parent.join("page-cache"))
+            .unwrap_or_else(|| PathBuf::from("page-cache"));
+        Self::new_with_native_channel_and_page_cache(
+            undo_log,
+            focus_db_path,
+            page_cache_path,
+            profile_name,
+            native_channel_available,
+        )
+    }
+
+    pub(super) fn new_with_native_channel_and_page_cache(
+        undo_log: PathBuf,
+        focus_db_path: PathBuf,
+        page_cache_path: PathBuf,
+        profile_name: Option<String>,
+        native_channel_available: bool,
+    ) -> Self {
         let state_db_path = undo_log
             .parent()
             .map(|parent| parent.join("state.db"))
@@ -112,8 +219,16 @@ impl HostState {
             undo_log,
             state_db_path,
             focus_db_path,
+            page_cache_path,
             profile_name,
             native_channel_available,
+        }
+    }
+
+    fn orchestration_context(&self) -> OrchestrationContext {
+        OrchestrationContext {
+            page_cache_path: Some(self.page_cache_path.clone()),
+            profile_name: self.profile_name.clone(),
         }
     }
 
@@ -441,7 +556,9 @@ impl HostState {
                 "record".to_string(),
                 Value::Object(record),
             )]));
-            if let Some(mut orch) = orchestration_for("undo", &undo_params) {
+            if let Some(mut orch) =
+                orchestration_for("undo", &undo_params, &self.orchestration_context())
+            {
                 let step = orch.start();
                 return self.process_orch_step(client_id, "undo", request.id, None, step, orch);
             }
@@ -544,7 +661,9 @@ impl HostState {
         // Must come before undo_actions legacy forward so migrated commands
         // use the orchestration path. Undo-tracked orchestrated commands get
         // a txid generated here.
-        if let Some(mut orch) = orchestration_for(&action, &request.params) {
+        if let Some(mut orch) =
+            orchestration_for(&action, &request.params, &self.orchestration_context())
+        {
             let txid = if undo_actions().contains(action.as_str()) {
                 Some(create_id("tx"))
             } else {
@@ -582,6 +701,10 @@ impl HostState {
                     &payload,
                 ) {
                     log_line(&format!("browser-state sync ingest failed: {err}"));
+                }
+            } else if message.action.as_deref() == Some("page-cache-capture") {
+                if let Some(payload) = message.data {
+                    self.ingest_page_cache_capture(payload);
                 }
             }
             return Vec::new();
@@ -870,17 +993,210 @@ impl HostState {
     }
 }
 
+fn page_cache_open_tabs_from_payload(root: &Map<String, Value>) -> Option<Vec<OpenTabCacheKey>> {
+    for key in ["openTabs", "tabs"] {
+        if let Some(tabs) = root.get(key).and_then(Value::as_array) {
+            let open_tabs = collect_page_cache_open_tabs(tabs);
+            if !open_tabs.is_empty() {
+                return Some(open_tabs);
+            }
+        }
+    }
+
+    root.get("snapshot").and_then(|snapshot| {
+        let open_tabs = collect_page_cache_open_tabs_from_snapshot(snapshot);
+        (!open_tabs.is_empty()).then_some(open_tabs)
+    })
+}
+
+fn collect_page_cache_open_tabs(tabs: &[Value]) -> Vec<OpenTabCacheKey> {
+    tabs.iter()
+        .filter_map(|tab| {
+            let tab = tab.as_object()?;
+            let tab_id = tab.get("tabId").and_then(Value::as_i64)?;
+            let url = tab.get("url").and_then(Value::as_str)?;
+            (!url.is_empty()).then(|| OpenTabCacheKey::new(tab_id, url))
+        })
+        .collect()
+}
+
+fn collect_page_cache_open_tabs_from_snapshot(snapshot: &Value) -> Vec<OpenTabCacheKey> {
+    let Some(snapshot) = snapshot.as_object() else {
+        return Vec::new();
+    };
+    if let Some(tabs) = snapshot.get("tabs").and_then(Value::as_array) {
+        return collect_page_cache_open_tabs(tabs);
+    }
+    snapshot
+        .get("windows")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|window| window.get("tabs").and_then(Value::as_array))
+        .flat_map(|tabs| collect_page_cache_open_tabs(tabs))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::{Map, Value};
+    use std::fs;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn state_path(name: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("state-tests")
+            .join(format!("{}-{}-{}", name, std::process::id(), id));
+        let _ = fs::remove_dir_all(&path);
+        path
+    }
 
     fn test_state() -> HostState {
-        HostState::new(
-            std::env::temp_dir().join("tabctl-host-state-test-undo.jsonl"),
-            std::env::temp_dir().join("tabctl-host-state-test-focus.db"),
-            None,
+        let path = state_path("default");
+        HostState::new(path.join("undo.jsonl"), path.join("focus.db"), None)
+    }
+
+    fn page_cache_test_state(name: &str) -> (HostState, PathBuf) {
+        let path = state_path(name);
+        let page_cache_path = path.join("page-cache");
+        (
+            HostState::new_with_native_channel_and_page_cache(
+                path.join("undo.jsonl"),
+                path.join("focus.db"),
+                page_cache_path.clone(),
+                Some("work".to_string()),
+                true,
+            ),
+            page_cache_path,
         )
+    }
+
+    fn page_cache_capture(
+        status: &str,
+        incognito: bool,
+        truncated_html: bool,
+        html: &str,
+    ) -> NativeMessage {
+        NativeMessage {
+            id: "unsolicited-page-cache".to_string(),
+            action: Some("page-cache-capture".to_string()),
+            ok: Some(true),
+            progress: None,
+            params: None,
+            data: Some(serde_json::json!({
+                "reason": "activation",
+                "capturedAt": 12345,
+                "tab": {
+                    "tabId": 42,
+                    "windowId": 7,
+                    "index": 0,
+                    "url": "https://example.com/page#section",
+                    "title": "Example Page",
+                    "incognito": incognito
+                },
+                "extraction": {
+                    "status": status,
+                    "html": html,
+                    "sourceHtmlChars": 99,
+                    "sourceTextChars": 12,
+                    "documentReadyState": "complete",
+                    "truncatedHtml": truncated_html
+                },
+                "snapshot": {
+                    "windows": [{
+                        "tabs": [{
+                            "tabId": 42,
+                            "url": "https://example.com/page#section"
+                        }]
+                    }]
+                }
+            })),
+            error: None,
+        }
+    }
+
+    fn cached_entry(path: &Path) -> Option<super::super::page_cache::PageCacheLookup> {
+        PageCache::load(path).lookup_open_tab(Some("work"), 42, "https://example.com/page#section")
+    }
+
+    #[test]
+    fn unsolicited_page_cache_capture_stores_valid_read() {
+        let (mut state, page_cache_path) = page_cache_test_state("valid-capture");
+        let effects = state.handle_native_message(page_cache_capture(
+            "READ",
+            false,
+            false,
+            "<html>ok</html>",
+        ));
+
+        assert!(effects.is_empty());
+        let entry = cached_entry(&page_cache_path).expect("cached page capture");
+        assert_eq!(entry.entry.title.as_deref(), Some("Example Page"));
+        assert_eq!(entry.entry.html, "<html>ok</html>");
+        assert_eq!(entry.entry.source_html_chars, 99);
+        assert_eq!(entry.entry.source_text_chars, 12);
+        assert_eq!(
+            entry.entry.document_ready_state.as_deref(),
+            Some("complete")
+        );
+        assert_eq!(entry.entry.captured_at, 12345);
+    }
+
+    #[test]
+    fn unsolicited_page_cache_capture_skips_invalid_status() {
+        let (mut state, page_cache_path) = page_cache_test_state("invalid-status");
+        let effects = state.handle_native_message(page_cache_capture(
+            "ERROR",
+            false,
+            false,
+            "<html>ok</html>",
+        ));
+
+        assert!(effects.is_empty());
+        assert!(cached_entry(&page_cache_path).is_none());
+    }
+
+    #[test]
+    fn unsolicited_page_cache_capture_skips_incognito() {
+        let (mut state, page_cache_path) = page_cache_test_state("incognito");
+        let effects =
+            state.handle_native_message(page_cache_capture("READ", true, false, "<html>ok</html>"));
+
+        assert!(effects.is_empty());
+        assert!(cached_entry(&page_cache_path).is_none());
+    }
+
+    #[test]
+    fn unsolicited_page_cache_capture_skips_truncated_html() {
+        let (mut state, page_cache_path) = page_cache_test_state("truncated");
+        let effects =
+            state.handle_native_message(page_cache_capture("READ", false, true, "<html>ok</html>"));
+
+        assert!(effects.is_empty());
+        assert!(cached_entry(&page_cache_path).is_none());
+    }
+
+    #[test]
+    fn unsolicited_page_cache_capture_save_failure_is_nonfatal() {
+        let (mut state, page_cache_path) = page_cache_test_state("save-failure");
+        fs::create_dir_all(page_cache_path.parent().expect("parent")).expect("create parent");
+        fs::write(&page_cache_path, b"not a directory").expect("create blocking file");
+
+        let effects = state.handle_native_message(page_cache_capture(
+            "READ",
+            false,
+            false,
+            "<html>ok</html>",
+        ));
+
+        assert!(effects.is_empty());
     }
 
     #[test]

--- a/rust/crates/host/src/host_impl/state.rs
+++ b/rust/crates/host/src/host_impl/state.rs
@@ -89,42 +89,46 @@ impl HostState {
         }
     }
 
-    fn ingest_page_cache_capture(&self, payload: Value) {
-        if let Err(err) = self.try_ingest_page_cache_capture(&payload) {
-            log_line(&format!("page-cache capture ingest failed: {err}"));
+    fn ingest_page_cache_capture(&self, payload: &Value) -> bool {
+        match self.try_ingest_page_cache_capture(payload) {
+            Ok(available) => available,
+            Err(err) => {
+                log_line(&format!("page-cache capture ingest failed: {err}"));
+                false
+            }
         }
     }
 
-    fn try_ingest_page_cache_capture(&self, payload: &Value) -> Result<(), String> {
+    fn try_ingest_page_cache_capture(&self, payload: &Value) -> Result<bool, String> {
         let Some(root) = payload.as_object() else {
-            return Ok(());
+            return Ok(false);
         };
         let Some(tab) = root.get("tab").and_then(Value::as_object) else {
-            return Ok(());
+            return Ok(false);
         };
         let Some(extraction) = root.get("extraction").and_then(Value::as_object) else {
-            return Ok(());
+            return Ok(false);
         };
 
         if extraction.get("status").and_then(Value::as_str) != Some("READ") {
-            return Ok(());
+            return Ok(false);
         }
 
         let Some(html) = extraction.get("html").and_then(Value::as_str) else {
-            return Ok(());
+            return Ok(false);
         };
         if html.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         let Some(tab_id) = tab.get("tabId").and_then(Value::as_i64) else {
-            return Ok(());
+            return Ok(false);
         };
         let Some(url) = tab.get("url").and_then(Value::as_str) else {
-            return Ok(());
+            return Ok(false);
         };
         if url.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
 
         let incognito = tab
@@ -135,8 +139,8 @@ impl HostState {
             .get("truncatedHtml")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        if incognito || truncated_html {
-            return Ok(());
+        if incognito || truncated_html || is_non_scriptable_url(url) {
+            return Ok(false);
         }
 
         let source_html_chars = extraction
@@ -171,7 +175,47 @@ impl HostState {
             incognito,
             captured_at,
         );
-        cache.save_if_dirty(&self.page_cache_path)
+        let available = cache.has_exact_open_tab(self.profile_name.as_deref(), tab_id, url);
+        cache.save_if_dirty(&self.page_cache_path)?;
+        Ok(available)
+    }
+
+    fn page_cache_status(&self, payload: &Value) -> Value {
+        let Some((tab_id, url, incognito, discarded)) = page_cache_tab_request(payload) else {
+            return page_cache_status_value(None, None, false);
+        };
+        if incognito || discarded || is_non_scriptable_url(&url) {
+            return page_cache_status_value(Some(tab_id), Some(&url), false);
+        }
+        let cache = PageCache::load(&self.page_cache_path);
+        page_cache_status_value(
+            Some(tab_id),
+            Some(&url),
+            cache.has_exact_open_tab(self.profile_name.as_deref(), tab_id, &url),
+        )
+    }
+
+    fn page_cache_status_effect(&self, id: String, payload: &Value, available: bool) -> HostEffect {
+        let Some((tab_id, url, _, _)) = page_cache_tab_request(payload) else {
+            return HostEffect::SendNative(NativeMessage {
+                id,
+                action: None,
+                ok: Some(true),
+                progress: None,
+                params: None,
+                data: Some(page_cache_status_value(None, None, false)),
+                error: None,
+            });
+        };
+        HostEffect::SendNative(NativeMessage {
+            id,
+            action: None,
+            ok: Some(true),
+            progress: None,
+            params: None,
+            data: Some(page_cache_status_value(Some(tab_id), Some(&url), available)),
+            error: None,
+        })
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -703,9 +747,21 @@ impl HostState {
                     log_line(&format!("browser-state sync ingest failed: {err}"));
                 }
             } else if message.action.as_deref() == Some("page-cache-capture") {
-                if let Some(payload) = message.data {
-                    self.ingest_page_cache_capture(payload);
-                }
+                let payload = message.data.unwrap_or(Value::Object(Map::new()));
+                let available = self.ingest_page_cache_capture(&payload);
+                return vec![self.page_cache_status_effect(message_id, &payload, available)];
+            } else if message.action.as_deref() == Some("page-cache-status") {
+                let payload = message.data.unwrap_or(Value::Object(Map::new()));
+                let data = self.page_cache_status(&payload);
+                return vec![HostEffect::SendNative(NativeMessage {
+                    id: message_id,
+                    action: None,
+                    ok: Some(true),
+                    progress: None,
+                    params: None,
+                    data: Some(data),
+                    error: None,
+                })];
             }
             return Vec::new();
         }
@@ -1037,6 +1093,38 @@ fn collect_page_cache_open_tabs_from_snapshot(snapshot: &Value) -> Vec<OpenTabCa
         .collect()
 }
 
+fn page_cache_tab_request(payload: &Value) -> Option<(i64, String, bool, bool)> {
+    let root = payload.as_object()?;
+    let tab = root.get("tab").and_then(Value::as_object)?;
+    let tab_id = tab.get("tabId").and_then(Value::as_i64)?;
+    let url = tab.get("url").and_then(Value::as_str)?.to_string();
+    if url.is_empty() {
+        return None;
+    }
+    let incognito = tab
+        .get("incognito")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let discarded = tab
+        .get("discarded")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Some((tab_id, url, incognito, discarded))
+}
+
+fn page_cache_status_value(tab_id: Option<i64>, url: Option<&str>, available: bool) -> Value {
+    serde_json::json!({
+        "tabId": tab_id,
+        "url": url,
+        "available": available,
+    })
+}
+
+fn is_non_scriptable_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    !(lower.starts_with("http://") || lower.starts_with("https://"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1126,6 +1214,38 @@ mod tests {
         PageCache::load(path).lookup_open_tab(Some("work"), 42, "https://example.com/page#section")
     }
 
+    fn page_cache_status_request(tab_id: i64, url: &str) -> NativeMessage {
+        NativeMessage {
+            id: "page-cache-status-1".to_string(),
+            action: Some("page-cache-status".to_string()),
+            ok: Some(true),
+            progress: None,
+            params: None,
+            data: Some(serde_json::json!({
+                "reason": "test",
+                "tab": {
+                    "tabId": tab_id,
+                    "url": url,
+                    "incognito": false,
+                    "discarded": false
+                }
+            })),
+            error: None,
+        }
+    }
+
+    fn assert_cache_status_effect(effects: &[HostEffect], available: bool) {
+        let [HostEffect::SendNative(message)] = effects else {
+            panic!("expected one native status response");
+        };
+        assert_eq!(message.action, None);
+        assert_eq!(message.ok, Some(true));
+        let data = message.data.as_ref().expect("status data");
+        assert_eq!(data["tabId"], 42);
+        assert_eq!(data["url"], "https://example.com/page#section");
+        assert_eq!(data["available"], available);
+    }
+
     #[test]
     fn unsolicited_page_cache_capture_stores_valid_read() {
         let (mut state, page_cache_path) = page_cache_test_state("valid-capture");
@@ -1136,7 +1256,7 @@ mod tests {
             "<html>ok</html>",
         ));
 
-        assert!(effects.is_empty());
+        assert_cache_status_effect(&effects, true);
         let entry = cached_entry(&page_cache_path).expect("cached page capture");
         assert_eq!(entry.entry.title.as_deref(), Some("Example Page"));
         assert_eq!(entry.entry.html, "<html>ok</html>");
@@ -1159,7 +1279,7 @@ mod tests {
             "<html>ok</html>",
         ));
 
-        assert!(effects.is_empty());
+        assert_cache_status_effect(&effects, false);
         assert!(cached_entry(&page_cache_path).is_none());
     }
 
@@ -1169,7 +1289,7 @@ mod tests {
         let effects =
             state.handle_native_message(page_cache_capture("READ", true, false, "<html>ok</html>"));
 
-        assert!(effects.is_empty());
+        assert_cache_status_effect(&effects, false);
         assert!(cached_entry(&page_cache_path).is_none());
     }
 
@@ -1179,7 +1299,7 @@ mod tests {
         let effects =
             state.handle_native_message(page_cache_capture("READ", false, true, "<html>ok</html>"));
 
-        assert!(effects.is_empty());
+        assert_cache_status_effect(&effects, false);
         assert!(cached_entry(&page_cache_path).is_none());
     }
 
@@ -1196,7 +1316,51 @@ mod tests {
             "<html>ok</html>",
         ));
 
-        assert!(effects.is_empty());
+        assert_cache_status_effect(&effects, false);
+    }
+
+    #[test]
+    fn page_cache_status_reports_exact_cached_entry() {
+        let (mut state, page_cache_path) = page_cache_test_state("status-hit");
+        let _ = state.handle_native_message(page_cache_capture(
+            "READ",
+            false,
+            false,
+            "<html>ok</html>",
+        ));
+        assert!(cached_entry(&page_cache_path).is_some());
+
+        let effects = state.handle_native_message(page_cache_status_request(
+            42,
+            "https://example.com/page#section",
+        ));
+
+        assert_cache_status_effect(&effects, true);
+    }
+
+    #[test]
+    fn page_cache_status_does_not_report_canonical_match() {
+        let (mut state, page_cache_path) = page_cache_test_state("status-canonical-miss");
+        let _ = state.handle_native_message(page_cache_capture(
+            "READ",
+            false,
+            false,
+            "<html>ok</html>",
+        ));
+        assert!(cached_entry(&page_cache_path).is_some());
+
+        let effects = state.handle_native_message(page_cache_status_request(
+            42,
+            "https://example.com/page#other",
+        ));
+
+        let [HostEffect::SendNative(message)] = &effects[..] else {
+            panic!("expected one native status response");
+        };
+        assert_eq!(
+            message.data.as_ref().expect("status data")["available"],
+            false
+        );
     }
 
     #[test]

--- a/rust/crates/tabctl/tests/browser_integration.rs
+++ b/rust/crates/tabctl/tests/browser_integration.rs
@@ -181,7 +181,7 @@ fn read_tabs_returns_markdown_for_known_page() {
     sleep(Duration::from_secs(1));
 
     let read = b.run_query(&format!(
-        r#"query {{ readTabs(tabIds: [{tab_id}], extract: true, maxChars: 50000, timeoutMs: 15000) {{ totals {{ tabs tasks }} entries {{ tabId url title chars truncated extracted status emptyReason diagnostics {{ sourceHtmlChars sourceTextChars documentReadyState truncatedHtml }} error markdown }} }} }}"#
+        r#"query {{ readTabs(tabIds: [{tab_id}], extract: true, maxChars: 50000, timeoutMs: 15000) {{ totals {{ tabs tasks }} entries {{ tabId url title chars truncated extracted cached status emptyReason diagnostics {{ source cachedAt cacheAgeMs sourceHtmlChars sourceTextChars documentReadyState truncatedHtml }} error markdown }} }} }}"#
     ));
     assert_ok("readTabs known markdown page", &read);
     let data = &response_data(&read)["readTabs"];
@@ -202,6 +202,7 @@ fn read_tabs_returns_markdown_for_known_page() {
     assert_eq!(entry["emptyReason"], serde_json::Value::Null);
     assert_eq!(entry["error"], serde_json::Value::Null);
     assert_eq!(entry["extracted"].as_bool(), Some(true));
+    assert_eq!(entry["cached"].as_bool(), Some(false));
     assert_eq!(entry["truncated"].as_bool(), Some(false));
     assert!(
         entry["chars"].as_i64().unwrap_or(0) > 0,
@@ -221,6 +222,9 @@ fn read_tabs_returns_markdown_for_known_page() {
             > 0,
         "readTabs should report source text diagnostics: {read}"
     );
+    assert_eq!(entry["diagnostics"]["source"].as_str(), Some("live"));
+    assert_eq!(entry["diagnostics"]["cachedAt"], serde_json::Value::Null);
+    assert_eq!(entry["diagnostics"]["cacheAgeMs"], serde_json::Value::Null);
     assert_eq!(
         entry["diagnostics"]["documentReadyState"].as_str(),
         Some("complete")

--- a/skills/tabctl/SKILL.md
+++ b/skills/tabctl/SKILL.md
@@ -44,7 +44,7 @@ tabctl help query
  tabctl query 'query { inspectTabs(windowId: 123, selectors: [{ name: "prices", selector: ".price", attr: "text", all: true, text: "$", textMode: "contains" }, { name: "submit_visible", selector: "#submit", attr: "visible" }, { name: "submit_style", selector: "#submit", attr: "styles", styleProps: ["color", "background-color"] }, { name: "item_count", selector: ".item", attr: "count" }, { name: "email_value", selector: "input[type=email]", attr: "value" }, { name: "tos_checked", selector: "input[name=terms]", attr: "checked" }]) { entries { tabId url signals { name valueJson } } } }'
 
 # Read page content as Markdown
- tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted status emptyReason diagnostics { sourceHtmlChars sourceTextChars documentReadyState truncatedHtml } error } } }'
+ tabctl query 'query { readTabs(windowId: 123, extract: true, maxChars: 30000) { entries { tabId title url markdown chars truncated extracted cached status emptyReason diagnostics { source sourceHtmlChars sourceTextChars documentReadyState truncatedHtml cachedAt cacheAgeMs } error } } }'
 
 # Build reports
  tabctl query '{ reportTabs(windowId: 123) { entries { tabId title url description } } }'
@@ -55,7 +55,7 @@ tabctl help query
 
 ## Read-only extraction notes
 
-- `readTabs` converts main-frame HTML to Markdown with Kreuzberg preprocessing. Check `status`, `emptyReason`, `diagnostics`, and `error` per tab.
+- `readTabs` converts main-frame HTML to Markdown with Kreuzberg preprocessing. Check `status`, `emptyReason`, `diagnostics`, and `error` per tab; cached fallbacks use a bounded profile-local open-tab cache refreshed by successful reads, active tab switches, and quiescent active pages, and report `status: CACHED`, `cached: true`, and cache provenance in diagnostics.
 - `readTabs` v1 does not traverse cross-origin iframes or shadow DOM; non-scriptable URLs are returned with `status: UNSUPPORTED_URL`.
 - `inspectTabs` selector attrs now include `html`, `value`, `count`, `box`, `styles`, `visible`, `enabled`, and `checked`.
 - `visible` means rendered and not `display:none`, `visibility:hidden`, or `opacity:0`.

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -32,6 +32,9 @@ const ACTIVE_PAGE_CACHE_QUIESCENT_RETRY_MS = 1_000;
 const ACTIVE_PAGE_CACHE_QUIESCENT_TIMEOUT_MS = 2_500;
 const ACTIVE_PAGE_CACHE_QUIESCENT_SAMPLE_MS = 350;
 const ACTIVE_PAGE_CACHE_QUIESCENT_COOLDOWN_MS = 30_000;
+const ACTIVE_PAGE_CACHE_STATUS_TIMEOUT_MS = 30_000;
+const CACHE_AVAILABLE_BADGE_TEXT = "C";
+const CACHE_AVAILABLE_BADGE_COLOR = "#2da44e";
 const RECONNECT_INITIAL_DELAY_MS = 250;
 const RECONNECT_MAX_DELAY_MS = 30_000;
 const RECONNECT_ALARM_MIN_DELAY_MS = 30_000;
@@ -78,6 +81,7 @@ const activePageCache = {
   lastCapturedKey: null as string | null,
   lastQuiescentCapturedKey: null as string | null,
   lastQuiescentCapturedAt: 0,
+  statusRequests: new Map<string, { tabId: number; url: string }>(),
 };
 
 function log(...args: Array<unknown>) {
@@ -177,6 +181,9 @@ function connectNative() {
     state.port = port;
     resetReconnectBackoffAfterStablePort(port);
     port.onMessage.addListener((message) => {
+      if (handlePageCacheStatusMessage(message)) {
+        return;
+      }
       void handleNativeMessage(port, message);
     });
     port.onDisconnect.addListener(() => {
@@ -189,11 +196,13 @@ function connectNative() {
       if (state.port === port) {
         state.port = null;
       }
+      activePageCache.statusRequests.clear();
       clearReconnectStableTimer();
       scheduleReconnect("disconnect");
     });
     log("Native host connected");
     queueBrowserStateSync("startup");
+    void refreshActivePageCacheIndicator("connectNative");
   } catch (error) {
     log("Native host connection failed", error);
     scheduleReconnect("connect-failed");
@@ -210,6 +219,19 @@ function nextActivePageCacheId() {
   const id = activePageCache.nextId;
   activePageCache.nextId += 1;
   return `page-cache-capture-${Date.now()}-${id}`;
+}
+
+function nextActivePageCacheStatusId() {
+  const id = activePageCache.nextId;
+  activePageCache.nextId += 1;
+  return `page-cache-status-${Date.now()}-${id}`;
+}
+
+function trackPageCacheStatusRequest(id: string, tabId: number, url: string) {
+  activePageCache.statusRequests.set(id, { tabId, url });
+  setTimeout(() => {
+    activePageCache.statusRequests.delete(id);
+  }, ACTIVE_PAGE_CACHE_STATUS_TIMEOUT_MS);
 }
 
 function isScriptableUrl(url: string) {
@@ -230,6 +252,123 @@ async function tabUrlMatches(tabId: number, expectedUrl: string) {
     return activePageCacheUrl(await chrome.tabs.get(tabId)) === expectedUrl;
   } catch {
     return false;
+  }
+}
+
+async function clearCacheAvailableIndicator(tabId: number) {
+  try {
+    await chrome.action?.setBadgeText?.({ tabId, text: "" });
+    await chrome.action?.setTitle?.({ tabId, title: "Tab Control" });
+  } catch (error) {
+    log("clear cache indicator failed", { tabId, error });
+  }
+}
+
+async function setCacheAvailableIndicator(tabId: number, expectedUrl: string) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (!isEligibleActivePageCacheTab(tab) || activePageCacheUrl(tab) !== expectedUrl) {
+      await clearCacheAvailableIndicator(tabId);
+      return;
+    }
+    await chrome.action?.setBadgeBackgroundColor?.({ tabId, color: CACHE_AVAILABLE_BADGE_COLOR });
+    await chrome.action?.setBadgeText?.({ tabId, text: CACHE_AVAILABLE_BADGE_TEXT });
+    await chrome.action?.setTitle?.({ tabId, title: "Tab Control - page cache available" });
+  } catch (error) {
+    log("set cache indicator failed", { tabId, error });
+  }
+}
+
+async function applyPageCacheStatus(tabId: number, expectedUrl: string, available: boolean) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (activePageCacheUrl(tab) !== expectedUrl) {
+      return;
+    }
+    if (!isEligibleActivePageCacheTab(tab) || !available) {
+      await clearCacheAvailableIndicator(tabId);
+      return;
+    }
+    await setCacheAvailableIndicator(tabId, expectedUrl);
+  } catch {
+    await clearCacheAvailableIndicator(tabId);
+  }
+}
+
+function handlePageCacheStatusMessage(message: {
+  id?: string;
+  action?: string;
+  ok?: boolean;
+  data?: Record<string, unknown>;
+}) {
+  if (!message || typeof message !== "object" || message.action) {
+    return false;
+  }
+  const requestId = typeof message.id === "string" ? message.id : "";
+  const pending = activePageCache.statusRequests.get(requestId);
+  if (!pending) {
+    return false;
+  }
+  activePageCache.statusRequests.delete(requestId);
+  const data = message.data && typeof message.data === "object" ? message.data : {};
+  const tabId = typeof data.tabId === "number" ? data.tabId : pending.tabId;
+  const url = typeof data.url === "string" ? data.url : pending.url;
+  const available = message.ok === true && data.available === true && tabId === pending.tabId && url === pending.url;
+  void applyPageCacheStatus(pending.tabId, pending.url, available);
+  return true;
+}
+
+function requestPageCacheStatus(tab: chrome.tabs.Tab, reason: string) {
+  const url = activePageCacheUrl(tab);
+  if (typeof tab.id !== "number" || !isEligibleActivePageCacheTab(tab)) {
+    if (typeof tab.id === "number") {
+      void clearCacheAvailableIndicator(tab.id);
+    }
+    return;
+  }
+  const port = state.port;
+  if (!port) {
+    connectNative();
+    void clearCacheAvailableIndicator(tab.id);
+    return;
+  }
+
+  const id = nextActivePageCacheStatusId();
+  trackPageCacheStatusRequest(id, tab.id, url);
+  port.postMessage({
+    id,
+    action: "page-cache-status",
+    ok: true,
+    data: {
+      reason,
+      requestedAt: Date.now(),
+      tab: {
+        tabId: tab.id,
+        url,
+        incognito: tab.incognito || false,
+        discarded: tab.discarded || false,
+        status: tab.status || null,
+      },
+    },
+  });
+}
+
+async function requestPageCacheStatusForTab(tabId: number, reason: string) {
+  try {
+    requestPageCacheStatus(await chrome.tabs.get(tabId), reason);
+  } catch {
+    await clearCacheAvailableIndicator(tabId);
+  }
+}
+
+async function refreshActivePageCacheIndicator(reason: string) {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (tab) {
+      requestPageCacheStatus(tab, reason);
+    }
+  } catch (error) {
+    log("active page cache indicator refresh failed", { reason, error });
   }
 }
 
@@ -302,11 +441,15 @@ function scheduleQuiescentActivePageCacheCapture(tab: chrome.tabs.Tab & { id: nu
 
 function scheduleActivePageCacheCapture(tab: chrome.tabs.Tab, reason: string) {
   if (!isEligibleActivePageCacheTab(tab)) {
+    if (typeof tab.id === "number") {
+      void clearCacheAvailableIndicator(tab.id);
+    }
     clearPendingActivePageCacheCapture();
     clearPendingQuiescentActivePageCacheCapture();
     return;
   }
 
+  requestPageCacheStatus(tab, reason);
   const url = activePageCacheUrl(tab);
   const key = activePageCacheKey(tab, url);
   scheduleQuiescentActivePageCacheCapture(tab, reason, key);
@@ -331,6 +474,7 @@ async function scheduleActivePageCacheCaptureForTab(tabId: number, reason: strin
     scheduleActivePageCacheCapture(await chrome.tabs.get(tabId), reason);
   } catch (error) {
     log("active page cache tab lookup failed", { tabId, reason, error });
+    await clearCacheAvailableIndicator(tabId);
   }
 }
 
@@ -431,6 +575,7 @@ async function captureActivePageCache(
 
     const extraction = await content.extractPageHtml(captureTab.id, ACTIVE_PAGE_CACHE_TIMEOUT_MS, ACTIVE_PAGE_CACHE_MAX_HTML_CHARS);
     if (extraction.status !== "READ" || typeof extraction.html !== "string" || extraction.html.length === 0) {
+      void requestPageCacheStatusForTab(captureTab.id, `${reason}:capture-failed`);
       return false;
     }
 
@@ -444,8 +589,10 @@ async function captureActivePageCache(
       return false;
     }
 
+    const id = nextActivePageCacheId();
+    trackPageCacheStatusRequest(id, verifiedTab.id, activePageCacheUrl(verifiedTab));
     port.postMessage({
-      id: nextActivePageCacheId(),
+      id,
       action: "page-cache-capture",
       ok: true,
       data: {
@@ -473,6 +620,7 @@ async function captureActivePageCache(
     return true;
   } catch (error) {
     log("active page cache capture failed", { tabId: tab.id, reason, error });
+    void requestPageCacheStatusForTab(tab.id, `${reason}:capture-error`);
     return false;
   } finally {
     activePageCache.inFlightKeys.delete(key);
@@ -609,6 +757,9 @@ function registerBrowserStateListeners() {
       incognito: tab.incognito,
       changeInfo,
     });
+    if ("url" in changeInfo || "status" in changeInfo || "discarded" in changeInfo) {
+      void clearCacheAvailableIndicator(tabId);
+    }
     if (tab.active && ("url" in changeInfo || "status" in changeInfo || "discarded" in changeInfo)) {
       scheduleActivePageCacheCapture(tab, "tabs.onUpdated");
     }
@@ -645,6 +796,12 @@ function registerBrowserStateListeners() {
       windowId: removeInfo.windowId,
       isWindowClosing: removeInfo.isWindowClosing,
     });
+    activePageCache.statusRequests.forEach((pending, requestId) => {
+      if (pending.tabId === tabId) {
+        activePageCache.statusRequests.delete(requestId);
+      }
+    });
+    void clearCacheAvailableIndicator(tabId);
   });
 
   chrome.tabs?.onActivated?.addListener((activeInfo) => {

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -23,6 +23,15 @@ const KEEPALIVE_ALARM = "tabctl-keepalive";
 const RECONNECT_ALARM = "tabctl-reconnect";
 const KEEPALIVE_INTERVAL_MINUTES = 1;
 const BROWSER_STATE_SYNC_DEBOUNCE_MS = 750;
+const ACTIVE_PAGE_CACHE_DEBOUNCE_MS = 1_000;
+const ACTIVE_PAGE_CACHE_TIMEOUT_MS = 5_000;
+const MAX_PAGE_HTML_CHARS = 1_500_000;
+const ACTIVE_PAGE_CACHE_MAX_HTML_CHARS = MAX_PAGE_HTML_CHARS;
+const ACTIVE_PAGE_CACHE_QUIESCENT_DELAY_MS = 6_000;
+const ACTIVE_PAGE_CACHE_QUIESCENT_RETRY_MS = 1_000;
+const ACTIVE_PAGE_CACHE_QUIESCENT_TIMEOUT_MS = 2_500;
+const ACTIVE_PAGE_CACHE_QUIESCENT_SAMPLE_MS = 350;
+const ACTIVE_PAGE_CACHE_QUIESCENT_COOLDOWN_MS = 30_000;
 const RECONNECT_INITIAL_DELAY_MS = 250;
 const RECONNECT_MAX_DELAY_MS = 30_000;
 const RECONNECT_ALARM_MIN_DELAY_MS = 30_000;
@@ -52,6 +61,23 @@ const browserState = {
   incognitoWindowIds: new Set<number>(),
   incognitoTabIds: new Set<number>(),
   incognitoGroupIds: new Set<number>(),
+};
+
+const activePageCache = {
+  nextId: 1,
+  timer: null as ReturnType<typeof setTimeout> | null,
+  pending: null as { tab: chrome.tabs.Tab & { id: number }; reason: string; key: string } | null,
+  quiescentTimer: null as ReturnType<typeof setTimeout> | null,
+  quiescentPending: null as {
+    tabId: number;
+    key: string;
+    reason: string;
+    attempts: number;
+  } | null,
+  inFlightKeys: new Set<string>(),
+  lastCapturedKey: null as string | null,
+  lastQuiescentCapturedKey: null as string | null,
+  lastQuiescentCapturedAt: 0,
 };
 
 function log(...args: Array<unknown>) {
@@ -178,6 +204,279 @@ function nextBrowserStateId() {
   const id = browserState.nextId;
   browserState.nextId += 1;
   return `browser-state-${Date.now()}-${id}`;
+}
+
+function nextActivePageCacheId() {
+  const id = activePageCache.nextId;
+  activePageCache.nextId += 1;
+  return `page-cache-capture-${Date.now()}-${id}`;
+}
+
+function isScriptableUrl(url: string) {
+  const lower = url.toLowerCase();
+  return lower.startsWith("http://") || lower.startsWith("https://");
+}
+
+function activePageCacheKey(tab: chrome.tabs.Tab, url: string) {
+  return `${tab.id}:${url}`;
+}
+
+function activePageCacheUrl(tab: chrome.tabs.Tab) {
+  return tab.url || tab.pendingUrl || "";
+}
+
+async function tabUrlMatches(tabId: number, expectedUrl: string) {
+  try {
+    return activePageCacheUrl(await chrome.tabs.get(tabId)) === expectedUrl;
+  } catch {
+    return false;
+  }
+}
+
+function urlMismatchPageHtmlResponse(expectedUrl: string) {
+  return {
+    status: "URL_MISMATCH",
+    html: "",
+    sourceHtmlChars: 0,
+    sourceTextChars: 0,
+    documentReadyState: null,
+    truncatedHtml: false,
+    error: `Tab URL changed before page HTML extraction completed: expected ${expectedUrl}`,
+  };
+}
+
+function isEligibleActivePageCacheTab(tab: chrome.tabs.Tab): tab is chrome.tabs.Tab & { id: number } {
+  const url = activePageCacheUrl(tab);
+  return typeof tab.id === "number"
+    && Boolean(url)
+    && tab.incognito !== true
+    && !browserState.incognitoTabIds.has(tab.id)
+    && (typeof tab.windowId !== "number" || !browserState.incognitoWindowIds.has(tab.windowId))
+    && tab.discarded !== true
+    && tab.status !== "loading"
+    && isScriptableUrl(url);
+}
+
+function clearPendingActivePageCacheCapture() {
+  if (activePageCache.timer) {
+    clearTimeout(activePageCache.timer);
+    activePageCache.timer = null;
+  }
+  activePageCache.pending = null;
+}
+
+function clearPendingQuiescentActivePageCacheCapture() {
+  if (activePageCache.quiescentTimer) {
+    clearTimeout(activePageCache.quiescentTimer);
+    activePageCache.quiescentTimer = null;
+  }
+  activePageCache.quiescentPending = null;
+}
+
+function isQuiescentCaptureCoolingDown(key: string) {
+  return activePageCache.lastQuiescentCapturedKey === key
+    && Date.now() - activePageCache.lastQuiescentCapturedAt < ACTIVE_PAGE_CACHE_QUIESCENT_COOLDOWN_MS;
+}
+
+function scheduleQuiescentActivePageCacheCapture(tab: chrome.tabs.Tab & { id: number }, reason: string, key: string) {
+  if (isQuiescentCaptureCoolingDown(key)) {
+    return;
+  }
+
+  clearPendingQuiescentActivePageCacheCapture();
+  activePageCache.quiescentPending = {
+    tabId: tab.id,
+    key,
+    reason: `${reason}:quiescent`,
+    attempts: 0,
+  };
+  activePageCache.quiescentTimer = setTimeout(() => {
+    activePageCache.quiescentTimer = null;
+    const pending = activePageCache.quiescentPending;
+    activePageCache.quiescentPending = null;
+    if (pending) {
+      void captureQuiescentActivePageCache(pending);
+    }
+  }, ACTIVE_PAGE_CACHE_QUIESCENT_DELAY_MS);
+}
+
+function scheduleActivePageCacheCapture(tab: chrome.tabs.Tab, reason: string) {
+  if (!isEligibleActivePageCacheTab(tab)) {
+    clearPendingActivePageCacheCapture();
+    clearPendingQuiescentActivePageCacheCapture();
+    return;
+  }
+
+  const url = activePageCacheUrl(tab);
+  const key = activePageCacheKey(tab, url);
+  scheduleQuiescentActivePageCacheCapture(tab, reason, key);
+  if (activePageCache.inFlightKeys.has(key) || activePageCache.lastCapturedKey === key) {
+    return;
+  }
+
+  clearPendingActivePageCacheCapture();
+  activePageCache.pending = { tab, reason, key };
+  activePageCache.timer = setTimeout(() => {
+    activePageCache.timer = null;
+    const pending = activePageCache.pending;
+    activePageCache.pending = null;
+    if (pending) {
+      void captureActivePageCache(pending.tab, pending.reason, pending.key);
+    }
+  }, ACTIVE_PAGE_CACHE_DEBOUNCE_MS);
+}
+
+async function scheduleActivePageCacheCaptureForTab(tabId: number, reason: string) {
+  try {
+    scheduleActivePageCacheCapture(await chrome.tabs.get(tabId), reason);
+  } catch (error) {
+    log("active page cache tab lookup failed", { tabId, reason, error });
+  }
+}
+
+async function scheduleActivePageCacheCaptureForWindow(windowId: number, reason: string) {
+  if (windowId === chrome.windows.WINDOW_ID_NONE) {
+    return;
+  }
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, windowId });
+    if (tab) {
+      scheduleActivePageCacheCapture(tab, reason);
+    }
+  } catch (error) {
+    log("active page cache window lookup failed", { windowId, reason, error });
+  }
+}
+
+async function currentActivePageCacheTab(tabId: number, key: string) {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    const url = activePageCacheUrl(tab);
+    if (!tab.active || !isEligibleActivePageCacheTab(tab) || activePageCacheKey(tab, url) !== key) {
+      return null;
+    }
+    return tab;
+  } catch {
+    return null;
+  }
+}
+
+async function rescheduleQuiescentActivePageCacheCapture(
+  pending: { tabId: number; key: string; reason: string; attempts: number },
+) {
+  if (pending.attempts >= 2 || isQuiescentCaptureCoolingDown(pending.key)) {
+    return;
+  }
+  activePageCache.quiescentPending = { ...pending, attempts: pending.attempts + 1 };
+  activePageCache.quiescentTimer = setTimeout(() => {
+    activePageCache.quiescentTimer = null;
+    const retry = activePageCache.quiescentPending;
+    activePageCache.quiescentPending = null;
+    if (retry) {
+      void captureQuiescentActivePageCache(retry);
+    }
+  }, ACTIVE_PAGE_CACHE_QUIESCENT_RETRY_MS);
+}
+
+async function captureQuiescentActivePageCache(pending: { tabId: number; key: string; reason: string; attempts: number }) {
+  if (isQuiescentCaptureCoolingDown(pending.key)) {
+    return;
+  }
+  if (activePageCache.inFlightKeys.has(pending.key)) {
+    await rescheduleQuiescentActivePageCacheCapture(pending);
+    return;
+  }
+
+  const tab = await currentActivePageCacheTab(pending.tabId, pending.key);
+  if (!tab) {
+    return;
+  }
+
+  const probe = await content.probePageQuiescence(
+    tab.id,
+    ACTIVE_PAGE_CACHE_QUIESCENT_TIMEOUT_MS,
+    ACTIVE_PAGE_CACHE_QUIESCENT_SAMPLE_MS,
+  );
+  if (!probe.quiet) {
+    await rescheduleQuiescentActivePageCacheCapture(pending);
+    return;
+  }
+
+  const captured = await captureActivePageCache(tab, pending.reason, pending.key);
+  if (captured) {
+    activePageCache.lastQuiescentCapturedKey = pending.key;
+    activePageCache.lastQuiescentCapturedAt = Date.now();
+  }
+}
+
+async function captureActivePageCache(
+  tab: chrome.tabs.Tab & { id: number },
+  reason: string,
+  key: string,
+) {
+  if (!state.port) {
+    connectNative();
+    return false;
+  }
+  if (!isEligibleActivePageCacheTab(tab) || activePageCache.inFlightKeys.has(key)) {
+    return false;
+  }
+
+  activePageCache.inFlightKeys.add(key);
+  try {
+    const captureTab = await currentActivePageCacheTab(tab.id, key);
+    if (!captureTab) {
+      return false;
+    }
+
+    const extraction = await content.extractPageHtml(captureTab.id, ACTIVE_PAGE_CACHE_TIMEOUT_MS, ACTIVE_PAGE_CACHE_MAX_HTML_CHARS);
+    if (extraction.status !== "READ" || typeof extraction.html !== "string" || extraction.html.length === 0) {
+      return false;
+    }
+
+    const verifiedTab = await currentActivePageCacheTab(captureTab.id, key);
+    if (!verifiedTab) {
+      return false;
+    }
+
+    const port = state.port;
+    if (!port) {
+      return false;
+    }
+
+    port.postMessage({
+      id: nextActivePageCacheId(),
+      action: "page-cache-capture",
+      ok: true,
+      data: {
+        reason,
+        capturedAt: Date.now(),
+        tab: {
+          tabId: verifiedTab.id,
+          windowId: verifiedTab.windowId,
+          index: verifiedTab.index,
+          url: activePageCacheUrl(verifiedTab),
+          title: verifiedTab.title,
+          groupId: verifiedTab.groupId,
+          favIconUrl: verifiedTab.favIconUrl || null,
+          status: verifiedTab.status || null,
+          pinned: verifiedTab.pinned || false,
+          active: verifiedTab.active || false,
+          incognito: verifiedTab.incognito || false,
+          discarded: verifiedTab.discarded || false,
+          lastAccessedAt: verifiedTab.lastAccessed || null,
+        },
+        extraction,
+      },
+    });
+    activePageCache.lastCapturedKey = key;
+    return true;
+  } catch (error) {
+    log("active page cache capture failed", { tabId: tab.id, reason, error });
+    return false;
+  } finally {
+    activePageCache.inFlightKeys.delete(key);
+  }
 }
 
 function normalizeEventPayload(
@@ -310,6 +609,9 @@ function registerBrowserStateListeners() {
       incognito: tab.incognito,
       changeInfo,
     });
+    if (tab.active && ("url" in changeInfo || "status" in changeInfo || "discarded" in changeInfo)) {
+      scheduleActivePageCacheCapture(tab, "tabs.onUpdated");
+    }
   });
 
   chrome.tabs?.onMoved?.addListener((tabId, moveInfo) => {
@@ -350,6 +652,7 @@ function registerBrowserStateListeners() {
       tabId: activeInfo.tabId,
       windowId: activeInfo.windowId,
     });
+    void scheduleActivePageCacheCaptureForTab(activeInfo.tabId, "tabs.onActivated");
   });
 
   chrome.tabGroups?.onCreated?.addListener((group) => {
@@ -407,6 +710,7 @@ function registerBrowserStateListeners() {
 
   chrome.windows?.onFocusChanged?.addListener((windowId) => {
     enqueueBrowserStateEvent("windows.onFocusChanged", { windowId });
+    void scheduleActivePageCacheCaptureForWindow(windowId, "windows.onFocusChanged");
   });
 }
 
@@ -582,14 +886,23 @@ async function handleAction(action: string, params: Record<string, unknown>, req
 
     case "p:page-html": {
       const targetTabId = requireFiniteId(params.tabId, "tabId");
+      const expectedUrl = typeof params.expectedUrl === "string" ? params.expectedUrl : "";
       const maxHtmlChars = typeof params.maxHtmlChars === "number"
-        ? Math.max(1, Math.min(params.maxHtmlChars, 650_000))
+        ? Math.max(1, Math.min(params.maxHtmlChars, MAX_PAGE_HTML_CHARS))
         : 500_000;
       const timeoutMs = typeof params.timeoutMs === "number"
         ? Math.max(1, params.timeoutMs)
         : 15_000;
 
-      return await content.extractPageHtml(targetTabId, timeoutMs, maxHtmlChars);
+      if (expectedUrl && !(await tabUrlMatches(targetTabId, expectedUrl))) {
+        return urlMismatchPageHtmlResponse(expectedUrl);
+      }
+
+      const result = await content.extractPageHtml(targetTabId, timeoutMs, maxHtmlChars);
+      if (expectedUrl && !(await tabUrlMatches(targetTabId, expectedUrl))) {
+        return urlMismatchPageHtmlResponse(expectedUrl);
+      }
+      return result;
     }
 
     default:

--- a/src/extension/lib/content.ts
+++ b/src/extension/lib/content.ts
@@ -43,7 +43,7 @@ export type ScriptExecutionResult<T> =
 export async function executeWithTimeoutDetailed<T>(
   tabId: number,
   timeoutMs: number,
-  func: (...args: Array<any>) => T,
+  func: (...args: Array<any>) => T | Promise<T>,
   args: Array<unknown> = [],
 ): Promise<ScriptExecutionResult<T>> {
   const execPromise: Promise<ScriptExecutionResult<T>> = chrome.scripting.executeScript({
@@ -124,6 +124,23 @@ type PageHtmlPayload = {
   truncatedHtml: boolean;
 };
 
+type PageQuiescenceCounters = {
+  textChars: number;
+  htmlChars: number;
+  domElements: number;
+  resourceCount: number | null;
+};
+
+export type PageQuiescenceProbe = {
+  quiet: boolean;
+  reason: string;
+  documentReadyState: string | null;
+  before: PageQuiescenceCounters | null;
+  after: PageQuiescenceCounters | null;
+  elapsedMs: number;
+  error: string | null;
+};
+
 function injectionStatus(message: string) {
   const lower = message.toLowerCase();
   if (lower.includes("cannot access") || lower.includes("permission") || lower.includes("extensions gallery")) {
@@ -186,6 +203,128 @@ export async function extractPageHtml(tabId: number, timeoutMs: number, maxHtmlC
     status,
     ...result.value,
     error: null,
+  };
+}
+
+export async function probePageQuiescence(tabId: number, timeoutMs: number, sampleWindowMs: number) {
+  const result = await executeWithTimeoutDetailed<PageQuiescenceProbe>(tabId, timeoutMs, async (rawWindowMs: number) => {
+    const startedAt = Date.now();
+    const windowMs = Math.max(50, Math.min(Number(rawWindowMs) || 350, 1_500));
+    const htmlCap = 250_000;
+
+    const sample = (): PageQuiescenceCounters => {
+      const root = document.documentElement;
+      const bodyText = document.body?.innerText || root?.textContent || "";
+      const html = root?.outerHTML || "";
+      const resources = typeof performance !== "undefined" && typeof performance.getEntriesByType === "function"
+        ? performance.getEntriesByType("resource").length
+        : null;
+      return {
+        textChars: bodyText.length,
+        htmlChars: Math.min(html.length, htmlCap),
+        domElements: document.getElementsByTagName("*").length,
+        resourceCount: resources,
+      };
+    };
+
+    const waitForIdleWindow = () => new Promise<void>((resolve) => {
+      const win = window as Window & {
+        requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+      };
+      const done = () => setTimeout(resolve, windowMs);
+      if (typeof win.requestIdleCallback === "function") {
+        let resolved = false;
+        const finish = () => {
+          if (resolved) {
+            return;
+          }
+          resolved = true;
+          done();
+        };
+        const fallback = setTimeout(finish, windowMs + 100);
+        win.requestIdleCallback(() => {
+          clearTimeout(fallback);
+          finish();
+        }, { timeout: windowMs });
+        return;
+      }
+      setTimeout(resolve, windowMs);
+    });
+
+    try {
+      const readyState = document.readyState;
+      if (readyState !== "interactive" && readyState !== "complete") {
+        return {
+          quiet: false,
+          reason: "not-ready",
+          documentReadyState: readyState,
+          before: null,
+          after: null,
+          elapsedMs: Date.now() - startedAt,
+          error: null,
+        };
+      }
+
+      const before = sample();
+      await waitForIdleWindow();
+      const after = sample();
+      const stable = before.textChars === after.textChars
+        && before.htmlChars === after.htmlChars
+        && before.domElements === after.domElements
+        && before.resourceCount === after.resourceCount;
+
+      return {
+        quiet: stable,
+        reason: stable ? "stable" : "changed",
+        documentReadyState: document.readyState,
+        before,
+        after,
+        elapsedMs: Date.now() - startedAt,
+        error: null,
+      };
+    } catch (err) {
+      return {
+        quiet: false,
+        reason: "probe-error",
+        documentReadyState: typeof document !== "undefined" ? document.readyState : null,
+        before: null,
+        after: null,
+        elapsedMs: Date.now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }, [sampleWindowMs]);
+
+  if (result.kind === "timeout") {
+    return {
+      quiet: false,
+      reason: "timed-out",
+      documentReadyState: null,
+      before: null,
+      after: null,
+      elapsedMs: timeoutMs,
+      error: `Timed out after ${timeoutMs}ms`,
+    };
+  }
+  if (result.kind === "error") {
+    return {
+      quiet: false,
+      reason: "injection-error",
+      documentReadyState: null,
+      before: null,
+      after: null,
+      elapsedMs: 0,
+      error: result.message,
+    };
+  }
+  return result.value ?? {
+    quiet: false,
+    reason: "no-result",
+    documentReadyState: null,
+    before: null,
+    after: null,
+    elapsedMs: 0,
+    error: "Content script returned no quiescence probe payload",
   };
 }
 

--- a/src/extension/manifest.template.json
+++ b/src/extension/manifest.template.json
@@ -18,5 +18,8 @@
   ],
   "background": {
     "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Tab Control"
   }
 }


### PR DESCRIPTION
## Summary
- cache readTabs page HTML per tab for stale/protected fallback
- refresh active tab cache on activation/quiescence
- show a per-tab extension badge when cached content is available
- bump branch release candidate to v0.6.0-rc.9

## Validation
- npm test
- npm run build
- npm run test:smoke