### PR TITLE
chore(release): v0.6.0-rc.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -568,6 +568,9 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tabctl-win32-x64": {
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.11",
+  "version": "0.6.0-rc.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabctl",
-      "version": "0.6.0-rc.11",
+      "version": "0.6.0-rc.12",
       "license": "MIT",
       "dependencies": {
         "normalize-url": "^8.1.1"
@@ -24,7 +24,7 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "tabctl-win32-x64": "0.6.0-rc.11"
+        "tabctl-win32-x64": "0.6.0-rc.12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -567,9 +567,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/tabctl-win32-x64": {
-      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl",
-  "version": "0.6.0-rc.11",
+  "version": "0.6.0-rc.12",
   "description": "CLI tool to manage and analyze browser tabs",
   "license": "MIT",
   "repository": {
@@ -53,7 +53,7 @@
     "typescript": "^5.4.5"
   },
   "optionalDependencies": {
-    "tabctl-win32-x64": "0.6.0-rc.11"
+    "tabctl-win32-x64": "0.6.0-rc.12"
   },
   "dependencies": {
     "normalize-url": "^8.1.1"

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabctl-win32-x64",
-  "version": "0.6.0-rc.11",
+  "version": "0.6.0-rc.12",
   "description": "Windows x64 native messaging host binary for tabctl",
   "license": "MIT",
   "repository": {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "auto_enums"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65398a2893f41bce5c9259f6e1a4f03fbae40637c1bdc755b4f387f48c613b03"
+checksum = "2e4487600931c9a89f8db7ffbdf3fbdd45bb7bd85e26861f659a463cd0dff966"
 dependencies = [
  "derive_utils",
  "proc-macro2",
@@ -141,9 +141,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -168,9 +168,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -628,18 +628,20 @@ dependencies = [
 
 [[package]]
 name = "html-to-markdown-rs"
-version = "3.5.7"
+version = "3.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbbfb183e8634cb956309c6bbd781d9ddae068d376fb9eb1451ac49cf4cbba7"
+checksum = "32027e930a32dd01839a07405eae5e482ff507ccc4ca6fd1a89091304bd7ba22"
 dependencies = [
  "ahash",
  "astral-tl",
  "base64",
+ "bitflags",
  "html-escape",
  "html5ever",
  "lru",
  "memchr",
  "once_cell",
+ "phf",
  "regex",
  "serde",
  "serde_json",
@@ -857,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -883,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -1070,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1093,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rusqlite"
@@ -1261,9 +1263,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smartstring"
@@ -1342,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 dependencies = [
  "clap",
  "dirs",
@@ -1358,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-graphql"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 dependencies = [
  "indexmap",
  "juniper",
@@ -1367,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-host"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 dependencies = [
  "getrandom",
  "html-to-markdown-rs",
@@ -1383,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "tabctl-shared"
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -1731,9 +1733,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1754,18 +1756,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,4 +8,4 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.11"
+version = "0.6.0-rc.12"

--- a/rust/crates/host/src/host_impl/browser_state/mod.rs
+++ b/rust/crates/host/src/host_impl/browser_state/mod.rs
@@ -137,6 +137,7 @@ fn open_db(db_path: &Path) -> Result<Connection, String> {
             browser_window_id INTEGER,
             browser_group_id INTEGER,
             browser_tab_id INTEGER,
+            browser_tab_url TEXT,
             payload_json TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_browser_state_events_profile_recorded
@@ -146,7 +147,39 @@ fn open_db(db_path: &Path) -> Result<Connection, String> {
         "#,
     )
     .map_err(|e| format!("Failed to initialize browser-state schema: {e}"))?;
+    ensure_event_tab_url_column(&conn)?;
     Ok(conn)
+}
+
+fn ensure_event_tab_url_column(conn: &Connection) -> Result<(), String> {
+    let has_column = conn
+        .query_row(
+            "SELECT 1
+             FROM pragma_table_info('browser_state_events')
+             WHERE name = 'browser_tab_url'
+             LIMIT 1",
+            [],
+            |_| Ok(()),
+        )
+        .optional()
+        .map_err(|e| format!("Failed to inspect browser-state event schema: {e}"))?
+        .is_some();
+
+    if !has_column {
+        conn.execute(
+            "ALTER TABLE browser_state_events ADD COLUMN browser_tab_url TEXT",
+            [],
+        )
+        .map_err(|e| format!("Failed to migrate browser-state event schema: {e}"))?;
+    }
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_browser_state_events_tab_url
+         ON browser_state_events(profile_name, browser_tab_url, after_snapshot_id DESC)",
+        [],
+    )
+    .map_err(|e| format!("Failed to index browser-state event URLs: {e}"))?;
+    Ok(())
 }
 
 fn previous_snapshot_meta(
@@ -165,6 +198,18 @@ fn previous_snapshot_meta(
     )
     .optional()
     .map_err(|e| format!("Failed to load latest browser-state snapshot: {e}"))
+}
+
+fn snapshot_by_id(conn: &Connection, snapshot_id: i64) -> Result<Value, String> {
+    let snapshot_json: String = conn
+        .query_row(
+            "SELECT snapshot_json FROM browser_state_snapshots WHERE id = ?1",
+            params![snapshot_id],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Failed to load browser-state snapshot {snapshot_id}: {e}"))?;
+    serde_json::from_str::<Value>(&snapshot_json)
+        .map_err(|e| format!("Invalid stored snapshot JSON for {snapshot_id}: {e}"))
 }
 
 fn previous_groups(
@@ -510,6 +555,149 @@ fn sanitized_events(snapshot: &Value, events: &[Value]) -> Vec<Value> {
         .collect()
 }
 
+fn tab_urls_by_id(snapshot: &Value) -> HashMap<i64, String> {
+    let mut urls = HashMap::new();
+    for window in snapshot
+        .get("windows")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        for tab in window
+            .get("tabs")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let Some(tab_id) = tab.get("tabId").and_then(Value::as_i64) else {
+                continue;
+            };
+            let Some(url) = tab.get("url").and_then(Value::as_str) else {
+                continue;
+            };
+            if !url.is_empty() {
+                urls.insert(tab_id, normalize_url(url));
+            }
+        }
+    }
+    urls
+}
+
+fn normalized_event_tab_url(
+    event: &Value,
+    current_tab_urls: &HashMap<i64, String>,
+    previous_tab_urls: &HashMap<i64, String>,
+) -> Option<String> {
+    let explicit_url = event
+        .get("url")
+        .and_then(Value::as_str)
+        .or_else(|| event.get("pendingUrl").and_then(Value::as_str))
+        .or_else(|| {
+            event
+                .get("changeInfo")
+                .and_then(|change| change.get("url"))
+                .and_then(Value::as_str)
+        });
+    if let Some(url) = explicit_url {
+        return (!url.is_empty()).then(|| normalize_url(url));
+    }
+
+    let tab_id = event.get("tabId").and_then(Value::as_i64)?;
+    current_tab_urls
+        .get(&tab_id)
+        .or_else(|| previous_tab_urls.get(&tab_id))
+        .cloned()
+}
+
+fn normalized_event_prune_urls(
+    event: &Value,
+    current_tab_urls: &HashMap<i64, String>,
+    previous_tab_urls: &HashMap<i64, String>,
+) -> HashSet<String> {
+    let mut urls = HashSet::new();
+    if let Some(url) = normalized_event_tab_url(event, current_tab_urls, previous_tab_urls) {
+        urls.insert(url);
+    }
+    if let Some(tab_id) = event.get("tabId").and_then(Value::as_i64) {
+        if let Some(url) = current_tab_urls.get(&tab_id) {
+            urls.insert(url.clone());
+        }
+        if let Some(url) = previous_tab_urls.get(&tab_id) {
+            urls.insert(url.clone());
+        }
+    }
+    urls
+}
+
+fn prune_replaced_event_snapshots(
+    tx: &rusqlite::Transaction<'_>,
+    profile: &str,
+    current_snapshot_id: i64,
+    event_urls: &HashSet<String>,
+    open_urls: &HashSet<String>,
+) -> Result<usize, String> {
+    let mut protected_snapshot_ids = HashSet::new();
+    protected_snapshot_ids.insert(current_snapshot_id);
+    for open_url in open_urls {
+        let latest = tx
+            .query_row(
+                "SELECT MAX(after_snapshot_id)
+                 FROM browser_state_events
+                 WHERE profile_name = ?1 AND browser_tab_url = ?2",
+                params![profile, open_url],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .map_err(|e| format!("Failed to find latest open browser-state snapshot: {e}"))?;
+        if let Some(snapshot_id) = latest {
+            protected_snapshot_ids.insert(snapshot_id);
+        }
+    }
+
+    let mut pruned = 0;
+    for event_url in event_urls {
+        let url_is_open = open_urls.contains(event_url);
+        let mut stmt = tx
+            .prepare(
+                "SELECT DISTINCT old.after_snapshot_id
+                 FROM browser_state_events old
+                 WHERE old.profile_name = ?1
+                   AND old.browser_tab_url = ?2
+                   AND (?3 = 0 OR old.after_snapshot_id != ?4)",
+            )
+            .map_err(|e| format!("Failed to prepare replaced browser-state snapshot query: {e}"))?;
+        let rows = stmt
+            .query_map(
+                params![
+                    profile,
+                    event_url,
+                    if url_is_open { 1 } else { 0 },
+                    current_snapshot_id,
+                ],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|e| format!("Failed to query replaced browser-state snapshots: {e}"))?;
+        let mut candidates = Vec::new();
+        for row in rows {
+            let snapshot_id =
+                row.map_err(|e| format!("Failed to read replaced browser-state snapshot: {e}"))?;
+            if !protected_snapshot_ids.contains(&snapshot_id) {
+                candidates.push(snapshot_id);
+            }
+        }
+        drop(stmt);
+
+        for snapshot_id in candidates {
+            pruned += tx
+                .execute(
+                    "DELETE FROM browser_state_snapshots WHERE profile_name = ?1 AND id = ?2",
+                    params![profile, snapshot_id],
+                )
+                .map_err(|e| format!("Failed to prune replaced browser-state snapshot: {e}"))?;
+        }
+    }
+    Ok(pruned)
+}
+
 pub(super) fn ingest_sync(
     db_path: &Path,
     profile: Option<&str>,
@@ -561,6 +749,25 @@ pub(super) fn ingest_sync(
             "snapshotHash": snapshot_hash,
         }));
     }
+
+    let previous_snapshot = previous
+        .as_ref()
+        .map(|prev| snapshot_by_id(&conn, prev.snapshot_id))
+        .transpose()?;
+    let current_tab_urls = tab_urls_by_id(&snapshot);
+    let previous_tab_urls = previous_snapshot
+        .as_ref()
+        .map(tab_urls_by_id)
+        .unwrap_or_default();
+    let open_urls = current_tab_urls.values().cloned().collect::<HashSet<_>>();
+    let event_tab_urls = events
+        .iter()
+        .map(|event| normalized_event_tab_url(event, &current_tab_urls, &previous_tab_urls))
+        .collect::<Vec<_>>();
+    let event_prune_urls = events
+        .iter()
+        .flat_map(|event| normalized_event_prune_urls(event, &current_tab_urls, &previous_tab_urls))
+        .collect::<HashSet<_>>();
 
     let previous_groups_list = match previous.as_ref() {
         Some(prev) => previous_groups(&conn, profile, prev.snapshot_id)?,
@@ -649,7 +856,7 @@ pub(super) fn ingest_sync(
         .map_err(|e| format!("Failed to insert browser-state group: {e}"))?;
     }
 
-    for event in &events {
+    for (index, event) in events.iter().enumerate() {
         let kind = event
             .get("kind")
             .and_then(Value::as_str)
@@ -660,8 +867,9 @@ pub(super) fn ingest_sync(
         tx.execute(
             "INSERT INTO browser_state_events (
                 profile_name, recorded_at, reason, before_snapshot_id, after_snapshot_id,
-                kind, browser_window_id, browser_group_id, browser_tab_id, payload_json
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                kind, browser_window_id, browser_group_id, browser_tab_id, browser_tab_url,
+                payload_json
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 profile,
                 event
@@ -675,11 +883,15 @@ pub(super) fn ingest_sync(
                 event.get("windowId").and_then(Value::as_i64),
                 event.get("groupId").and_then(Value::as_i64),
                 event.get("tabId").and_then(Value::as_i64),
+                event_tab_urls.get(index).and_then(Option::as_deref),
                 payload_json,
             ],
         )
         .map_err(|e| format!("Failed to insert browser-state event: {e}"))?;
     }
+
+    let pruned_snapshots =
+        prune_replaced_event_snapshots(&tx, profile, snapshot_id, &event_prune_urls, &open_urls)?;
 
     tx.commit()
         .map_err(|e| format!("Failed to commit browser-state transaction: {e}"))?;
@@ -694,6 +906,7 @@ pub(super) fn ingest_sync(
         "groupCount": group_count,
         "tabCount": tab_count,
         "previousSnapshotId": previous.map(|prev| prev.snapshot_id),
+        "prunedSnapshots": pruned_snapshots,
     }))
 }
 
@@ -840,7 +1053,8 @@ pub(super) fn list_events(
         let mut stmt = conn
             .prepare(
                 "SELECT id, recorded_at, reason, before_snapshot_id, after_snapshot_id, kind,
-                        browser_window_id, browser_group_id, browser_tab_id, payload_json
+                        browser_window_id, browser_group_id, browser_tab_id, browser_tab_url,
+                        payload_json
                  FROM browser_state_events
                  WHERE profile_name = ?1 AND kind = ?2
                  ORDER BY id DESC
@@ -857,7 +1071,8 @@ pub(super) fn list_events(
         let mut stmt = conn
             .prepare(
                 "SELECT id, recorded_at, reason, before_snapshot_id, after_snapshot_id, kind,
-                        browser_window_id, browser_group_id, browser_tab_id, payload_json
+                        browser_window_id, browser_group_id, browser_tab_id, browser_tab_url,
+                        payload_json
                  FROM browser_state_events
                  WHERE profile_name = ?1
                  ORDER BY id DESC
@@ -885,7 +1100,8 @@ fn map_event_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Value> {
         "browserWindowId": row.get::<_, Option<i64>>(6)?,
         "browserGroupId": row.get::<_, Option<i64>>(7)?,
         "browserTabId": row.get::<_, Option<i64>>(8)?,
-        "payloadJson": row.get::<_, String>(9)?,
+        "browserTabUrl": row.get::<_, Option<String>>(9)?,
+        "payloadJson": row.get::<_, String>(10)?,
     }))
 }
 
@@ -1251,5 +1467,289 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0]["kind"], "tabs.onRemoved");
         assert_eq!(items[0]["browserTabId"].as_i64(), Some(999));
+    }
+
+    #[test]
+    fn migrates_existing_events_table_with_tab_url_column() {
+        let db = TempDbPath::new();
+        let conn = Connection::open(db.as_path()).expect("create old db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE browser_state_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_name TEXT NOT NULL,
+                recorded_at INTEGER NOT NULL,
+                reason TEXT NOT NULL,
+                before_snapshot_id INTEGER,
+                after_snapshot_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                browser_window_id INTEGER,
+                browser_group_id INTEGER,
+                browser_tab_id INTEGER,
+                payload_json TEXT NOT NULL
+            );
+            "#,
+        )
+        .expect("create old events table");
+        drop(conn);
+
+        let conn = open_db(db.as_path()).expect("migrate db");
+        let has_column: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0
+                 FROM pragma_table_info('browser_state_events')
+                 WHERE name = 'browser_tab_url'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("column check");
+        let has_index: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0
+                 FROM sqlite_master
+                 WHERE type = 'index' AND name = 'idx_browser_state_events_tab_url'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("index check");
+
+        assert!(has_column);
+        assert!(has_index);
+    }
+
+    #[test]
+    fn prunes_replaced_event_snapshots_by_normalized_url() {
+        let db = TempDbPath::new();
+        for idx in 0..3 {
+            ingest_sync(
+                db.as_path(),
+                Some("edge"),
+                &serde_json::json!({
+                    "reason": "event",
+                    "recordedAt": 1000 + idx as i64,
+                    "events": [{
+                        "kind": "tabs.onUpdated",
+                        "tabId": 1,
+                        "changeInfo": { "title": format!("tick-{idx}") }
+                    }],
+                    "snapshot": sample_snapshot("Work", &["https://example.com/page#frag", "https://example.org/other"])
+                }),
+            )
+            .expect("ingest");
+        }
+        ingest_sync(
+            db.as_path(),
+            Some("edge"),
+            &serde_json::json!({
+                "reason": "event",
+                "recordedAt": 2000,
+                "events": [{
+                    "kind": "tabs.onUpdated",
+                    "tabId": 2,
+                    "changeInfo": { "title": "other page" }
+                }],
+                "snapshot": sample_snapshot("Work", &["https://example.com/page#later", "https://example.org/other"])
+            }),
+        )
+        .expect("ingest distinct URL");
+        ingest_sync(
+            db.as_path(),
+            Some("edge"),
+            &serde_json::json!({
+                "reason": "event",
+                "recordedAt": 3000,
+                "events": [{
+                    "kind": "tabs.onUpdated",
+                    "tabId": 1,
+                    "changeInfo": { "title": "latest page" }
+                }],
+                "snapshot": sample_snapshot("Work", &["https://example.com/page#latest", "https://example.org/other"])
+            }),
+        )
+        .expect("ingest latest URL");
+
+        let conn = open_db(db.as_path()).expect("open db");
+        let snapshot_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_snapshots WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count snapshots");
+        let window_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_windows WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count windows");
+        let group_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_groups WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count groups");
+        let event_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_events WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count events");
+
+        assert_eq!(snapshot_count, 2);
+        assert_eq!(window_count, 2);
+        assert_eq!(group_count, 2);
+        assert_eq!(event_count, 2);
+
+        let events = list_events(db.as_path(), Some("edge"), Some(10), None).expect("events");
+        let items = events.as_array().expect("event items");
+        let urls = items
+            .iter()
+            .filter_map(|item| item["browserTabUrl"].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(urls, vec!["example.com/page", "example.org/other"]);
+    }
+
+    #[test]
+    fn removes_snapshots_for_closed_normalized_url() {
+        let db = TempDbPath::new();
+        ingest_sync(
+            db.as_path(),
+            Some("edge"),
+            &serde_json::json!({
+                "reason": "event",
+                "recordedAt": 1000,
+                "events": [{
+                    "kind": "tabs.onUpdated",
+                    "tabId": 1,
+                    "changeInfo": { "title": "open" }
+                }],
+                "snapshot": sample_snapshot("Work", &["https://closed.example/page#open", "https://open.example/other"])
+            }),
+        )
+        .expect("open ingest");
+
+        ingest_sync(
+            db.as_path(),
+            Some("edge"),
+            &serde_json::json!({
+                "reason": "event",
+                "recordedAt": 2000,
+                "events": [{
+                    "kind": "tabs.onRemoved",
+                    "tabId": 1,
+                    "windowId": 100
+                }],
+                "snapshot": {
+                    "generatedAt": 1_700_000_000_001_i64,
+                    "windows": [{
+                        "windowId": 100,
+                        "focused": true,
+                        "state": "normal",
+                        "tabs": [{
+                            "tabId": 2,
+                            "windowId": 100,
+                            "index": 0,
+                            "url": "https://open.example/other",
+                            "title": "Still open",
+                            "active": true,
+                            "pinned": false,
+                            "groupId": -1
+                        }],
+                        "groups": []
+                    }]
+                }
+            }),
+        )
+        .expect("close ingest");
+
+        let conn = open_db(db.as_path()).expect("open db");
+        let snapshot_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_snapshots WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count snapshots");
+        let event_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_events WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count events");
+
+        assert_eq!(snapshot_count, 1);
+        assert_eq!(event_count, 1);
+
+        let latest = latest_snapshot(db.as_path(), Some("edge")).expect("latest");
+        let tabs = latest["snapshot"]["windows"][0]["tabs"]
+            .as_array()
+            .expect("latest tabs");
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(tabs[0]["url"].as_str(), Some("https://open.example/other"));
+    }
+
+    #[test]
+    fn removes_snapshots_for_replaced_tab_url() {
+        let db = TempDbPath::new();
+        ingest_sync(
+            db.as_path(),
+            Some("edge"),
+            &serde_json::json!({
+                "reason": "event",
+                "recordedAt": 1000,
+                "events": [{
+                    "kind": "tabs.onUpdated",
+                    "tabId": 1,
+                    "changeInfo": { "title": "old page" }
+                }],
+                "snapshot": sample_snapshot("Work", &["https://old.example/page#old", "https://open.example/other"])
+            }),
+        )
+        .expect("old URL ingest");
+
+        ingest_sync(
+            db.as_path(),
+            Some("edge"),
+            &serde_json::json!({
+                "reason": "event",
+                "recordedAt": 2000,
+                "events": [{
+                    "kind": "tabs.onUpdated",
+                    "tabId": 1,
+                    "changeInfo": { "url": "https://new.example/page#new" }
+                }],
+                "snapshot": sample_snapshot("Work", &["https://new.example/page#new", "https://open.example/other"])
+            }),
+        )
+        .expect("new URL ingest");
+
+        let conn = open_db(db.as_path()).expect("open db");
+        let snapshot_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_snapshots WHERE profile_name = 'edge'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count snapshots");
+        let old_url_events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM browser_state_events WHERE profile_name = 'edge' AND browser_tab_url = 'old.example/page'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count old URL events");
+
+        assert_eq!(snapshot_count, 1);
+        assert_eq!(old_url_events, 0);
+
+        let latest = latest_snapshot(db.as_path(), Some("edge")).expect("latest");
+        assert_eq!(
+            latest["snapshot"]["windows"][0]["tabs"][0]["url"].as_str(),
+            Some("https://new.example/page#new")
+        );
     }
 }

--- a/rust/crates/host/src/host_impl/page_cache.rs
+++ b/rust/crates/host/src/host_impl/page_cache.rs
@@ -21,6 +21,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 const MAX_HTML_CHARS_PER_ENTRY: usize = 10 * 1024 * 1024;
 const MAX_ENTRIES: usize = 250;
 const MAX_TOTAL_HTML_BYTES: usize = 512 * 1024 * 1024;
+const MAX_OPEN_TAB_CLEANUP_FILE_READS: usize = 16;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct CacheKey {
@@ -58,6 +59,24 @@ pub(crate) struct PageCacheEntry {
     pub(crate) source_text_chars: i64,
     pub(crate) document_ready_state: Option<String>,
     pub(crate) captured_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PageCacheFileMetadata {
+    profile: String,
+    tab_id: i64,
+    url_key: String,
+    #[serde(default)]
+    canonical_url_key: String,
+}
+
+#[derive(Debug)]
+struct PageCacheFileSummary {
+    path: PathBuf,
+    key: CacheKey,
+    captured_at: i64,
+    html_bytes: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -179,12 +198,19 @@ impl PageCache {
             })
     }
 
-    pub(crate) fn has_exact_open_tab(&self, profile: Option<&str>, tab_id: i64, url: &str) -> bool {
-        self.entries.contains_key(&CacheKey {
-            profile: profile_key(profile),
-            tab_id,
-            url_key: url_key(url),
-        })
+    pub(crate) fn exact_file_available(
+        path: &Path,
+        profile: Option<&str>,
+        tab_id: i64,
+        url: &str,
+    ) -> Result<bool, String> {
+        let profile = profile_key(profile);
+        let url_key = url_key(url);
+        let file_path = cache_file_path_for_key(path, &profile, tab_id, &url_key);
+        let Some(entry) = read_exact_file_entry(&file_path, &profile, tab_id, &url_key)? else {
+            return Ok(false);
+        };
+        Ok(is_usable_entry(&entry))
     }
 
     #[cfg(test)]
@@ -218,39 +244,73 @@ impl PageCache {
         incognito: bool,
         captured_at: i64,
     ) {
-        if incognito
-            || truncated_html
-            || html.is_empty()
-            || html.chars().count() > MAX_HTML_CHARS_PER_ENTRY
-        {
-            return;
-        }
-
-        let profile = profile_key(profile);
-        let url_key = url_key(url);
-        let canonical_url_key = canonical_url_key(url);
-        let key = CacheKey {
-            profile: profile.clone(),
+        let Some(entry) = build_success_entry(
+            profile,
             tab_id,
-            url_key: url_key.clone(),
+            url,
+            title,
+            html,
+            source_html_chars,
+            source_text_chars,
+            document_ready_state,
+            truncated_html,
+            incognito,
+            captured_at,
+        ) else {
+            return;
         };
-        self.entries.insert(
-            key,
-            PageCacheEntry {
-                profile,
-                tab_id,
-                url_key,
-                canonical_url_key,
-                title: title.map(str::to_string),
-                html: html.to_string(),
-                source_html_chars,
-                source_text_chars,
-                document_ready_state: document_ready_state.map(str::to_string),
-                captured_at,
-            },
-        );
+
+        let key = CacheKey {
+            profile: entry.profile.clone(),
+            tab_id: entry.tab_id,
+            url_key: entry.url_key.clone(),
+        };
+        self.entries.insert(key, entry);
         self.dirty = true;
         self.enforce_caps();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn store_success_file(
+        path: &Path,
+        profile: Option<&str>,
+        tab_id: i64,
+        url: &str,
+        title: Option<&str>,
+        html: &str,
+        source_html_chars: i64,
+        source_text_chars: i64,
+        document_ready_state: Option<&str>,
+        truncated_html: bool,
+        incognito: bool,
+        captured_at: i64,
+        open_tabs: Option<&[OpenTabCacheKey]>,
+    ) -> Result<bool, String> {
+        let Some(entry) = build_success_entry(
+            profile,
+            tab_id,
+            url,
+            title,
+            html,
+            source_html_chars,
+            source_text_chars,
+            document_ready_state,
+            truncated_html,
+            incognito,
+            captured_at,
+        ) else {
+            return Ok(false);
+        };
+
+        fs::create_dir_all(path).map_err(|err| format!("create page cache directory: {err}"))?;
+        set_private_dir_permissions(path)?;
+        write_cache_entry(path, &entry)?;
+        remove_replaced_files_for_current_tab(path, &entry)?;
+        if let Some(open_tabs) = open_tabs {
+            remove_stale_files_to_open_tabs(path, &entry.profile, open_tabs)?;
+        }
+        enforce_file_caps(path)?;
+        Self::exact_file_available(path, Some(&entry.profile), entry.tab_id, &entry.url_key)
     }
 
     pub(crate) fn prune_to_open_tabs(
@@ -307,23 +367,7 @@ impl PageCache {
         let mut entries: Vec<_> = self.entries.values().cloned().collect();
         entries.sort_by_key(|entry| (entry.captured_at, entry.profile.clone(), entry.tab_id));
         for entry in entries {
-            let file_path = cache_file_path(path, &entry);
-            let tmp_path = file_path.with_extension(format!(
-                "json.tmp.{}.{}",
-                std::process::id(),
-                crate::host_impl::protocol::now_ms()
-            ));
-            let bytes = serde_json::to_vec_pretty(&entry)
-                .map_err(|err| format!("serialize page cache: {err}"))?;
-            write_private_file(&tmp_path, &bytes).map_err(|err| {
-                let _ = fs::remove_file(&tmp_path);
-                err
-            })?;
-            fs::rename(&tmp_path, &file_path).map_err(|err| {
-                let _ = fs::remove_file(&tmp_path);
-                format!("replace page cache: {err}")
-            })?;
-            set_private_file_permissions(&file_path)?;
+            write_cache_entry(path, &entry)?;
         }
         self.dirty = false;
         Ok(())
@@ -364,11 +408,288 @@ impl PageCache {
 }
 
 fn cache_file_path(dir: &Path, entry: &PageCacheEntry) -> PathBuf {
+    cache_file_path_for_key(dir, &entry.profile, entry.tab_id, &entry.url_key)
+}
+
+fn cache_file_path_for_key(dir: &Path, profile: &str, tab_id: i64, url_key: &str) -> PathBuf {
     dir.join(format!(
         "tab-{}-{}.json",
-        entry.tab_id,
-        cache_file_hash(&entry.profile, entry.tab_id, &entry.url_key)
+        tab_id,
+        cache_file_hash(profile, tab_id, url_key)
     ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_success_entry(
+    profile: Option<&str>,
+    tab_id: i64,
+    url: &str,
+    title: Option<&str>,
+    html: &str,
+    source_html_chars: i64,
+    source_text_chars: i64,
+    document_ready_state: Option<&str>,
+    truncated_html: bool,
+    incognito: bool,
+    captured_at: i64,
+) -> Option<PageCacheEntry> {
+    if incognito
+        || truncated_html
+        || html.is_empty()
+        || html.chars().count() > MAX_HTML_CHARS_PER_ENTRY
+    {
+        return None;
+    }
+
+    let profile = profile_key(profile);
+    let url_key = url_key(url);
+    Some(PageCacheEntry {
+        profile,
+        tab_id,
+        canonical_url_key: canonical_url_key(url),
+        url_key,
+        title: title.map(str::to_string),
+        html: html.to_string(),
+        source_html_chars,
+        source_text_chars,
+        document_ready_state: document_ready_state.map(str::to_string),
+        captured_at,
+    })
+}
+
+fn read_exact_file_entry(
+    file_path: &Path,
+    profile: &str,
+    tab_id: i64,
+    url_key: &str,
+) -> Result<Option<PageCacheEntry>, String> {
+    let bytes = match fs::read(file_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(format!("read page cache: {err}")),
+    };
+    let Ok(entry) = serde_json::from_slice::<PageCacheEntry>(&bytes) else {
+        let _ = fs::remove_file(file_path);
+        return Ok(None);
+    };
+    if entry.profile != profile
+        || entry.tab_id != tab_id
+        || entry.url_key != url_key
+        || !is_usable_entry(&entry)
+    {
+        let _ = fs::remove_file(file_path);
+        return Ok(None);
+    }
+    Ok(Some(entry))
+}
+
+fn is_usable_entry(entry: &PageCacheEntry) -> bool {
+    !entry.html.is_empty() && entry.html.chars().count() <= MAX_HTML_CHARS_PER_ENTRY
+}
+
+fn write_cache_entry(dir: &Path, entry: &PageCacheEntry) -> Result<(), String> {
+    let file_path = cache_file_path(dir, entry);
+    let tmp_path = file_path.with_extension(format!(
+        "json.tmp.{}.{}",
+        std::process::id(),
+        crate::host_impl::protocol::now_ms()
+    ));
+    let bytes =
+        serde_json::to_vec_pretty(entry).map_err(|err| format!("serialize page cache: {err}"))?;
+    write_private_file(&tmp_path, &bytes).map_err(|err| {
+        let _ = fs::remove_file(&tmp_path);
+        err
+    })?;
+    fs::rename(&tmp_path, &file_path).map_err(|err| {
+        let _ = fs::remove_file(&tmp_path);
+        format!("replace page cache: {err}")
+    })?;
+    set_private_file_permissions(&file_path)
+}
+
+fn remove_stale_files_to_open_tabs(
+    dir: &Path,
+    profile: &str,
+    open_tabs: &[OpenTabCacheKey],
+) -> Result<(), String> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(format!("read page cache directory: {err}")),
+    };
+    let open_exact_urls: HashSet<String> = open_tabs.iter().map(|tab| url_key(&tab.url)).collect();
+    let open_canonical_urls: HashSet<String> = open_tabs
+        .iter()
+        .map(|tab| canonical_url_key(&tab.url))
+        .collect();
+
+    let mut files_read = 0usize;
+    for dir_entry in entries.filter_map(Result::ok) {
+        if files_read >= MAX_OPEN_TAB_CLEANUP_FILE_READS {
+            break;
+        }
+        let file_path = dir_entry.path();
+        if file_path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = match fs::read(&file_path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(format!("read page cache: {err}")),
+        };
+        files_read += 1;
+        let Ok(entry) = serde_json::from_slice::<PageCacheFileMetadata>(&bytes) else {
+            continue;
+        };
+        if entry.profile != profile {
+            continue;
+        }
+        let canonical_url_key = if entry.canonical_url_key.is_empty() {
+            canonical_url_key(&entry.url_key)
+        } else {
+            entry.canonical_url_key.clone()
+        };
+        if !open_exact_urls.contains(&entry.url_key)
+            && !open_canonical_urls.contains(&canonical_url_key)
+        {
+            let _ = fs::remove_file(&file_path);
+        }
+    }
+    Ok(())
+}
+
+fn remove_replaced_files_for_current_tab(
+    dir: &Path,
+    current: &PageCacheEntry,
+) -> Result<(), String> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(format!("read page cache directory: {err}")),
+    };
+    let current_path = cache_file_path(dir, current);
+    let tab_prefix = format!("tab-{}-", current.tab_id);
+
+    for dir_entry in entries.filter_map(Result::ok) {
+        let file_path = dir_entry.path();
+        if file_path == current_path
+            || file_path.extension().and_then(|ext| ext.to_str()) != Some("json")
+            || !dir_entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with(&tab_prefix)
+        {
+            continue;
+        }
+
+        let bytes = match fs::read(&file_path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(format!("read page cache: {err}")),
+        };
+        let Ok(entry) = serde_json::from_slice::<PageCacheFileMetadata>(&bytes) else {
+            continue;
+        };
+        if entry.profile != current.profile || entry.tab_id != current.tab_id {
+            continue;
+        }
+        let canonical_url_key = if entry.canonical_url_key.is_empty() {
+            canonical_url_key(&entry.url_key)
+        } else {
+            entry.canonical_url_key
+        };
+        if entry.url_key != current.url_key && canonical_url_key != current.canonical_url_key {
+            let _ = fs::remove_file(&file_path);
+        }
+    }
+    Ok(())
+}
+
+fn enforce_file_caps(dir: &Path) -> Result<(), String> {
+    enforce_file_caps_with_limits(dir, MAX_ENTRIES, MAX_TOTAL_HTML_BYTES)
+}
+
+fn enforce_file_caps_with_limits(
+    dir: &Path,
+    max_entries: usize,
+    max_total_html_bytes: usize,
+) -> Result<(), String> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(format!("read page cache directory: {err}")),
+    };
+
+    let mut file_paths = Vec::new();
+    let mut total_file_bytes = 0usize;
+    for dir_entry in entries.filter_map(Result::ok) {
+        let file_path = dir_entry.path();
+        if file_path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(metadata) = dir_entry.metadata() {
+            total_file_bytes = total_file_bytes.saturating_add(metadata.len() as usize);
+        }
+        file_paths.push(file_path);
+    }
+
+    if file_paths.len() <= max_entries && total_file_bytes <= max_total_html_bytes {
+        return Ok(());
+    }
+
+    let mut summaries = Vec::new();
+    for file_path in file_paths {
+        match read_cache_file_summary(&file_path)? {
+            Some(summary) => summaries.push(summary),
+            None => {
+                let _ = fs::remove_file(file_path);
+            }
+        }
+    }
+
+    summaries.sort_by_key(|summary| summary.captured_at);
+    let mut keep = HashSet::new();
+    let mut total_html_bytes = 0usize;
+    for summary in summaries.iter().rev() {
+        if keep.len() >= max_entries
+            || total_html_bytes.saturating_add(summary.html_bytes) > max_total_html_bytes
+        {
+            continue;
+        }
+        total_html_bytes += summary.html_bytes;
+        keep.insert(summary.key.clone());
+    }
+
+    for summary in summaries {
+        if !keep.contains(&summary.key) {
+            let _ = fs::remove_file(summary.path);
+        }
+    }
+    Ok(())
+}
+
+fn read_cache_file_summary(file_path: &Path) -> Result<Option<PageCacheFileSummary>, String> {
+    let bytes = match fs::read(file_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(format!("read page cache: {err}")),
+    };
+    let Ok(entry) = serde_json::from_slice::<PageCacheEntry>(&bytes) else {
+        return Ok(None);
+    };
+    if !is_usable_entry(&entry) {
+        return Ok(None);
+    }
+    Ok(Some(PageCacheFileSummary {
+        path: file_path.to_path_buf(),
+        key: CacheKey {
+            profile: entry.profile,
+            tab_id: entry.tab_id,
+            url_key: entry.url_key,
+        },
+        captured_at: entry.captured_at,
+        html_bytes: entry.html.len(),
+    }))
 }
 
 fn cache_file_hash(profile: &str, tab_id: i64, url_key: &str) -> String {
@@ -417,9 +738,7 @@ fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
         .map_err(|err| format!("create page cache temp file: {err}"))?;
 
     file.write_all(bytes)
-        .map_err(|err| format!("write page cache: {err}"))?;
-    file.sync_all()
-        .map_err(|err| format!("sync page cache: {err}"))
+        .map_err(|err| format!("write page cache: {err}"))
 }
 
 fn set_private_dir_permissions(path: &Path) -> Result<(), String> {
@@ -452,6 +771,7 @@ fn set_private_file_permissions(path: &Path) -> Result<(), String> {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
 
     fn cache_path(name: &str) -> std::path::PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1022,5 +1342,375 @@ mod tests {
             .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
             .collect();
         assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn fast_store_writes_single_exact_file_without_rewriting_unrelated_entries() {
+        let path = cache_path("fast-store");
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("other"),
+            1,
+            "https://example.com/other",
+            "other",
+            1,
+        );
+        cache.save_if_dirty(&path).expect("seed cache");
+        let unrelated_path = fs::read_dir(&path)
+            .expect("read cache dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .expect("unrelated cache file");
+        let before = fs::metadata(&unrelated_path)
+            .expect("metadata before")
+            .modified()
+            .expect("modified before");
+
+        PageCache::store_success_file(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/page",
+            Some("Page"),
+            "<html>fast</html>",
+            17,
+            4,
+            Some("complete"),
+            false,
+            false,
+            2,
+            None,
+        )
+        .expect("fast store");
+
+        assert_eq!(
+            fs::metadata(&unrelated_path)
+                .expect("metadata after")
+                .modified()
+                .expect("modified after"),
+            before
+        );
+        assert!(PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/page"
+        )
+        .expect("exact status"));
+        assert_eq!(
+            fs::read_dir(&path)
+                .expect("read cache dir")
+                .filter_map(Result::ok)
+                .filter(
+                    |entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+                )
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn fast_store_enforces_max_entries_without_rewriting_retained_files() {
+        let path = cache_path("fast-store-entry-cap");
+        let mut cache = PageCache::default();
+        for i in 0..MAX_ENTRIES {
+            store(
+                &mut cache,
+                Some("work"),
+                i as i64,
+                &format!("https://example.com/{i}"),
+                "seed",
+                i as i64,
+            );
+        }
+        cache.save_if_dirty(&path).expect("seed cache");
+        let retained_path = cache_file_path_for_key(
+            &path,
+            "work",
+            (MAX_ENTRIES - 1) as i64,
+            &format!("https://example.com/{}", MAX_ENTRIES - 1),
+        );
+        let before = fs::metadata(&retained_path)
+            .expect("metadata before")
+            .modified()
+            .expect("modified before");
+        std::thread::sleep(Duration::from_millis(20));
+
+        PageCache::store_success_file(
+            &path,
+            Some("work"),
+            MAX_ENTRIES as i64,
+            "https://example.com/new",
+            Some("Page"),
+            "<html>new</html>",
+            16,
+            3,
+            Some("complete"),
+            false,
+            false,
+            MAX_ENTRIES as i64,
+            None,
+        )
+        .expect("fast store");
+
+        assert_eq!(
+            fs::read_dir(&path)
+                .expect("read cache dir")
+                .filter_map(Result::ok)
+                .filter(
+                    |entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json")
+                )
+                .count(),
+            MAX_ENTRIES
+        );
+        assert!(
+            !PageCache::exact_file_available(&path, Some("work"), 0, "https://example.com/0")
+                .expect("oldest evicted")
+        );
+        assert!(PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            MAX_ENTRIES as i64,
+            "https://example.com/new"
+        )
+        .expect("new retained"));
+        assert_eq!(
+            fs::metadata(&retained_path)
+                .expect("metadata after")
+                .modified()
+                .expect("modified after"),
+            before
+        );
+    }
+
+    #[test]
+    fn exact_file_status_deletes_known_stale_exact_file_only() {
+        let path = cache_path("exact-stale");
+        fs::create_dir_all(&path).expect("create dir");
+        let exact_path = cache_file_path_for_key(&path, "work", 42, "https://example.com/page");
+        let unrelated_path = cache_file_path_for_key(&path, "work", 43, "https://example.com/page");
+        fs::write(&exact_path, b"not-json").expect("write corrupt exact cache");
+        fs::write(&unrelated_path, b"not-json").expect("write corrupt unrelated cache");
+
+        assert!(!PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/page"
+        )
+        .expect("exact status"));
+        assert!(!exact_path.exists());
+        assert!(unrelated_path.exists());
+    }
+
+    #[test]
+    fn fast_store_removes_stale_files_for_closed_tabs_from_open_snapshot() {
+        let path = cache_path("fast-closed-tab-cleanup");
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work"),
+            10,
+            "https://example.com/keep",
+            "keep",
+            1,
+        );
+        store(
+            &mut cache,
+            Some("work"),
+            11,
+            "https://example.com/closed",
+            "closed",
+            2,
+        );
+        store(
+            &mut cache,
+            Some("other"),
+            11,
+            "https://example.com/closed",
+            "other",
+            3,
+        );
+        cache.save_if_dirty(&path).expect("seed cache");
+
+        PageCache::store_success_file(
+            &path,
+            Some("work"),
+            12,
+            "https://example.com/current",
+            Some("Page"),
+            "<html>current</html>",
+            20,
+            3,
+            Some("complete"),
+            false,
+            false,
+            4,
+            Some(&[
+                OpenTabCacheKey::new(10, "https://example.com/keep"),
+                OpenTabCacheKey::new(12, "https://example.com/current"),
+            ]),
+        )
+        .expect("fast store");
+
+        let loaded = PageCache::load(&path);
+        assert!(loaded
+            .lookup_exact_open_tab(Some("work"), 10, "https://example.com/keep")
+            .is_some());
+        assert!(loaded
+            .lookup_exact_open_tab(Some("work"), 11, "https://example.com/closed")
+            .is_none());
+        assert!(loaded
+            .lookup_exact_open_tab(Some("work"), 12, "https://example.com/current")
+            .is_some());
+        assert!(loaded
+            .lookup_exact_open_tab(Some("other"), 11, "https://example.com/closed")
+            .is_some());
+    }
+
+    #[test]
+    fn fast_store_removes_replaced_url_cache_and_keeps_new_entry() {
+        let path = cache_path("fast-replaced-url-cleanup");
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work"),
+            42,
+            "https://example.com/old#section",
+            "old",
+            1,
+        );
+        cache.save_if_dirty(&path).expect("seed cache");
+
+        PageCache::store_success_file(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/new#section",
+            Some("Page"),
+            "<html>new</html>",
+            16,
+            3,
+            Some("complete"),
+            false,
+            false,
+            2,
+            Some(&[OpenTabCacheKey::new(42, "https://example.com/new#section")]),
+        )
+        .expect("fast store");
+
+        let loaded = PageCache::load(&path);
+        assert!(loaded
+            .lookup_exact_open_tab(Some("work"), 42, "https://example.com/old#section")
+            .is_none());
+        assert!(loaded
+            .lookup_exact_open_tab(Some("work"), 42, "https://example.com/new#section")
+            .is_some());
+        assert!(PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/new#section"
+        )
+        .expect("exact status"));
+    }
+
+    #[test]
+    fn fast_store_does_not_rewrite_retained_profile_files() {
+        let path = cache_path("fast-retained-no-rewrite");
+        let mut cache = PageCache::default();
+        store(
+            &mut cache,
+            Some("work"),
+            10,
+            "https://example.com/retained",
+            "retained",
+            1,
+        );
+        cache.save_if_dirty(&path).expect("seed cache");
+        let retained_path =
+            cache_file_path_for_key(&path, "work", 10, "https://example.com/retained");
+        let before = fs::metadata(&retained_path)
+            .expect("metadata before")
+            .modified()
+            .expect("modified before");
+        std::thread::sleep(Duration::from_millis(20));
+
+        PageCache::store_success_file(
+            &path,
+            Some("work"),
+            12,
+            "https://example.com/current",
+            Some("Page"),
+            "<html>current</html>",
+            20,
+            3,
+            Some("complete"),
+            false,
+            false,
+            2,
+            Some(&[
+                OpenTabCacheKey::new(10, "https://example.com/retained"),
+                OpenTabCacheKey::new(12, "https://example.com/current"),
+            ]),
+        )
+        .expect("fast store");
+
+        assert_eq!(
+            fs::metadata(&retained_path)
+                .expect("metadata after")
+                .modified()
+                .expect("modified after"),
+            before
+        );
+        let loaded = PageCache::load(&path);
+        assert!(loaded
+            .lookup_exact_open_tab(Some("work"), 10, "https://example.com/retained")
+            .is_some());
+    }
+
+    #[test]
+    fn exact_file_status_remains_exact_not_canonical_or_duplicate() {
+        let path = cache_path("exact-status-exact-only");
+        PageCache::store_success_file(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/page#section",
+            Some("Page"),
+            "<html>exact</html>",
+            18,
+            3,
+            Some("complete"),
+            false,
+            false,
+            1,
+            None,
+        )
+        .expect("store exact");
+
+        assert!(PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/page#section"
+        )
+        .expect("exact hit"));
+        assert!(!PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            42,
+            "https://example.com/page#other"
+        )
+        .expect("canonical miss"));
+        assert!(!PageCache::exact_file_available(
+            &path,
+            Some("work"),
+            7,
+            "https://example.com/page#section"
+        )
+        .expect("duplicate-tab miss"));
     }
 }

--- a/rust/crates/host/src/host_impl/state.rs
+++ b/rust/crates/host/src/host_impl/state.rs
@@ -158,11 +158,9 @@ impl HostState {
             .unwrap_or_else(|| now_ms() as i64);
         let title = tab.get("title").and_then(Value::as_str);
 
-        let mut cache = PageCache::load(&self.page_cache_path);
-        if let Some(open_tabs) = page_cache_open_tabs_from_payload(root) {
-            cache.prune_to_open_tabs(self.profile_name.as_deref(), &open_tabs);
-        }
-        cache.store_success(
+        let open_tabs = page_cache_open_tabs_from_payload(root);
+        PageCache::store_success_file(
+            &self.page_cache_path,
             self.profile_name.as_deref(),
             tab_id,
             url,
@@ -174,10 +172,8 @@ impl HostState {
             truncated_html,
             incognito,
             captured_at,
-        );
-        let available = cache.has_exact_open_tab(self.profile_name.as_deref(), tab_id, url);
-        cache.save_if_dirty(&self.page_cache_path)?;
-        Ok(available)
+            open_tabs.as_deref(),
+        )
     }
 
     fn page_cache_status(&self, payload: &Value) -> Value {
@@ -187,12 +183,19 @@ impl HostState {
         if incognito || discarded || is_non_scriptable_url(&url) {
             return page_cache_status_value(Some(tab_id), Some(&url), false);
         }
-        let cache = PageCache::load(&self.page_cache_path);
-        page_cache_status_value(
-            Some(tab_id),
-            Some(&url),
-            cache.has_exact_open_tab(self.profile_name.as_deref(), tab_id, &url),
-        )
+        let available = match PageCache::exact_file_available(
+            &self.page_cache_path,
+            self.profile_name.as_deref(),
+            tab_id,
+            &url,
+        ) {
+            Ok(available) => available,
+            Err(err) => {
+                log_line(&format!("page-cache status failed: {err}"));
+                false
+            }
+        };
+        page_cache_status_value(Some(tab_id), Some(&url), available)
     }
 
     fn page_cache_status_effect(&self, id: String, payload: &Value, available: bool) -> HostEffect {
@@ -1132,6 +1135,7 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, Instant};
 
     fn state_path(name: &str) -> PathBuf {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -1360,6 +1364,82 @@ mod tests {
         assert_eq!(
             message.data.as_ref().expect("status data")["available"],
             false
+        );
+    }
+
+    #[test]
+    fn page_cache_capture_with_many_existing_files_has_fast_post_settle_contract() {
+        let (mut state, page_cache_path) = page_cache_test_state("many-existing-fast-contract");
+        let mut cache = PageCache::default();
+        for i in 0..200 {
+            let html = format!("<html>unrelated {i}</html>");
+            cache.store_success(
+                Some("other-profile"),
+                i,
+                &format!("https://unrelated.example/{i}"),
+                Some("Unrelated"),
+                &html,
+                html.chars().count() as i64,
+                i,
+                Some("complete"),
+                false,
+                false,
+                i,
+            );
+        }
+        cache
+            .save_if_dirty(&page_cache_path)
+            .expect("seed cache files");
+
+        let before_files: Vec<_> = fs::read_dir(&page_cache_path)
+            .expect("read seeded cache")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .map(|path| {
+                let modified = fs::metadata(&path)
+                    .expect("metadata before")
+                    .modified()
+                    .expect("modified before");
+                (path, modified)
+            })
+            .collect();
+        assert_eq!(before_files.len(), 200);
+        std::thread::sleep(Duration::from_millis(20));
+
+        let started = Instant::now();
+        let effects = state.handle_native_message(page_cache_capture(
+            "READ",
+            false,
+            false,
+            "<html>ok</html>",
+        ));
+        let elapsed = started.elapsed();
+
+        assert_cache_status_effect(&effects, true);
+        let modified_existing = before_files
+            .iter()
+            .filter(|(path, before)| {
+                fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .map(|after| after != *before)
+                    .unwrap_or(true)
+            })
+            .count();
+        let after_file_count = fs::read_dir(&page_cache_path)
+            .expect("read cache after capture")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .count();
+
+        assert_eq!(
+            modified_existing, 0,
+            "post-settle capture should not rewrite unrelated cache files"
+        );
+        assert_eq!(after_file_count, before_files.len() + 1);
+        assert!(
+            elapsed < Duration::from_millis(300),
+            "post-settle cache capture should complete under 0.3s, got {elapsed:?}"
         );
     }
 

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -23,7 +23,12 @@ const KEEPALIVE_ALARM = "tabctl-keepalive";
 const RECONNECT_ALARM = "tabctl-reconnect";
 const KEEPALIVE_INTERVAL_MINUTES = 1;
 const BROWSER_STATE_SYNC_DEBOUNCE_MS = 750;
-const ACTIVE_PAGE_CACHE_DEBOUNCE_MS = 1_000;
+const ACTIVE_PAGE_CACHE_LOADING_RETRY_MS = 100;
+const ACTIVE_PAGE_CACHE_SETTLING_RETRY_MS = 150;
+const ACTIVE_PAGE_CACHE_FIRST_QUIESCENT_TIMEOUT_MS = 750;
+const ACTIVE_PAGE_CACHE_FIRST_QUIESCENT_SAMPLE_MS = 75;
+const ACTIVE_PAGE_CACHE_FIRST_LOADING_MAX_ATTEMPTS = 300;
+const ACTIVE_PAGE_CACHE_FIRST_SETTLING_MAX_ATTEMPTS = 200;
 const ACTIVE_PAGE_CACHE_TIMEOUT_MS = 5_000;
 const MAX_PAGE_HTML_CHARS = 10 * 1024 * 1024;
 const ACTIVE_PAGE_CACHE_MAX_HTML_CHARS = MAX_PAGE_HTML_CHARS;
@@ -73,7 +78,7 @@ const browserState = {
 const activePageCache = {
   nextId: 1,
   timer: null as ReturnType<typeof setTimeout> | null,
-  pending: null as { tab: chrome.tabs.Tab & { id: number }; reason: string; key: string } | null,
+  pending: null as { tabId: number; reason: string; key: string; attempts: number } | null,
   quiescentTimer: null as ReturnType<typeof setTimeout> | null,
   quiescentPending: null as {
     tabId: number;
@@ -86,7 +91,22 @@ const activePageCache = {
   lastQuiescentCapturedKey: null as string | null,
   lastQuiescentCapturedAt: 0,
   statusRequests: new Map<string, { tabId: number; url: string }>(),
-  diagnostics: new Map<string, { kind: "waiting" | "error"; detail: string }>(),
+  states: new Map<string, ActivePageCacheState>(),
+};
+
+type ActivePageCacheStateKind = "checking" | "loading" | "settling" | "capturing" | "cached" | "error";
+type ActivePageCacheState = {
+  kind: ActivePageCacheStateKind;
+  detail: string;
+};
+
+const ACTIVE_PAGE_CACHE_STATE_DETAILS: Record<ActivePageCacheStateKind, string> = {
+  checking: "checking status",
+  loading: "page still loading",
+  settling: "waiting for page settle",
+  capturing: "capture pending",
+  cached: "page cache available",
+  error: "capture failed",
 };
 
 function log(...args: Array<unknown>) {
@@ -325,21 +345,60 @@ function hasPendingActivePageCacheWork(tabId: number, url: string) {
     || activePageCache.quiescentPending?.key === key;
 }
 
-function setActivePageCacheDiagnostic(tabId: number, url: string, kind: "waiting" | "error", detail: string) {
-  activePageCache.diagnostics.set(activePageCacheKeyForTabId(tabId, url), { kind, detail });
+function setActivePageCacheState(
+  tabId: number,
+  url: string,
+  kind: ActivePageCacheStateKind,
+  detail = ACTIVE_PAGE_CACHE_STATE_DETAILS[kind],
+) {
+  activePageCache.states.set(activePageCacheKeyForTabId(tabId, url), { kind, detail });
 }
 
-function clearActivePageCacheDiagnostic(tabId: number, url: string) {
-  activePageCache.diagnostics.delete(activePageCacheKeyForTabId(tabId, url));
+function activePageCacheState(tabId: number, url: string) {
+  return activePageCache.states.get(activePageCacheKeyForTabId(tabId, url));
 }
 
-function clearActivePageCacheDiagnosticsForTab(tabId: number) {
+function clearActivePageCacheState(tabId: number, url: string) {
+  activePageCache.states.delete(activePageCacheKeyForTabId(tabId, url));
+}
+
+function clearActivePageCacheStatesForTab(tabId: number) {
   const prefix = `${tabId}:`;
-  for (const key of activePageCache.diagnostics.keys()) {
+  for (const key of activePageCache.states.keys()) {
     if (key.startsWith(prefix)) {
-      activePageCache.diagnostics.delete(key);
+      activePageCache.states.delete(key);
     }
   }
+}
+
+function clearPendingFirstActivePageCacheCapture(key: string) {
+  if (activePageCache.pending?.key === key) {
+    activePageCache.pending = null;
+  }
+}
+
+function failFirstActivePageCacheCapture(
+  pending: { tabId: number; key: string },
+  tab: chrome.tabs.Tab & { id: number },
+  url: string,
+  detail: string,
+) {
+  clearPendingFirstActivePageCacheCapture(pending.key);
+  setActivePageCacheState(tab.id, url, "error", detail);
+  void setCacheErrorIndicator(tab.id, url, detail);
+  void requestPageCacheStatusForTab(tab.id, `first-capture:${detail.replace(/\s+/g, "-")}`);
+}
+
+function waitingDetailForActivePageCacheState(state: ActivePageCacheState | undefined) {
+  if (
+    state?.kind === "checking"
+    || state?.kind === "loading"
+    || state?.kind === "settling"
+    || state?.kind === "capturing"
+  ) {
+    return state.detail;
+  }
+  return null;
 }
 
 async function applyPageCacheStatus(tabId: number, expectedUrl: string, available: boolean) {
@@ -353,23 +412,26 @@ async function applyPageCacheStatus(tabId: number, expectedUrl: string, availabl
       return;
     }
     if (!available) {
-      const diagnostic = activePageCache.diagnostics.get(activePageCacheKeyForTabId(tabId, expectedUrl));
-      if (diagnostic?.kind === "waiting") {
-        await setCacheWaitingIndicator(tabId, expectedUrl, diagnostic.detail);
+      const cacheState = activePageCacheState(tabId, expectedUrl);
+      const waitingDetail = waitingDetailForActivePageCacheState(cacheState);
+      if (waitingDetail) {
+        await setCacheWaitingIndicator(tabId, expectedUrl, waitingDetail);
         return;
       }
-      if (diagnostic?.kind === "error") {
-        await setCacheErrorIndicator(tabId, expectedUrl, diagnostic.detail);
+      if (cacheState?.kind === "error") {
+        await setCacheErrorIndicator(tabId, expectedUrl, cacheState.detail);
         return;
       }
       if (hasPendingActivePageCacheWork(tabId, expectedUrl)) {
-        await setCacheWaitingIndicator(tabId, expectedUrl, "capture pending");
+        setActivePageCacheState(tabId, expectedUrl, "capturing");
+        await setCacheWaitingIndicator(tabId, expectedUrl, ACTIVE_PAGE_CACHE_STATE_DETAILS.capturing);
         return;
       }
+      clearActivePageCacheState(tabId, expectedUrl);
       await clearCacheAvailableIndicator(tabId);
       return;
     }
-    clearActivePageCacheDiagnostic(tabId, expectedUrl);
+    setActivePageCacheState(tabId, expectedUrl, "cached");
     await setCacheAvailableIndicator(tabId, expectedUrl);
   } catch {
     await clearCacheAvailableIndicator(tabId);
@@ -410,6 +472,7 @@ function requestPageCacheStatus(tab: chrome.tabs.Tab, reason: string) {
   const port = state.port;
   if (!port) {
     connectNative();
+    setActivePageCacheState(tab.id, url, "checking", "native host reconnecting");
     void setCacheWaitingIndicator(tab.id, url, "native host reconnecting");
     return;
   }
@@ -473,7 +536,6 @@ function isEligibleActivePageCacheTab(tab: chrome.tabs.Tab): tab is chrome.tabs.
     && !browserState.incognitoTabIds.has(tab.id)
     && (typeof tab.windowId !== "number" || !browserState.incognitoWindowIds.has(tab.windowId))
     && tab.discarded !== true
-    && tab.status !== "loading"
     && isScriptableUrl(url);
 }
 
@@ -520,6 +582,21 @@ function scheduleQuiescentActivePageCacheCapture(tab: chrome.tabs.Tab & { id: nu
   }, ACTIVE_PAGE_CACHE_QUIESCENT_DELAY_MS);
 }
 
+function scheduleFirstActivePageCacheRetry(
+  pending: { tabId: number; reason: string; key: string; attempts: number },
+  delayMs: number,
+) {
+  clearPendingActivePageCacheCapture();
+  activePageCache.pending = pending;
+  activePageCache.timer = setTimeout(() => {
+    activePageCache.timer = null;
+    const retry = activePageCache.pending;
+    if (retry) {
+      void captureFirstSettledActivePageCache(retry);
+    }
+  }, delayMs);
+}
+
 function scheduleActivePageCacheCapture(tab: chrome.tabs.Tab, reason: string) {
   if (!isEligibleActivePageCacheTab(tab)) {
     if (typeof tab.id === "number") {
@@ -532,24 +609,28 @@ function scheduleActivePageCacheCapture(tab: chrome.tabs.Tab, reason: string) {
 
   const url = activePageCacheUrl(tab);
   const key = activePageCacheKey(tab, url);
-  clearActivePageCacheDiagnostic(tab.id, url);
-  void setCacheWaitingIndicator(tab.id, url, "checking status");
+
+  if (tab.status === "loading") {
+    setActivePageCacheState(tab.id, url, "loading");
+    void setCacheWaitingIndicator(tab.id, url, ACTIVE_PAGE_CACHE_STATE_DETAILS.loading);
+    if (activePageCache.pending?.key !== key) {
+      scheduleFirstActivePageCacheRetry({ tabId: tab.id, reason, key, attempts: 0 }, ACTIVE_PAGE_CACHE_LOADING_RETRY_MS);
+    }
+    return;
+  }
+
+  setActivePageCacheState(tab.id, url, "checking");
+  void setCacheWaitingIndicator(tab.id, url, ACTIVE_PAGE_CACHE_STATE_DETAILS.checking);
   requestPageCacheStatus(tab, reason);
   scheduleQuiescentActivePageCacheCapture(tab, reason, key);
   if (activePageCache.inFlightKeys.has(key) || activePageCache.lastCapturedKey === key) {
     return;
   }
+  if (activePageCache.pending?.key === key) {
+    return;
+  }
 
-  clearPendingActivePageCacheCapture();
-  activePageCache.pending = { tab, reason, key };
-  activePageCache.timer = setTimeout(() => {
-    activePageCache.timer = null;
-    const pending = activePageCache.pending;
-    activePageCache.pending = null;
-    if (pending) {
-      void captureActivePageCache(pending.tab, pending.reason, pending.key);
-    }
-  }, ACTIVE_PAGE_CACHE_DEBOUNCE_MS);
+  scheduleFirstActivePageCacheRetry({ tabId: tab.id, reason, key, attempts: 0 }, 0);
 }
 
 async function scheduleActivePageCacheCaptureForTab(tabId: number, reason: string) {
@@ -588,6 +669,95 @@ async function currentActivePageCacheTab(tabId: number, key: string) {
   }
 }
 
+async function getPageCacheOpenTabs() {
+  const tabs = await chrome.tabs.query({});
+  return tabs
+    .filter((tab): tab is chrome.tabs.Tab & { id: number } => typeof tab.id === "number")
+    .filter((tab) => tab.incognito !== true)
+    .map((tab) => ({ tabId: tab.id, url: activePageCacheUrl(tab) }))
+    .filter((tab) => tab.url.length > 0 && isScriptableUrl(tab.url));
+}
+
+async function captureFirstSettledActivePageCache(
+  pending: { tabId: number; key: string; reason: string; attempts: number },
+) {
+  if (activePageCache.inFlightKeys.has(pending.key) || activePageCache.lastCapturedKey === pending.key) {
+    if (activePageCache.pending?.key === pending.key) {
+      activePageCache.pending = null;
+    }
+    return;
+  }
+
+  const tab = await currentActivePageCacheTab(pending.tabId, pending.key);
+  if (!tab) {
+    if (activePageCache.pending?.key === pending.key) {
+      activePageCache.pending = null;
+    }
+    return;
+  }
+
+  const tabUrl = activePageCacheUrl(tab);
+  if (tab.status === "loading") {
+    setActivePageCacheState(tab.id, tabUrl, "loading");
+    void setCacheWaitingIndicator(tab.id, tabUrl, ACTIVE_PAGE_CACHE_STATE_DETAILS.loading);
+    if (pending.attempts < ACTIVE_PAGE_CACHE_FIRST_LOADING_MAX_ATTEMPTS) {
+      scheduleFirstActivePageCacheRetry(
+        { ...pending, attempts: pending.attempts + 1 },
+        ACTIVE_PAGE_CACHE_LOADING_RETRY_MS,
+      );
+    } else {
+      failFirstActivePageCacheCapture(pending, tab, tabUrl, "loading attempts exhausted");
+    }
+    return;
+  }
+
+  setActivePageCacheState(tab.id, tabUrl, "settling");
+  void setCacheWaitingIndicator(tab.id, tabUrl, ACTIVE_PAGE_CACHE_STATE_DETAILS.settling);
+  const probe = await content.probePageQuiescence(
+    tab.id,
+    ACTIVE_PAGE_CACHE_FIRST_QUIESCENT_TIMEOUT_MS,
+    ACTIVE_PAGE_CACHE_FIRST_QUIESCENT_SAMPLE_MS,
+  );
+  if (activePageCache.pending?.key !== pending.key) {
+    return;
+  }
+  if (!probe.quiet) {
+    if (probe.error || probe.documentReadyState === null) {
+      failFirstActivePageCacheCapture(
+        pending,
+        tab,
+        tabUrl,
+        probe.reason || "page settle probe failed",
+      );
+      return;
+    }
+    const loading = probe.documentReadyState !== "interactive" && probe.documentReadyState !== "complete";
+    setActivePageCacheState(tab.id, tabUrl, loading ? "loading" : "settling");
+    void setCacheWaitingIndicator(
+      tab.id,
+      tabUrl,
+      loading ? ACTIVE_PAGE_CACHE_STATE_DETAILS.loading : ACTIVE_PAGE_CACHE_STATE_DETAILS.settling,
+    );
+    if (pending.attempts < ACTIVE_PAGE_CACHE_FIRST_SETTLING_MAX_ATTEMPTS) {
+      scheduleFirstActivePageCacheRetry(
+        { ...pending, attempts: pending.attempts + 1 },
+        loading ? ACTIVE_PAGE_CACHE_LOADING_RETRY_MS : ACTIVE_PAGE_CACHE_SETTLING_RETRY_MS,
+      );
+    } else {
+      failFirstActivePageCacheCapture(
+        pending,
+        tab,
+        tabUrl,
+        loading ? "loading attempts exhausted" : "settling attempts exhausted",
+      );
+    }
+    return;
+  }
+
+  clearPendingFirstActivePageCacheCapture(pending.key);
+  await captureActivePageCache(tab, pending.reason, pending.key);
+}
+
 async function rescheduleQuiescentActivePageCacheCapture(
   pending: { tabId: number; key: string; reason: string; attempts: number },
 ) {
@@ -619,6 +789,9 @@ async function captureQuiescentActivePageCache(pending: { tabId: number; key: st
     return;
   }
 
+  const tabUrl = activePageCacheUrl(tab);
+  setActivePageCacheState(tab.id, tabUrl, "settling");
+  void setCacheWaitingIndicator(tab.id, tabUrl, ACTIVE_PAGE_CACHE_STATE_DETAILS.settling);
   const probe = await content.probePageQuiescence(
     tab.id,
     ACTIVE_PAGE_CACHE_QUIESCENT_TIMEOUT_MS,
@@ -645,7 +818,7 @@ async function captureActivePageCache(
     connectNative();
     return false;
   }
-  if (!isEligibleActivePageCacheTab(tab) || activePageCache.inFlightKeys.has(key)) {
+  if (!isEligibleActivePageCacheTab(tab) || tab.status === "loading" || activePageCache.inFlightKeys.has(key)) {
     return false;
   }
 
@@ -656,6 +829,15 @@ async function captureActivePageCache(
       return false;
     }
 
+    const captureUrl = activePageCacheUrl(captureTab);
+    if (captureTab.status === "loading") {
+      setActivePageCacheState(captureTab.id, captureUrl, "loading");
+      void setCacheWaitingIndicator(captureTab.id, captureUrl, ACTIVE_PAGE_CACHE_STATE_DETAILS.loading);
+      scheduleFirstActivePageCacheRetry({ tabId: captureTab.id, reason, key, attempts: 0 }, ACTIVE_PAGE_CACHE_LOADING_RETRY_MS);
+      return false;
+    }
+    setActivePageCacheState(captureTab.id, captureUrl, "capturing");
+    void setCacheWaitingIndicator(captureTab.id, captureUrl, ACTIVE_PAGE_CACHE_STATE_DETAILS.capturing);
     const extraction = await content.extractPageHtml(captureTab.id, ACTIVE_PAGE_CACHE_TIMEOUT_MS, ACTIVE_PAGE_CACHE_MAX_HTML_CHARS);
     if (extraction.status !== "READ" || typeof extraction.html !== "string" || extraction.html.length === 0) {
       log("active page cache extraction not readable", {
@@ -671,12 +853,16 @@ async function captureActivePageCache(
       });
       if (extraction.status === "NOT_LOADED") {
         const url = activePageCacheUrl(captureTab);
-        setActivePageCacheDiagnostic(captureTab.id, url, "waiting", "page still loading");
-        void setCacheWaitingIndicator(captureTab.id, url, "page still loading");
+        setActivePageCacheState(captureTab.id, url, "loading");
+        void setCacheWaitingIndicator(captureTab.id, url, ACTIVE_PAGE_CACHE_STATE_DETAILS.loading);
+        scheduleFirstActivePageCacheRetry(
+          { tabId: captureTab.id, reason, key, attempts: 0 },
+          ACTIVE_PAGE_CACHE_LOADING_RETRY_MS,
+        );
       } else {
         const detail = typeof extraction.status === "string" ? extraction.status.toLowerCase().replace(/_/g, " ") : "capture failed";
         const url = activePageCacheUrl(captureTab);
-        setActivePageCacheDiagnostic(captureTab.id, url, "error", detail);
+        setActivePageCacheState(captureTab.id, url, "error", detail);
         void setCacheErrorIndicator(captureTab.id, url, detail);
       }
       void requestPageCacheStatusForTab(captureTab.id, `${reason}:capture-failed`);
@@ -693,6 +879,7 @@ async function captureActivePageCache(
       return false;
     }
 
+    const openTabs = await getPageCacheOpenTabs();
     const id = nextActivePageCacheId();
     trackPageCacheStatusRequest(id, verifiedTab.id, activePageCacheUrl(verifiedTab));
     port.postMessage({
@@ -702,6 +889,7 @@ async function captureActivePageCache(
       data: {
         reason,
         capturedAt: Date.now(),
+        openTabs,
         tab: {
           tabId: verifiedTab.id,
           windowId: verifiedTab.windowId,
@@ -725,7 +913,7 @@ async function captureActivePageCache(
   } catch (error) {
     log("active page cache capture failed", { tabId: tab.id, reason, error });
     const url = activePageCacheUrl(tab);
-    setActivePageCacheDiagnostic(tab.id, url, "error", "capture exception");
+    setActivePageCacheState(tab.id, url, "error", "capture exception");
     void setCacheErrorIndicator(tab.id, url, "capture exception");
     void requestPageCacheStatusForTab(tab.id, `${reason}:capture-error`);
     return false;
@@ -865,7 +1053,7 @@ function registerBrowserStateListeners() {
       changeInfo,
     });
     if ("url" in changeInfo || "status" in changeInfo || "discarded" in changeInfo) {
-      clearActivePageCacheDiagnosticsForTab(tabId);
+      clearActivePageCacheStatesForTab(tabId);
       void clearCacheAvailableIndicator(tabId);
     }
     if (tab.active && ("url" in changeInfo || "status" in changeInfo || "discarded" in changeInfo)) {
@@ -909,7 +1097,7 @@ function registerBrowserStateListeners() {
         activePageCache.statusRequests.delete(requestId);
       }
     });
-    clearActivePageCacheDiagnosticsForTab(tabId);
+    clearActivePageCacheStatesForTab(tabId);
     void clearCacheAvailableIndicator(tabId);
   });
 


### PR DESCRIPTION
## Summary
- Improve active page-cache badge states and scheduling
- Add fast exact-file page-cache capture/status paths with bounded cleanup
- Bump version to 0.6.0-rc.12

## Validation
- npm test
- npm run build
- npm run test:smoke

After merge, run: scripts/ci-wait-merge.sh <PR#> --tag v0.6.0-rc.12